### PR TITLE
Adding new jasmine test framework for selenium

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -415,10 +415,55 @@ if(BUILD_TESTING)
       endif()
     endforeach()
 
+    set(jasmine_runner ${CMAKE_CURRENT_BINARY_DIR}/test/selenium_jasmine_runner.py)
+    set(JASMINE_DEPLOY_URL /test/jasmine)
+
+    configure_file(
+      ${CMAKE_CURRENT_SOURCE_DIR}/testing/test-runners/selenium_jasmine_runner.py.in
+      ${jasmine_runner}
+    )
+
+    list(APPEND JAMINE_TEST_FILES ${jasmine_runner})
+
+    set(JASMINE_TEST_DIR "${GEOJS_DEPLOY_DIR}/test/jasmine")
+    file(GLOB JASMINE_TEST_SOURCES
+      ${CMAKE_CURRENT_SOURCE_DIR}/testing/test-cases/jasmine-tests/*.js
+    )
+    foreach(f ${JASMINE_TEST_SOURCES})
+      get_filename_component(base "${f}" NAME_WE)
+      set(html "${JASMINE_TEST_DIR}/${base}.html")
+
+      add_custom_command(OUTPUT ${html}
+        COMMAND ${CMAKE_COMMAND} -DTEST_HTML="${html}"
+                                 -DSOURCE_DIR="${CMAKE_CURRENT_SOURCE_DIR}"
+                                 -DSOURCE_FILE="${f}"
+                                 -DSCRIPT_INCLUDE="${_script_include}"
+                                 -DBLANKET_INCLUDE="${BLANKET_INCLUDE}"
+                                 -P ${CMAKE_SOURCE_DIR}/cmake/configure-js-unit-test.cmake
+        COMMAND ${CMAKE_COMMAND} -E touch ${html}
+        DEPENDS ${f} ${CMAKE_SOURCE_DIR}/testing/test-runners/jasmine-runner.html.in
+        COMMENT "Generating jasmine unit test ${base}"
+      )
+      list(APPEND JASMINE_TEST_FILES ${html})
+
+      add_test(
+        NAME "selenium:jasmine:${base}"
+        COMMAND ${PYTHON_EXECUTABLE} ${jasmine_runner} ${base}
+      )
+      set_property(TEST "selenium:jasmine:${base}" APPEND PROPERTY RESOURCE_LOCK webserver)
+      if(COVERAGE_TESTS)
+        set_property(TEST "selenium:jasmine:${base}" APPEND PROPERTY DEPENDS "coverage-reset")
+        set_property(TEST "coverage-report" APPEND PROPERTY DEPENDS "selenium:jasmine:${base}")
+      endif()
+      set_property(TEST "selenium:jasmine:${base}" APPEND PROPERTY ENVIRONMENT "PYTHONPATH=${CMAKE_CURRENT_BINARY_DIR}/test")
+      set_property(TEST "selenium:jasmine:${base}" APPEND PROPERTY ENVIRONMENT "FIREFOX_TESTS=${FIREFOX_TESTS}")
+      set_property(TEST "selenium:jasmine:${base}" APPEND PROPERTY ENVIRONMENT "CHROME_TESTS=${CHROME_TESTS}")
+    endforeach()
+
     add_custom_target(
       selenium_tests
       ALL
-      DEPENDS ${SELENIUM_TEST_FILES} ${MIDAS_DOWNLOAD_FILES}
+      DEPENDS ${SELENIUM_TEST_FILES} ${MIDAS_DOWNLOAD_FILES} ${JASMINE_TEST_FILES}
     )
 
   endif()

--- a/docs/developers.rst
+++ b/docs/developers.rst
@@ -2,7 +2,7 @@
 Geojs testing frameworks
 ========================
 
-Geojs employs three different frameworks for unit testing.  These
+Geojs employs several different frameworks for unit testing.  These
 frameworks have been designed to make it easy for developers to
 add more tests as new features are added to the api.
 
@@ -39,6 +39,12 @@ starting up a test server ::
 
 and navigating to `<http://localhost:50100/test/phantomjs>`_ in your
 browser.
+
+For tests that require webgl, there is a similar framework for running
+Jasmine unittests inside selenium.  For these cases, you can add your
+tests inside the ``testing/test-cases/jasmine-tests``.  CMake will
+automatically pick up the scripts in the directory and generate a test
+case for them.
 
 Selenium testing
 ----------------

--- a/testing/test-cases/jasmine-tests/osmProjection.js
+++ b/testing/test-cases/jasmine-tests/osmProjection.js
@@ -1,0 +1,153 @@
+/*global describe, it, expect, geo, xit*/
+
+describe('osm projection', function () {
+  'use strict';
+
+  var map, width = 800, height = 800;
+
+  // create an osm map layer
+  map = geo.map({
+    'center': [0, 0],
+    'zoom': 1
+  });
+
+  map.createLayer('osm');
+  map.resize(0, 0, width, height);
+  map.draw();
+
+  // make sure georeferencing operators are 
+  // inverses of each other for several points
+  describe('Invert georeference', function () {
+  
+    var pts = [
+      [0, 0], [200, 0], [-300, 0],
+      [0, 400], [0, -500], [100, 600],
+      [-300, 600], [-600, 500]
+    ];
+
+    pts.forEach(function (pt) {
+      var d = {x: pt[0], y: pt[1]};
+
+      it('(' + pt.join() + ')', function () {
+        var g, d0;
+        
+        g = map.displayToGcs(d);
+        d0 = map.gcsToDisplay(g);
+
+        expect(d0.x).toBeCloseTo(d.x, 0);
+        expect(d0.y).toBeCloseTo(d.y, 0);
+      });
+    });
+
+  });
+
+  describe('Call and return types', function () {
+
+    var obj1, obj2;
+
+    it('gcsToDisplay ( geo.latlng )', function () {
+      obj1 = map.gcsToDisplay(geo.latlng(0, 0));
+      expect(typeof obj1).toBe('object');
+      expect(Number.isFinite(obj1.x)).toBe(true);
+      expect(Number.isFinite(obj1.y)).toBe(true);
+    });
+ 
+    it('gcsToDisplay ( object )', function () {
+      var obj;
+      obj = map.gcsToDisplay({x: 0, y: 0});
+      expect(obj).toEqual(obj1);
+    });
+    
+    // currently doesn't work
+    xit('gcsToDisplay ( [geo.latlng] )', function () {
+      var arr;
+      arr = map.gcsToDisplay([geo.latlng(0, 0)]);
+      expect(Array.isArray(arr)).toBe(true);
+      expect(typeof arr[0]).toBe('object');
+      expect(arr[0].x).toBeCloseTo(obj1.x, 6);
+      expect(arr[0].y).toBeCloseTo(obj1.y, 6);
+    });
+    
+    // currently doesn't work
+    xit('gcsToDisplay ( [geo.latlng, ... , geo.latlng] )', function () {
+      var arr = [], N = 10, i;
+
+      for (i = 0; i < N; i += 1) {
+        arr.push(geo.latlng(0, 0));
+      }
+
+      arr = map.gcsToDisplay(arr);
+
+      expect(Array.isArray(arr)).toBe(true);
+
+      for (i = 0; i < N; i += 1) {
+        expect(typeof arr[i]).toBe('object');
+        expect(arr[i].x).toBeCloseTo(obj1.x, 6);
+        expect(arr[i].y).toBeCloseTo(obj1.y, 6);
+      }
+    });
+
+    // currently doesn't work
+    xit('gcsToDisplay ( [object] )', function () {
+      var arr;
+      arr = map.gcsToDisplay([{x: 0, y: 0}]);
+      expect(Array.isArray(arr)).toBe(true);
+      expect(typeof arr[0]).toBe('object');
+      expect(arr[0].x).toBeCloseTo(obj1.x, 6);
+      expect(arr[0].y).toBeCloseTo(obj1.y, 6);
+    });
+ 
+    // currently doesn't work
+    xit('gcsToDisplay ( [object, ... , object] )', function () {
+      var arr = [], N = 10, i;
+
+      for (i = 0; i < N; i += 1) {
+        arr.push({x: 0, y: 0});
+      }
+
+      arr = map.gcsToDisplay(arr);
+
+      expect(Array.isArray(arr)).toBe(true);
+
+      for (i = 0; i < N; i += 1) {
+        expect(typeof arr[i]).toBe('object');
+        expect(arr[i].x).toBeCloseTo(obj1.x, 6);
+        expect(arr[i].y).toBeCloseTo(obj1.y, 6);
+      }
+    });
+
+    it('displayToGcs ( object )', function () {
+      obj2 = map.displayToGcs({x: 400, y: 400});
+      expect(typeof obj2).toBe('object');
+      expect(Number.isFinite(obj2.x)).toBe(true);
+      expect(Number.isFinite(obj2.y)).toBe(true);
+    });
+    
+    it('displayToGcs ( [object] )', function () {
+      var arr;
+      arr = map.displayToGcs([{x: 400, y: 400}]);
+      expect(Array.isArray(arr)).toBe(true);
+      expect(typeof arr[0]).toBe('object');
+      expect(arr[0].x).toBeCloseTo(obj2.x, 6);
+      expect(arr[0].y).toBeCloseTo(obj2.y, 6);
+    });
+    
+    it('displayToGcs ( [object, ... , object] )', function () {
+      var arr = [], N = 10, i;
+
+      for (i = 0; i < N; i += 1) {
+        arr.push({x: 400, y: 400});
+      }
+
+      arr = map.displayToGcs(arr);
+
+      expect(Array.isArray(arr)).toBe(true);
+
+      for (i = 0; i < N; i += 1) {
+        expect(typeof arr[i]).toBe('object');
+        expect(arr[i].x).toBeCloseTo(obj2.x, 6);
+        expect(arr[i].y).toBeCloseTo(obj2.y, 6);
+      }
+    });
+  });
+});

--- a/testing/test-runners/selenium_jasmine_runner.py.in
+++ b/testing/test-runners/selenium_jasmine_runner.py.in
@@ -1,0 +1,64 @@
+
+import sys
+import os
+
+from selenium_test import setUpModule, tearDownModule, makeAllBrowserTest
+
+_urls = []
+_baseurl = "@JASMINE_DEPLOY_URL@"
+
+# query for jasmine to be finished (from run-jasmine.js)
+_done = ' '.join([
+    'return',
+    'document.body.querySelector(".symbolSummary .pending") === null &&',
+    'document.body.className === "reporter-done";'
+])
+
+
+class JasmineTest(object):
+
+    url = ''
+
+    def test_run(self):
+
+        _url = '/'.join((_baseurl, self.url)) + '.html'
+        self.loadURL(_url, relative=False)
+
+        self.wait(function=_done)
+
+        failedElements = self.getElements('.specDetail.failed')
+        allElements = self.getElements('.specSummary')
+
+        if len(failedElements):
+            msg = ["\n%i/%i tests failed" % (len(failedElements), len(allElements))]
+
+            for i, el in enumerate(failedElements):
+                a = el.find_element_by_css_selector('a')
+                messages = el.find_elements_by_css_selector('.resultMessage')
+                msg.append(('#%i: ' % (i + 1)) + a.get_attribute('title'))
+                for message in messages:
+                    msg.append('  * ' + message.text)
+
+            msg = '\n'.join(msg)
+            self.fail(msg)
+
+if __name__ == '__main__':
+    _urls = sys.argv[1:]
+else:
+    _urls = os.environ.get('JASMINE_TESTS', '').split(':')
+
+_urls = [
+    '/'.join(os.path.split(url.strip())) for url in _urls if len(url.strip())
+]
+
+for url in _urls:
+    name = os.path.split(url)[-1]
+    name = os.path.splitext(name)[0]
+    name = name[0].upper() + name[1:]
+
+    makeAllBrowserTest(JasmineTest, baseName=name, url=url)
+
+if __name__ == '__main__':
+    sys.argv = [sys.argv[0]]
+    import unittest
+    unittest.main()

--- a/testing/test-runners/selenium_test.py.in
+++ b/testing/test-runners/selenium_test.py.in
@@ -13,6 +13,7 @@ import unittest
 from unittest import TestCase
 from math import sqrt
 import json
+import inspect
 
 if sys.version_info[0] == 2:
     from cStringIO import StringIO
@@ -248,18 +249,23 @@ class BaseTest(TestCase):
         )
         self.driver.quit()
 
-    def wait(self, variable='window.testComplete', timeout=5):
+    def wait(self, variable='window.testComplete', function=None, timeout=5):
         '''
-        Wait for a variable to be set to true.  Raise an error
-        if timeout is exceeded.
+        Wait for a variable to be set to true, or a function to return true.
+        Raise an error if timeout is exceeded.
 
         :param string variable: The variable to query.
+        :param string function: The function to execute.
         :param float timeout: The maximum number of seconds to wait.
 
         '''
+        if function is None:
+            function = 'return !!%s' % variable
+            variable = 'function return value'
+
         def check_status(drv):
             try:
-                return drv.execute_script('return !!%s' % variable)
+                return drv.execute_script(function)
             except Exception:
                 return False
 
@@ -695,3 +701,45 @@ def tearDownModule():
     your test, you should import this function into your test module.
     '''
     BaseTest.stopServer()
+
+
+def makeAllBrowserTest(cls, baseName=None, **kw):
+    '''
+    Instrument a test class to run in all currently enabled browsers.
+    Takes in a class that will be used to generate browser specific
+    classes using class mixins.  This is a convience function for the
+    case when a test doesn't need any special handling for different
+    browsers.  Extra keyword arguments are appended as class level
+    variables.
+
+    :param class cls: The base test class
+    :param str baseName: Override cls.__name__ to construct generated class names
+
+    For example, ::
+
+        class MyTest(object):
+            def test_example(self):
+                pass  # Do test here
+
+        makeAllBrowserTest(MyTest, aparam=1)
+    '''
+
+    # This black magic is used to get the module of the calling function:
+    module = inspect.getmodule(inspect.stack()[1][0])
+
+    if baseName is None:
+        baseName = cls.__name__
+
+    testCase = tuple(getattr(cls, 'testCase', ()))
+
+    for base in [FirefoxTest, ChromeTest]:
+        name = baseName + base.driverName.capitalize()
+
+        _kw = dict(**kw)
+        _kw['testCase'] = testCase + (base.driverName,)
+
+        setattr(
+            module,
+            name,
+            type(name, (cls, base), _kw)
+        )


### PR DESCRIPTION
This adds jasmine tests much like the phantomjs tests work, but it runs inside selenium.  For example: [osmProjection.js](https://github.com/OpenGeoscience/geojs/blob/c44e3608bec5dedbd57ebf3d0c79e14877ac70d6/testing/test-cases/jasmine-tests/osmProjection.js).
