### PR TITLE
Add globals to window explicitly

### DIFF
--- a/src/core/init.js
+++ b/src/core/init.js
@@ -41,7 +41,8 @@ ogs.namespace = function (ns_string) {
 };
 
 /** geo namespace */
-geo = ogs.namespace("geo"); // jshint ignore: line
+var geo = ogs.namespace("geo"); // jshint ignore: line
+window.geo = geo; // jshint ignore: line
 
 geo.renderers = {};
 geo.features = {};


### PR DESCRIPTION
This is necessary to make geojs work as a meteor package.
