### PR TITLE
Resize on window.resize by default

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -63,8 +63,8 @@ and creating a basic full map using the `osmLayer` class.
 .. code-block:: html
 
     <head>
-        <script src="/dist/built/geo.ext.min.js"></script>
-        <script src="/dist/built/geo.min.js"></script>
+        <script src="/built/geo.ext.min.js"></script>
+        <script src="/built/geo.min.js"></script>
 
         <style>
             html, body, #map {
@@ -77,20 +77,7 @@ and creating a basic full map using the `osmLayer` class.
 
         <script>
         $(function () {
-            var map;
-
-            function resize() {
-                map.resize(0, 0, $('#map').width(), $('#map').height());
-            }
-
-            map = geo.map({
-                'node': '#map',
-                'zoom': 2
-            });
-            map.createLayer('osm');
-
-            $(window).resize(resize);
-            resize();
+            geo.map({'node': '#map'}).createLayer('osm');
         });
         </script>
     </head>

--- a/examples/geoJSON/main.js
+++ b/examples/geoJSON/main.js
@@ -21,11 +21,6 @@ $(function () {
     }
   );
 
-  // Make the map resize with the browser window
-  $(window).resize(function () {
-    map.resize(0, 0, map.node().width(), map.node().height());
-  });
-
   // Create a gl layer to put the features in
   var layer = map.createLayer('feature');
   map.draw();

--- a/examples/layerEvents/main.js
+++ b/examples/layerEvents/main.js
@@ -101,11 +101,6 @@ $(function () {
       d3.event.stopPropagation();
     });
 
-  // Make the map resize with the browser window
-  $(window).resize(function () {
-    map.resize(0, 0, map.node().width(), map.node().height());
-  });
-
   // Draw the map
   map.draw();
 

--- a/examples/layers/main.js
+++ b/examples/layers/main.js
@@ -136,11 +136,6 @@ $(function () {
   drawLayer(map, 'unscaled-moving', 'This is a moving layer without rescaling.', 1);
   drawLayer(map, 'scaled-moving', 'This is a moving layer with rescaling.', 2, true);
 
-  // Make the map resize with the browser window
-  $(window).resize(function () {
-    map.resize(0, 0, map.node().width(), map.node().height());
-  });
-
   // Draw the map
   map.draw();
 });

--- a/examples/legend/main.js
+++ b/examples/legend/main.js
@@ -15,11 +15,6 @@ $(function () {
     }
   );
 
-  // Make the map resize with the browser window
-  $(window).resize(function () {
-    map.resize(0, 0, map.node().width(), map.node().height());
-  });
-
   // Create a ui layer
   var ui = map.createLayer('ui');
 

--- a/examples/osm/main.js
+++ b/examples/osm/main.js
@@ -19,12 +19,4 @@ $(function () {
       baseUrl: 'http://otile1.mqcdn.com/tiles/1.0.0/map/'
     }
   );
-
-  // Make the map resize with the browser window
-  $(window).resize(function () {
-    map.resize(0, 0, map.node().width(), map.node().height());
-  });
-
-  // Draw the map
-  map.draw();
 });

--- a/examples/picking/main.js
+++ b/examples/picking/main.js
@@ -83,11 +83,6 @@ $(function () {
     .geoOn(geo.event.feature.mouseclick, handleMouseClick)
     .geoOn(geo.event.feature.brushend, handleBrush);
 
-  // Make the map resize with the browser window
-  $(window).resize(function () {
-    map.resize(0, 0, map.node().width(), map.node().height());
-  });
-
   // Draw the map
   map.draw();
 });

--- a/examples/points/main.js
+++ b/examples/points/main.js
@@ -104,11 +104,6 @@ $(function () {
   });
   makePoints(data, svgLayer, svgColor);
 
-  // Make the map resize with the browser window
-  $(window).resize(function () {
-    map.resize(0, 0, map.node().width(), map.node().height());
-  });
-
   // Draw the map
   map.draw();
 });

--- a/examples/ui/main.js
+++ b/examples/ui/main.js
@@ -18,12 +18,4 @@ $(function () {
   // Add a layer for the ui elements and create a zoom slider
   map.createLayer('ui')
     .createWidget('slider');
-
-  // Make the map resize with the browser window
-  $(window).resize(function () {
-    map.resize(0, 0, map.node().width(), map.node().height());
-  });
-
-  // Draw the map
-  map.draw();
 });

--- a/src/core/map.js
+++ b/src/core/map.js
@@ -41,6 +41,7 @@ geo.map = function (arg) {
 
 
   arg.center = geo.util.normalizeCoordinates(arg.center);
+  arg.autoResize = arg.autoResize === undefined ? true : arg.autoResize;
 
   ////////////////////////////////////////////////////////////////////////////
   /**
@@ -756,6 +757,12 @@ geo.map = function (arg) {
 
   this.interactor(arg.interactor || geo.mapInteractor());
   this.clock(arg.clock || geo.clock());
+
+  if (arg.autoResize) {
+    $(window).resize(function () {
+      m_this.resize(0, 0, m_node.width(), m_node.height());
+    });
+  }
 
   return this;
 };

--- a/testing/test-runners/selenium-test-utils.js
+++ b/testing/test-runners/selenium-test-utils.js
@@ -58,7 +58,6 @@ window.geoTests = {
       map.draw();
     }
 
-    $(window).resize(resizeMap);
     resizeMap();
 
     window.gjsmap = map;


### PR DESCRIPTION
Creating a map is now as simple as: `geo.map({'node': '#map'}).createLayer('osm');`.

Fixes #280 and maybe #241.