### PR TITLE
GeoJS requires 2.8.12

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 2.8.12)
 
 project(geojs NONE)
 set(GEOJS_VERSION 0.1.0)


### PR DESCRIPTION
This is because the get_file_component DIRECTORY option got added in 2.8.12 only
