### PR TITLE
Fixing map.gcsToDisplay

### DIFF
--- a/src/core/osmLayer.js
+++ b/src/core/osmLayer.js
@@ -106,6 +106,7 @@ geo.osmLayer = function(arg) {
 
       if (input[0] instanceof Object) {
         for (i = 0; i < input.length; ++i) {
+          output[i] = {};
           output[i].x = input[i].x;
           output[i].y = geo.mercator.y2lat(input[i].y);
         }

--- a/src/gl/vglRenderer.js
+++ b/src/gl/vglRenderer.js
@@ -41,21 +41,23 @@ ggl.vglRenderer = function(arg) {
   this.displayToWorld = function(input) {
     var i, delta, node = this.canvas(),
         ren = this.contextRenderer(), cam = ren.camera(),
-        fdp = ren.focusDisplayPoint(), output = [], temp;
+        fdp = ren.focusDisplayPoint(), output = [], temp,
+        point;
 
     if (input instanceof Array && input.length > 0) {
       if (input[0] instanceof Object) {
         delta = 1;
-        for (i = 0; i < points.length; i =+ delta) {
+        for (i = 0; i < input.length; i += delta) {
+          point = input[i];
           temp = ren.displayToWorld(vec4.fromValues(
-                   input.x, input.y, fdp[2], 1.0),
+                   point.x, point.y, fdp[2], 1.0),
                    cam.viewMatrix(), cam.projectionMatrix(),
                    node.width(), node.height());
           output.push({x: temp[0], y: temp[1], z: temp[2], w: temp[3]});
         }
       } else {
         delta = input.length % 3 === 0 ? 3 : 2;
-        for (i = 0; i < input.length; i =+ delta) {
+        for (i = 0; i < input.length; i += delta) {
           output.push(ren.displayToWorld(vec4.fromValues(
             input[i],
             input[i + 1],


### PR DESCRIPTION
Fixing several bugs in gcsToDisplay.  Also, should we be returning geo.latlng objects from this method?  I didn't make that change, but for symmetry with displayToGcs it might make sense.
