### PR TITLE
Event updates

### DIFF
--- a/src/core/event.js
+++ b/src/core/event.js
@@ -1,54 +1,191 @@
 //////////////////////////////////////////////////////////////////////////////
 /**
- * Create a new instance of class event
+ * Common object containing all event types that are provided by the GeoJS
+ * API.  Each property contained here is a valid target for event handling
+ * via {@link geo.object#geoOn}.  The event object provided to handlers is
+ * different for each event type.  Each handler will generally be called
+ * with a the <code>this</code> context being the class that caused the event.<br>
+ * <br>
+ * The following properties are common to all event objects:
  *
- * @class
- * @returns {geo.event}
+ * @namespace
+ * @property type {string} The event type that was triggered
+ * @property geo {object} A universal event object for controlling propagation
+ *
+ * @example
+ * map.geoOn(geo.event.layerAdd, function (event) {
+ *   // event is an object with type: {@link geo.event.layerAdd}
+ * });
+ *
  */
- //////////////////////////////////////////////////////////////////////////////
-geo.event = function () {
-  "use strict";
-  if (!(this instanceof geo.event)) {
-    return new geo.event();
-  }
-  vgl.event.call(this);
-
-  return this;
-};
-
-inherit(geo.event, vgl.event);
+//////////////////////////////////////////////////////////////////////////////
+geo.event = {};
 
 //////////////////////////////////////////////////////////////////////////////
-/**
+/*
  * Event types
  */
 //////////////////////////////////////////////////////////////////////////////
 
-// TODO Add documentation
-geo.event.update = "geo_update";
-geo.event.opacityUpdate = "geo_opacityUpdate";
-geo.event.layerAdd = "geo_layerAdd";
-geo.event.layerRemove = "geo_layerRemove";
-geo.event.layerToggle = "geo_layerToggle";
-geo.event.layerSelect = "geo_layerSelect";
-geo.event.layerUnselect = "geo_layerUnselect";
-geo.event.zoom = "geo_zoom";
-geo.event.pan = "geo_pan";
-geo.event.rotate = "geo_rotate";
-geo.event.resize = "geo_resize";
-geo.event.animate = "geo_animate";
-geo.event.query = "geo_query";
-geo.event.draw = "geo_draw";
-geo.event.drawEnd = "geo_drawEnd";
-geo.event.mousemove = "geo_mousemove";
-geo.event.mouseclick = "geo_mouseclick";
-geo.event.brush = "geo_brush"; // mousemove during a selection
-geo.event.brushend = "geo_brushend"; // mouseup after a selection has been made
-geo.event.brushstart = "geo_brushstart"; // mousedown starting a selection
+// The following were not triggered nor used anywhere.  Removing until their
+// purpose is defined more clearly.
+//
+// geo.event.update = "geo_update";
+// geo.event.opacityUpdate = "geo_opacityUpdate";
+// geo.event.layerToggle = "geo_layerToggle";
+// geo.event.layerSelect = "geo_layerSelect";
+// geo.event.layerUnselect = "geo_layerUnselect";
+// geo.event.rotate = "geo_rotate";
+// geo.event.query = "geo_query";
 
+//////////////////////////////////////////////////////////////////////////////
+/**
+ * Triggered when a layer is added to the map.
+ *
+ * @property target {geo.map} The current map
+ * @property layer {geo.layer} The new layer
+ */
+//////////////////////////////////////////////////////////////////////////////
+geo.event.layerAdd = "geo_layerAdd";
+
+//////////////////////////////////////////////////////////////////////////////
+/**
+ * Triggered when a layer is removed from the map.
+ *
+ * @property target {geo.map} The current map
+ * @property layer {geo.layer} The old layer
+ */
+//////////////////////////////////////////////////////////////////////////////
+geo.event.layerRemove = "geo_layerRemove";
+
+//////////////////////////////////////////////////////////////////////////////
+/**
+ * Triggered when the map's zoom level is changed.  Note that zoom is never
+ * triggered on the map itself.  Instead it is triggered individually on
+ * layers, starting with the base layer.
+ *
+ * @property zoomLevel {Number} New zoom level
+ * @property screenPosition {object} The screen position of mouse pointer
+ */
+//////////////////////////////////////////////////////////////////////////////
+geo.event.zoom = "geo_zoom";
+
+//////////////////////////////////////////////////////////////////////////////
+/**
+ * Triggered when the map is panned either by user interaction or map
+ * transition.
+ *
+ * @property screenDelta {object} The number of pixels to pan the map by
+ * @property center {object} The new map center
+ */
+//////////////////////////////////////////////////////////////////////////////
+geo.event.pan = "geo_pan";
+
+//////////////////////////////////////////////////////////////////////////////
+/**
+ * Triggered when the map's canvas is resized.
+ *
+ * @property width {Number} The new width in pixels
+ * @property height {Number} The new height in pixels
+ */
+//////////////////////////////////////////////////////////////////////////////
+geo.event.resize = "geo_resize";
+
+//////////////////////////////////////////////////////////////////////////////
+/**
+ * Triggered on every call to {@link geo.map#draw} before the map is rendered.
+ *
+ * @property target {geo.map} The current map
+ */
+//////////////////////////////////////////////////////////////////////////////
+geo.event.draw = "geo_draw";
+
+//////////////////////////////////////////////////////////////////////////////
+/**
+ * Triggered on every call to {@link geo.map#draw} after the map is rendered.
+ *
+ * @property target {geo.map} The current map
+ */
+//////////////////////////////////////////////////////////////////////////////
+geo.event.drawEnd = "geo_drawEnd";
+
+//////////////////////////////////////////////////////////////////////////////
+/**
+ * Triggered on every "mousemove" over the map's DOM element.  The event
+ * object extends {@link geo.mouseState}.
+ * @mixes geo.mouseState
+ */
+//////////////////////////////////////////////////////////////////////////////
+geo.event.mousemove = "geo_mousemove";
+
+//////////////////////////////////////////////////////////////////////////////
+/**
+ * Triggered on every "mousedown" over the map's DOM element.  The event
+ * object extends {@link geo.mouseState}.
+ * @mixes geo.mouseState
+ */
+//////////////////////////////////////////////////////////////////////////////
+geo.event.mouseclick = "geo_mouseclick";
+
+//////////////////////////////////////////////////////////////////////////////
+/**
+ * Triggered on every "mousemove" during a brushing selection.
+ * The event object extends {@link geo.brushSelection}.
+ * @mixes geo.brushSelection
+ */
+//////////////////////////////////////////////////////////////////////////////
+geo.event.brush = "geo_brush";
+
+//////////////////////////////////////////////////////////////////////////////
+/**
+ * Triggered after a brush selection ends.
+ * The event object extends {@link geo.brushSelection}.
+ * @mixes geo.brushSelection
+ */
+//////////////////////////////////////////////////////////////////////////////
+geo.event.brushend = "geo_brushend";
+
+//////////////////////////////////////////////////////////////////////////////
+/**
+ * Triggered when a brush selection starts.
+ * The event object extends {@link geo.brushSelection}.
+ * @mixes geo.brushSelection
+ */
+//////////////////////////////////////////////////////////////////////////////
+geo.event.brushstart = "geo_brushstart";
+
+
+////////////////////////////////////////////////////////////////////////////
+/**
+ * @namespace
+ */
+////////////////////////////////////////////////////////////////////////////
 geo.event.clock = {
   play: "geo_clock_play",
   stop: "geo_clock_stop",
   pause: "geo_clock_pause",
   change: "geo_clock_change"
+};
+
+////////////////////////////////////////////////////////////////////////////
+/**
+ * This event object provides mouse/keyboard events that can be handled
+ * by the features.  This provides a similar interface as core events,
+ * but with different names so the events don't interfere.  Subclasses
+ * can override this to provide custom events.
+ *
+ * These events will only be triggered on features which were instantiated
+ * with the option "selectionAPI".
+ * @namespace
+ */
+////////////////////////////////////////////////////////////////////////////
+geo.event.feature = {
+  mousemove:  "geo_feature_mousemove",
+  mouseover:  "geo_feature_mouseover",
+  mouseout:   "geo_feature_mouseout",
+  mouseon:    "geo_feature_mouseon",
+  mouseoff:   "geo_feature_mouseoff",
+  mouseclick: "geo_feature_mouseclick",
+  brushend:   "geo_feature_brushend",
+  brush:      "geo_feature_brush"
 };

--- a/src/core/event.js
+++ b/src/core/event.js
@@ -155,6 +155,35 @@ geo.event.brushend = "geo_brushend";
 geo.event.brushstart = "geo_brushstart";
 
 
+//////////////////////////////////////////////////////////////////////////////
+/**
+ * Triggered before a map navigation animation begins.  Set
+ * <code>event.geo.cancelAnimation</code> to cancel the animation
+ * of the navigation.  This will cause the map to navigate to the
+ * target location immediately.  Set <code>event.geo.cancelNavigation</code>
+ * to cancel the navigation completely.  The transition options can
+ * be modified in place.
+ *
+ * @property {geo.geoPosition} center The target center
+ * @property {Number} zoom The target zoom level
+ * @property {Number} duration The duration of the transition in milliseconds
+ * @property {function} ease The easing function
+ */
+//////////////////////////////////////////////////////////////////////////////
+geo.event.transitionstart = "geo_transitionstart";
+
+//////////////////////////////////////////////////////////////////////////////
+/**
+ * Triggered after a map navigation animation ends.
+ *
+ * @property {geo.geoPosition} center The target center
+ * @property {Number} zoom The target zoom level
+ * @property {Number} duration The duration of the transition in milliseconds
+ * @property {function} ease The easing function
+ */
+//////////////////////////////////////////////////////////////////////////////
+geo.event.transitionend = "geo_transitionend";
+
 ////////////////////////////////////////////////////////////////////////////
 /**
  * @namespace

--- a/src/core/feature.js
+++ b/src/core/feature.js
@@ -486,24 +486,6 @@ geo.feature = function (arg) {
   return this;
 };
 
-
-////////////////////////////////////////////////////////////////////////////
-/**
- * This event object provides mouse/keyboard events that can be handled
- * by the features.  This provides a similar interface as core events,
- * but with different names so the events don't interfere.  Subclasses
- * can override this to provide custom events.
- */
-////////////////////////////////////////////////////////////////////////////
-geo.event.feature = {
-  mousemove:  "geo_feature_mousemove",
-  mouseover:  "geo_feature_mouseover",
-  mouseout:   "geo_feature_mouseout",
-  mouseclick: "geo_feature_mouseclick",
-  brushend:   "geo_feature_brushend",
-  brush:      "geo_feature_brush"
-};
-
 geo.feature.eventID = 0;
 
 inherit(geo.feature, geo.sceneObject);

--- a/src/core/feature.js
+++ b/src/core/feature.js
@@ -119,7 +119,12 @@ geo.feature = function (arg) {
     var mouse = m_this.layer().map().interactor().mouse(),
         data = m_this.data(),
         over = m_this.pointSearch(mouse.geo),
-        newFeatures = [], oldFeatures = [];
+        newFeatures = [], oldFeatures = [], lastTop = -1, top = -1;
+
+    // Get the index of the element that was previously on top
+    if (m_selectedFeatures.length) {
+      lastTop = m_selectedFeatures[m_selectedFeatures.length - 1];
+    }
 
     // There are probably faster ways of doing this:
     newFeatures = over.index.filter(function (i) {
@@ -167,6 +172,30 @@ geo.feature = function (arg) {
 
     // Replace the selected features array
     m_selectedFeatures = over.index;
+
+    // Get the index of the element that is now on top
+    if (m_selectedFeatures.length) {
+      top = m_selectedFeatures[m_selectedFeatures.length - 1];
+    }
+
+    if (lastTop !== top) {
+      // The element on top changed so we need to fire mouseon/mouseoff
+      if (lastTop !== -1) {
+        m_this.geoTrigger(geo.event.feature.mouseoff, {
+          data: data[lastTop],
+          index: lastTop,
+          mouse: mouse
+        }, true);
+      }
+
+      if (top !== -1) {
+        m_this.geoTrigger(geo.event.feature.mouseon, {
+          data: data[top],
+          index: top,
+          mouse: mouse
+        }, true);
+      }
+    }
   };
 
   ////////////////////////////////////////////////////////////////////////////

--- a/src/core/feature.js
+++ b/src/core/feature.js
@@ -129,30 +129,39 @@ geo.feature = function (arg) {
       return over.index.indexOf(i) < 0;
     });
 
+    geo.feature.eventID += 1;
     // Fire events for mouse in first.
-    newFeatures.forEach(function (i) {
+    newFeatures.forEach(function (i, idx) {
       m_this.geoTrigger(geo.event.feature.mouseover, {
         data: data[i],
         index: i,
-        mouse: mouse
+        mouse: mouse,
+        eventID: geo.feature.eventID,
+        top: idx === newFeatures.length - 1
       }, true);
     });
 
+    geo.feature.eventID += 1;
     // Fire events for mouse out next
-    oldFeatures.forEach(function (i) {
+    oldFeatures.forEach(function (i, idx) {
       m_this.geoTrigger(geo.event.feature.mouseout, {
         data: data[i],
         index: i,
-        mouse: mouse
+        mouse: mouse,
+        eventID: geo.feature.eventID,
+        top: idx === oldFeatures.length - 1
       }, true);
     });
 
+    geo.feature.eventID += 1;
     // Fire events for mouse move last
-    over.index.forEach(function (i) {
+    over.index.forEach(function (i, idx) {
       m_this.geoTrigger(geo.event.feature.mousemove, {
         data: data[i],
         index: i,
-        mouse: mouse
+        mouse: mouse,
+        eventID: geo.feature.eventID,
+        top: idx === over.index.length - 1
       }, true);
     });
 
@@ -170,11 +179,14 @@ geo.feature = function (arg) {
         data = m_this.data(),
         over = m_this.pointSearch(mouse.geo);
 
-    over.index.forEach(function (i) {
+    geo.feature.eventID += 1;
+    over.index.forEach(function (i, idx) {
       m_this.geoTrigger(geo.event.feature.mouseclick, {
         data: data[i],
         index: i,
-        mouse: mouse
+        mouse: mouse,
+        eventID: geo.feature.eventID,
+        top: idx === over.index.length - 1
       }, true);
     });
   };
@@ -188,12 +200,15 @@ geo.feature = function (arg) {
     var idx = m_this.boxSearch(brush.gcs.lowerLeft, brush.gcs.upperRight),
         data = m_this.data();
 
-    idx.forEach(function (i) {
+    geo.feature.eventID += 1;
+    idx.forEach(function (i, idx) {
       m_this.geoTrigger(geo.event.feature.brush, {
         data: data[i],
         index: i,
         mouse: brush.mouse,
-        brush: brush
+        brush: brush,
+        eventID: geo.feature.eventID,
+        top: idx === idx.length - 1
       }, true);
     });
   };
@@ -207,12 +222,15 @@ geo.feature = function (arg) {
     var idx = m_this.boxSearch(brush.gcs.lowerLeft, brush.gcs.upperRight),
         data = m_this.data();
 
-    idx.forEach(function (i) {
+    geo.feature.eventID += 1;
+    idx.forEach(function (i, idx) {
       m_this.geoTrigger(geo.event.feature.brushend, {
         data: data[i],
         index: i,
         mouse: brush.mouse,
-        brush: brush
+        brush: brush,
+        eventID: geo.feature.eventID,
+        top: idx === idx.length - 1
       }, true);
     });
   };
@@ -485,5 +503,7 @@ geo.event.feature = {
   brushend:   "geo_feature_brushend",
   brush:      "geo_feature_brush"
 };
+
+geo.feature.eventID = 0;
 
 inherit(geo.feature, geo.sceneObject);

--- a/src/core/mapInteractor.js
+++ b/src/core/mapInteractor.js
@@ -144,6 +144,88 @@ geo.mapInteractor = function (args) {
   //   }
   // }
 
+  // A bunch of type definitions for api documentation:
+  /**
+   * General representation of rectangular bounds in world coordinates
+   * @typedef geo.geoBounds
+   * @type {object}
+   * @property {geo.geoPosition} upperLeft Upper left corner
+   * @property {geo.geoPosition} upperRight Upper right corner
+   * @property {geo.geoPosition} lowerLeft Lower left corner
+   * @property {geo.geoPosition} lowerRight Lower right corner
+   */
+
+  /**
+   * General representation of rectangular bounds in pixel coordinates
+   * @typedef geo.geoBounds
+   * @type {object}
+   * @property {geo.screenPosition} upperLeft Upper left corner
+   * @property {geo.screenPosition} upperRight Upper right corner
+   * @property {geo.screenPosition} lowerLeft Lower left corner
+   * @property {geo.screenPosition} lowerRight Lower right corner
+   */
+
+  /**
+   * General representation of a point on the screen.
+   * @typedef geo.screenPosition
+   * @type {object}
+   * @property {Number} x Horizontal coordinate in pixels
+   * @property {Number} y Vertical coordinate in pixels
+   */
+
+  /**
+   * General represention of a point on the earth.
+   * @typedef geo.geoPosition
+   * @type {object}
+   * @property {Number} x Horizontal coordinate in degrees longitude
+   * @property {Number} y Vertical coordinate in degrees latitude
+   */
+
+  /**
+   * The status of all mouse buttons.
+   * @typedef geo.mouseButtons
+   * @type {object}
+   * @property {true|false} left The left mouse button
+   * @property {true|false} right The right mouse button
+   * @property {true|false} middle The middle mouse button
+   */
+
+  /**
+   * The status of all modifier keys these are copied from the
+   * standard DOM events.
+   * @typedef geo.modifierKeys
+   * @type {object}
+   * @property {true|false} alt <code>Event.alt</code>
+   * @property {true|false} ctrl <code>Event.ctrl</code>
+   * @property {true|false} shift <code>Event.shift</code>
+   * @property {true|false} meta <code>Event.meta</code>
+   */
+
+  /**
+   * Provides information about the state of the mouse
+   * @typedef geo.mouseState
+   * @type {object}
+   * @property {geo.screenPosition} page Mouse location in pixel space
+   * @property {geo.geoPosition} map Mouse location in world space
+   * @property {geo.mouseButtons} buttons The current state of the mouse buttons
+   * @property {geo.modifierKeys} modifiers The current state of all modifier keys
+   * @property {Date} time The timestamp the event took place
+   * @property {Number} deltaTime The time in milliseconds since the last mouse event
+   * @property {geo.screenPosition} velocity The velocity of the mouse pointer
+   * in pixels per second
+   */
+
+  /**
+   * @typedef geo.brushSelection
+   * @type {object}
+   * @property {geo.screenBounds} display The selection bounds in pixel space
+   * @property {geo.geoBounds} gcs The selection bounds in world space
+   * @property {geo.mouseState} mouse The current mouse state
+   * @property {geo.mouseState} origin The mouse state at the start of the
+   * brush action
+   */
+
+
   // default mouse object
   m_mouse = {
     page: { // mouse position relative to the page

--- a/src/core/mapInteractor.js
+++ b/src/core/mapInteractor.js
@@ -157,7 +157,7 @@ geo.mapInteractor = function (args) {
 
   /**
    * General representation of rectangular bounds in pixel coordinates
-   * @typedef geo.geoBounds
+   * @typedef geo.screenBounds
    * @type {object}
    * @property {geo.screenPosition} upperLeft Upper left corner
    * @property {geo.screenPosition} upperRight Upper right corner

--- a/src/core/mapInteractor.js
+++ b/src/core/mapInteractor.js
@@ -311,7 +311,14 @@ geo.mapInteractor = function (args) {
       x: evt.pageX - offset.left,
       y: evt.pageY - offset.top
     };
-    m_mouse.geo = m_this.map().displayToGcs(m_mouse.map);
+    try {
+      m_mouse.geo = m_this.map().displayToGcs(m_mouse.map);
+    } catch (e) {
+      // catch georeferencing problems and move on
+      // needed for handling the map before the base layer
+      // is attached
+      m_mouse.geo = null;
+    }
   };
 
   ////////////////////////////////////////////////////////////////////////////

--- a/src/core/mapInteractor.js
+++ b/src/core/mapInteractor.js
@@ -610,9 +610,13 @@ geo.mapInteractor = function (args) {
           y: m_mouse.velocity.y * m_mouse.deltaTime
         });
 
-        window.requestAnimationFrame(m_state.handler);
+        if (m_state.handler) {
+          window.requestAnimationFrame(m_state.handler);
+        }
       };
-      window.requestAnimationFrame(m_state.handler);
+      if (m_state.handler) {
+        window.requestAnimationFrame(m_state.handler);
+      }
     }
   };
 

--- a/testing/test-cases/jasmine-tests/zoomSlider.js
+++ b/testing/test-cases/jasmine-tests/zoomSlider.js
@@ -5,40 +5,40 @@ describe('zoom slider', function () {
 
   var map, width = 800, height = 800;
 
-  it('Setup map', function () {
-    // create an osm map layer
-    map = geo.map({
-      'node': '#map',
-      'center': [0, 0],
-      'zoom': 3
-    });
-    map.createLayer('osm');
-    map.resize(0, 0, width, height);
-    map.createLayer('ui').createWidget('slider');
-    map.draw();
+  // create an osm map layer
+  map = geo.map({
+    'node': '#map',
+    'center': [0, 0],
+    'zoom': 3
   });
+  map.createLayer('osm');
+  map.resize(0, 0, width, height);
+  map.createLayer('ui').createWidget('slider');
+  map.draw();
 
   it('Zoom in button', function (done) {
-    var z = map.zoom(), eps;
+    var eps;
     d3.select('.geo-ui-slider .geo-zoom-in').on('click')();
 
-    window.setTimeout(function () {
-      eps = Math.abs(z + 1 - map.zoom());
-      expect(eps).toBeLessThan(1e-2);
-      done();
-    }, 1000);
+    map.geoOff(geo.event.transitionend)
+      .geoOn(geo.event.transitionend, function (evt) {
+        eps = Math.abs(evt.zoom - map.zoom());
+        expect(eps).toBeLessThan(1e-2);
+        done();
+      });
   });
   
   it('Zoom out button', function (done) {
     map.zoom(2);
-    var z = map.zoom(), eps;
+    var eps;
     d3.select('.geo-ui-slider .geo-zoom-out').on('click')();
 
-    window.setTimeout(function () {
-      eps = Math.abs(z - 1 - map.zoom());
-      expect(eps).toBeLessThan(1e-2);
-      done();
-    }, 1000);
+    map.geoOff(geo.event.transitionend)
+      .geoOn(geo.event.transitionend, function (evt) {
+        eps = Math.abs(evt.zoom - map.zoom());
+        expect(eps).toBeLessThan(1e-2);
+        done();
+      });
   });
 
   it('Nub responds to map', function () {


### PR DESCRIPTION
This PR includes several features needed to wrap up GRITS.
* Feature specific mouse events give more information:
  * a unique ID number
  * whether the current feature is on top or not
* New feature mouse events:
  * `geo.feature.mouseon`: When the mouse pointer is on the marker.  This is like mouseover, but only fires for the marker on top.  This is similar to the DOM's `mouseenter`.
  * `geo.feature.mouseoff`: Fires when the mouse pointer is no longer directly over the marker either because it exited the maker or another marker is now on top.
* Core event documentation done
* Implemented clamping of the map bounds to the visible window via a spring like animation.  I will probably revisit this later to move the map navigation animation to one place.  The current code is fragmented across `mapInteractor` and `map`, but it seems to work well enough for now.