### PR TITLE
Installing web deps with bower

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -122,11 +122,11 @@ module.exports = function (grunt) {
       ext: {
         files: {
           'dist/built/geo.ext.min.js': [
-            'node_modules/jquery-browser/lib/jquery.js',
-            'node_modules/jquery-mousewheel/jquery.mousewheel.js',
-            'node_modules/gl-matrix/dist/gl-matrix.js',
-            'node_modules/proj4/dist/proj4-src.js',
-            'node_modules/d3-browser/lib/d3.js'
+            'bower_components/jquery/dist/jquery.js',
+            'bower_components/jquery-mousewheel/jquery.mousewheel.js',
+            'bower_components/gl-matrix/dist/gl-matrix.js',
+            'bower_components/proj4/dist/proj4-src.js',
+            'bower_components/d3/d3.js'
           ]
         }
       }

--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,21 @@
+{
+  "name": "geojs",
+  "version": "0.1.0",
+  "description": "JavaScript Geo visualization and Analysis Library",
+  "homepage": "https://github.com/OpenGeoscience/geojs",
+  "main": "dist/built/geo.min.js",
+  "bugs": {
+    "url": "https://github.com/OpenGeoscience/geojs/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/OpenGeoscience/geojs"
+  },
+  "dependencies": {
+    "d3": "~3.3",
+    "gl-matrix": "~2.1",
+    "jquery": "~2.1",
+    "jquery-mousewheel": "^3.1.12",
+    "proj4": "~2.2"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -11,17 +11,13 @@
     "url": "https://github.com/OpenGeoscience/geojs"
   },
   "dependencies": {
-    "d3-browser": "~3.2",
-    "gl-matrix": "~2.1",
     "grunt": "~0.4",
     "grunt-cli": "~0.1",
     "grunt-contrib-clean": "~0.6",
     "grunt-contrib-copy": "~0.6",
     "grunt-contrib-uglify": "~0.6",
     "grunt-template": "~0.2",
-    "jquery-browser": "~1.10",
-    "jquery-mousewheel": "^3.1.12",
-    "proj4": "~2.2"
+    "bower": "~1.3"
   },
   "devDependencies": {
     "grunt-contrib-watch": "~0.6",
@@ -31,6 +27,6 @@
     "phantomjs": "~1.9"
   },
   "scripts": {
-    "postinstall": "./node_modules/.bin/grunt"
+    "postinstall": "./node_modules/.bin/bower install && ./node_modules/.bin/grunt"
   }
 }


### PR DESCRIPTION
npm is dropping support for browser only packages `jquery-browser` and `d3-browser`.  This just installs the web dependencies with bower with no changes exposed to users.
