### PR TITLE
Fixing mouse wheel event handler

### DIFF
--- a/src/gl/vglRenderer.js
+++ b/src/gl/vglRenderer.js
@@ -320,7 +320,7 @@ ggl.vglRenderer = function (arg) {
 
       /// https://developer.mozilla.org/en-US/docs/Web/Events/wheel
       var map = $(m_this.layer().map().node()),
-          wheel = "onwheel" in map ? "wheel" :
+          wheel = "onwheel" in map.get(0) ? "wheel" :
                   document.onmousewheel !== undefined ? "mousewheel" :
                   "MozMousePixelScroll",
           wheelDelta = (wheel === "wheel") ? function (evt) {


### PR DESCRIPTION
I have no idea why this just now stopped working for me.  Maybe a chrome update.  Anyway, this fixes mouse wheel zooming in Chrome.
