### PR TITLE
Bounds clamping on zoom and pan

### DIFF
--- a/src/core/mapInteractor.js
+++ b/src/core/mapInteractor.js
@@ -498,6 +498,27 @@ geo.mapInteractor = function (args) {
 
   ////////////////////////////////////////////////////////////////////////////
   /**
+   * Immediately cancel an ongoing action.
+   *
+   * @param {string?} action The action type, if null cancel any action
+   * @returns {bool} If an action was canceled
+   */
+  ////////////////////////////////////////////////////////////////////////////
+  this.cancel = function (action) {
+    var out;
+    if (!action) {
+      out = !!m_state.action;
+    } else {
+      out = m_state.action === action;
+    }
+    if (out) {
+      m_state = {};
+    }
+    return out;
+  };
+
+  ////////////////////////////////////////////////////////////////////////////
+  /**
    * Handle event when a mouse button is pressed
    */
   ////////////////////////////////////////////////////////////////////////////

--- a/src/core/mapInteractor.js
+++ b/src/core/mapInteractor.js
@@ -93,7 +93,7 @@ geo.mapInteractor = function (args) {
         drag: 0.01
       },
       spring: {
-        enabled: true,
+        enabled: false,
         springConstant: 0.00005
       }
     },
@@ -332,15 +332,8 @@ geo.mapInteractor = function (args) {
         m_options.zoomMoveButton === 'right') {
       $node.on('contextmenu.geojs', function () { return false; });
     }
-    m_options.map.geoOn(geo.event.transitionend, mapHandler);
-    m_options.map._zoomCallback(mapHandler);
     return m_this;
   };
-
-  function mapHandler() {
-    m_state.action = {};
-    m_this.springBack(false);
-  }
 
   ////////////////////////////////////////////////////////////////////////////
   /**
@@ -352,10 +345,6 @@ geo.mapInteractor = function (args) {
     if ($node) {
       $node.off('.geojs');
       $node = null;
-    }
-    if (m_options.map) {
-      m_options.map.geoOff(geo.event.transitionend, mapHandler);
-      m_options.map._zoomCallback(null);
     }
     return m_this;
   };
@@ -714,6 +703,9 @@ geo.mapInteractor = function (args) {
         yplus,  // force to the top
         yminus; // force to the bottom
 
+    if (!m_options.spring.enabled) {
+      return {x: 0, y: 0};
+    }
     // get screen coordinates of corners
     var ul = m_this.map().gcsToDisplay({
       x: -180,

--- a/src/gl/vglRenderer.js
+++ b/src/gl/vglRenderer.js
@@ -438,7 +438,6 @@ geo.gl.vglRenderer = function (arg) {
         camera,
         renderWindow,
         layer = m_this.layer(),
-        delta,
         center,
         dir,
         focusPoint,
@@ -461,6 +460,7 @@ geo.gl.vglRenderer = function (arg) {
     position = camera.position();
     newZ = 360 * Math.pow(2, -evt.zoomLevel);
 
+    evt.pan = null;
     if (evt.screenPosition) {
       center = renderWindow.displayToWorld(
         evt.screenPosition.x,
@@ -469,17 +469,13 @@ geo.gl.vglRenderer = function (arg) {
         vglRenderer
       );
       dir = [center[0] - position[0], center[1] - position[1], center[2] - position[2]];
-      position[0] += dir[0] * (1 - newZ / position[2]);
-      position[1] += dir[1] * (1 - newZ / position[2]);
-    } else {
-      dir = undefined;
-      delta = -delta;
+      evt.center = layer.fromLocal({
+        x: position[0] + dir[0] * (1 - newZ / position[2]),
+        y: position[1] + dir[1] * (1 - newZ / position[2])
+      });
     }
 
     camera.setPosition(position[0], position[1], 360 * Math.pow(2, -evt.zoomLevel));
-    if (dir) {
-      camera.setFocalPoint(position[0], position[1], focusPoint[2]);
-    }
 
     m_this._updateRendererCamera();
   });

--- a/testing/test-cases/phantomjs-tests/mapInteractor.js
+++ b/testing/test-cases/phantomjs-tests/mapInteractor.js
@@ -53,6 +53,7 @@ describe('mapInteractor', function () {
     };
     map.displayToGcs = base.displayToGcs;
     map.info = info;
+    map._zoomCallback = function () {};
     return map;
   }
 


### PR DESCRIPTION
This PR adds proper bounds clamping to the map navigation.  The clamping is enforced on pan, zoom, and resize.  This behavior can be disabled by setting the map option `clampBounds` to `false`.

Depends on #285.  See [here](https://github.com/OpenGeoscience/geojs/compare/event-updates...bounds-clamping) for changes added by this PR.

<!---
@huboard:{"order":221.9375,"milestone_order":299,"custom_state":""}
-->
