### PR TITLE
removing borders and scroll bars from selenium tests

### DIFF
--- a/testing/test-cases/selenium-tests/d3Animation/include.css
+++ b/testing/test-cases/selenium-tests/d3Animation/include.css
@@ -1,0 +1,3 @@
+body {
+    overflow: hidden;
+}

--- a/testing/test-cases/selenium-tests/d3Animation/testd3Animate.py
+++ b/testing/test-cases/selenium-tests/d3Animation/testd3Animate.py
@@ -22,7 +22,7 @@ class osmBase(object):
 
         testName = 'd3AnimateFrame15'
         self.runScript('window.animateForward(15);')
-        self.screenshotTest(testName, revision=2)
+        self.screenshotTest(testName, revision=3)
 
     def testd3AnimateBackward(self):
         self.loadPage()
@@ -30,7 +30,7 @@ class osmBase(object):
         testName = 'd3AnimateFrame75'
         self.runScript('window.animateForward(80);')
         self.runScript('window.animateBackward(5);')
-        self.screenshotTest(testName, revision=2)
+        self.screenshotTest(testName, revision=3)
 
     def testd3AnimateToEnd(self):
         self.loadPage()
@@ -43,7 +43,7 @@ class osmBase(object):
             '''
         )
         self.wait('window.animationTestFinished')
-        self.screenshotTest(testName, revision=2)
+        self.screenshotTest(testName, revision=3)
 
 
 class FirefoxOSM(osmBase, FirefoxTest):

--- a/testing/test-cases/selenium-tests/osmLayer/include.css
+++ b/testing/test-cases/selenium-tests/osmLayer/include.css
@@ -1,0 +1,3 @@
+body {
+    overflow: hidden;
+}

--- a/testing/test-cases/selenium-tests/osmLayer/testDrawOsm.py
+++ b/testing/test-cases/selenium-tests/osmLayer/testDrawOsm.py
@@ -18,14 +18,14 @@ class osmBase(object):
     def test_osm_draw(self):
         testName = 'osmDraw'
         self.loadPage()
-        self.screenshotTest(testName, revision=2)
+        self.screenshotTest(testName, revision=3)
 
     def test_osm_pan(self):
         testName = 'osmPan'
         self.loadPage()
         self.drag('#map', (200, 150))
         time.sleep(1)  # wait for tiles to load
-        self.screenshotTest(testName, revision=2)
+        self.screenshotTest(testName, revision=3)
 
 
 class FirefoxOSM(osmBase, FirefoxTest):

--- a/testing/test-runners/selenium-template.html.in
+++ b/testing/test-runners/selenium-template.html.in
@@ -13,6 +13,7 @@
 @SCRIPT_INCLUDE@ 
     <style>
         html, body{
+            margin: 0;
             height: 100%;
         }
     </style>


### PR DESCRIPTION
The selenium tests randomly fail because the scroll bars show up on occasion.  To fix it, I am removing the borders from the test pages and hiding overflow just in case.
