### PR TITLE
Responding to zoom event in d3 renderer

### DIFF
--- a/src/d3/d3Renderer.js
+++ b/src/d3/d3Renderer.js
@@ -222,6 +222,15 @@ gd3.d3Renderer = function(arg) {
     });
   });
 
+  // connect to zoom event
+  this.on(geo.event.zoom, function (event) {
+    // reset the translation
+    translate();
+
+    // redraw
+    m_this.updateFeatures();
+  });
+
   this.on(geo.event.resize, function (event) {
     m_this._resize(event.x, event.y, event.width, event.height);
   });


### PR DESCRIPTION
Trivial change to get zoom working in d3 renderer.  Seems to work well with d3Points.html.
