### PR TITLE
d3 vector feature and core API

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,7 +114,7 @@ if (COVERAGE_TESTS)
   file(COPY "${GEOJS_DEPLOY_DIR}/src" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}")
 else()
 
-  set(SOURCES_INCLUDE <script src=/built/geo.all.js></script>)
+  set(SOURCES_INCLUDE <script src=/built/geo.all.dev.js></script>)
   set(BLANKET_INCLUDE "")
 
 endif()

--- a/sources.json
+++ b/sources.json
@@ -30,6 +30,7 @@
         "pathFeature.js",
         "polygonFeature.js",
         "planeFeature.js",
+        "vectorFeature.js",
         "geomFeature.js",
         "graphFeature.js",
         "transform.js",
@@ -67,6 +68,7 @@
         "pathFeature.js",
         "graphFeature.js",
         "planeFeature.js",
+        "vectorFeature.js",
         "d3Renderer.js"
       ]
     },

--- a/src/core/vectorFeature.js
+++ b/src/core/vectorFeature.js
@@ -1,0 +1,96 @@
+//////////////////////////////////////////////////////////////////////////////
+/**
+ * Create a new instance of class vectorFeature
+ *
+ * @class
+ * @extends geo.feature
+ * @returns {geo.vectorFeature}
+ */
+//////////////////////////////////////////////////////////////////////////////
+geo.vectorFeature = function (arg) {
+  'use strict';
+  if (!(this instanceof geo.vectorFeature)) {
+    return new geo.vectorFeature(arg);
+  }
+  arg = arg || {};
+  geo.feature.call(this, arg);
+
+  ////////////////////////////////////////////////////////////////////////////
+  /**
+   * @private
+   */
+  ////////////////////////////////////////////////////////////////////////////
+  var m_this = this,
+      s_init = this._init,
+      s_style = this.style;
+
+  ////////////////////////////////////////////////////////////////////////////
+  /**
+   * Get or set the accessor for the origin of the vector.  This is the point
+   * that the vector base resides at.  Defaults to (0, 0, 0).
+   * @param {geo.accessor|geo.geoPosition} [accessor] The origin accessor
+   */
+  ////////////////////////////////////////////////////////////////////////////
+  this.origin = function (val) {
+    if (val === undefined) {
+      return s_style('origin');
+    } else {
+      s_style('origin', val);
+      m_this.dataTime().modified();
+      m_this.modified();
+    }
+    return m_this;
+  };
+
+  ////////////////////////////////////////////////////////////////////////////
+  /**
+   * Get or set the accessor for the displacement (coordinates) of the vector.
+   * @param {geo.accessor|geo.geoPosition} [accessor] The accessor
+   */
+  ////////////////////////////////////////////////////////////////////////////
+  this.delta = function (val) {
+    if (val === undefined) {
+      return s_style('delta');
+    } else {
+      s_style('delta', val);
+      m_this.dataTime().modified();
+      m_this.modified();
+    }
+    return m_this;
+  };
+
+  ////////////////////////////////////////////////////////////////////////////
+  /**
+   * Initialize
+   * @protected
+   */
+  ////////////////////////////////////////////////////////////////////////////
+  this._init = function (arg) {
+    s_init.call(m_this, arg);
+
+    var defaultStyle = $.extend(
+      {},
+      {
+        strokeColor: 'black',
+        strokeWidth: 2.0,
+        strokeOpacity: 1.0,
+        // TODO: define styles for the end markers
+        // originStyle: 'none',
+        // endStyle: 'arrow',
+        origin: {x: 0, y: 0, z: 0},
+        delta: function (d) { return d; },
+        scale: null // size scaling factor (null -> renderer decides)
+      },
+      arg.style === undefined ? {} : arg.style
+    );
+
+    if (arg.origin !== undefined) {
+      defaultStyle.origin = arg.origin;
+    }
+
+    m_this.style(defaultStyle);
+    m_this.dataTime().modified();
+  };
+};
+
+inherit(geo.vectorFeature, geo.feature);

--- a/src/d3/d3Renderer.js
+++ b/src/d3/d3Renderer.js
@@ -316,8 +316,8 @@ geo.d3.d3Renderer = function (arg) {
         .attr('viewBox', '0 0 10 10')
         .attr('refX', '1')
         .attr('refY', '5')
-        .attr('markerWidth', '6')
-        .attr('markerHeight', '6')
+        .attr('markerWidth', '5')
+        .attr('markerHeight', '5')
         .attr('orient', 'auto')
         .append('path')
           .attr('d', 'M 0 0 L 10 5 L 0 10 z');

--- a/src/d3/d3Renderer.js
+++ b/src/d3/d3Renderer.js
@@ -310,6 +310,18 @@ geo.d3.d3Renderer = function (arg) {
           .attr('stdDeviation', 20)
           .attr('in', 'SourceGraphic');
 
+      // add markers for vector features
+      m_defs.append('marker')
+        .attr('id', 'geo-arrow')
+        .attr('viewBox', '0 0 10 10')
+        .attr('refX', '1')
+        .attr('refY', '5')
+        .attr('markerWidth', '6')
+        .attr('markerHeight', '6')
+        .attr('orient', 'auto')
+        .append('path')
+          .attr('d', 'M 0 0 L 10 5 L 0 10 z');
+
       m_sticky = m_this.layer().sticky();
       m_svg.attr('class', m_this._d3id());
       m_svg.attr('width', m_this.layer().node().width());

--- a/src/d3/vectorFeature.js
+++ b/src/d3/vectorFeature.js
@@ -72,7 +72,7 @@ geo.d3.vectorFeature = function (arg) {
         x1: origin.x,
         y1: origin.y,
         dx: delta.x,
-        dy: delta.y
+        dy: -delta.y
       };
     });
 
@@ -101,7 +101,8 @@ geo.d3.vectorFeature = function (arg) {
       },
       y2: function (d, i) {
         return cache[i].y1 + getScale() * cache[i].dy;
-      }
+      },
+      'marker-end': 'url(#geo-arrow)'
     };
     m_style.style = {
       stroke: function () { return true; },

--- a/src/d3/vectorFeature.js
+++ b/src/d3/vectorFeature.js
@@ -1,0 +1,146 @@
+//////////////////////////////////////////////////////////////////////////////
+/**
+ * Create a new instance of vectorFeature
+ *
+ * @class
+ * @extends geo.vectorFeature
+ * @extends geo.d3.object
+ * @returns {geo.d3.vectorFeature}
+ */
+//////////////////////////////////////////////////////////////////////////////
+geo.d3.vectorFeature = function (arg) {
+  'use strict';
+  if (!(this instanceof geo.d3.vectorFeature)) {
+    return new geo.d3.vectorFeature(arg);
+  }
+  arg = arg || {};
+  geo.vectorFeature.call(this, arg);
+  geo.d3.object.call(this);
+
+  ////////////////////////////////////////////////////////////////////////////
+  /**
+   * @private
+   */
+  ////////////////////////////////////////////////////////////////////////////
+  var m_this = this,
+      s_init = this._init,
+      s_update = this._update,
+      m_buildTime = geo.timestamp(),
+      m_style = {},
+      m_sticky;
+
+  ////////////////////////////////////////////////////////////////////////////
+  /**
+   * Initialize
+   * @protected
+   */
+  ////////////////////////////////////////////////////////////////////////////
+  this._init = function (arg) {
+    s_init.call(m_this, arg);
+    m_sticky = m_this.layer().sticky();
+    return m_this;
+  };
+
+  ////////////////////////////////////////////////////////////////////////////
+  /**
+   * Build
+   * @protected
+   */
+  ////////////////////////////////////////////////////////////////////////////
+  this._build = function () {
+    var data = m_this.data(),
+        s_style = m_this.style.get(),
+        m_renderer = m_this.renderer(),
+        orig_func = m_this.origin(),
+        size_func = m_this.delta(),
+        cache = [],
+        scale = m_this.style('scale'),
+        max = Number.NEGATIVE_INFINITY;
+
+    // call super-method
+    s_update.call(m_this);
+
+    // default to empty data array
+    if (!data) { data = []; }
+
+    // cache the georeferencing
+    cache = data.map(function (d, i) {
+      var origin = m_renderer.worldToDisplay(orig_func(d, i)),
+          delta = size_func(d, i);
+      max = Math.max(max, delta.x * delta.x + delta.y * delta.y);
+      return {
+        x1: origin.x,
+        y1: origin.y,
+        dx: delta.x,
+        dy: delta.y
+      };
+    });
+
+    max = Math.sqrt(max);
+    if (!scale) {
+      scale = 75 / max;
+    }
+
+    function getScale() {
+      return scale / m_renderer.scaleFactor();
+    }
+
+    // fill in d3 renderer style object defaults
+    m_style.id = m_this._d3id();
+    m_style.data = data;
+    m_style.append = 'line';
+    m_style.attributes = {
+      x1: function (d, i) {
+        return cache[i].x1;
+      },
+      y1: function (d, i) {
+        return cache[i].y1;
+      },
+      x2: function (d, i) {
+        return cache[i].x1 + getScale() * cache[i].dx;
+      },
+      y2: function (d, i) {
+        return cache[i].y1 + getScale() * cache[i].dy;
+      }
+    };
+    m_style.style = {
+      stroke: function () { return true; },
+      strokeColor: s_style.strokeColor,
+      strokeWidth: s_style.strokeWidth,
+      strokeOpacity: s_style.strokeOpacity
+    };
+    m_style.classes = ['d3VectorFeature'];
+
+    // pass to renderer to draw
+    m_this.renderer()._drawFeatures(m_style);
+
+    // update time stamps
+    m_buildTime.modified();
+    m_this.updateTime().modified();
+    return m_this;
+  };
+
+  ////////////////////////////////////////////////////////////////////////////
+  /**
+   * Update
+   * @protected
+   */
+  ////////////////////////////////////////////////////////////////////////////
+  this._update = function () {
+    s_update.call(m_this);
+
+    if (m_this.getMTime() >= m_buildTime.getMTime()) {
+      m_this._build();
+    }
+
+    return m_this;
+  };
+
+  this._init(arg);
+  return this;
+};
+
+inherit(geo.d3.vectorFeature, geo.vectorFeature);
+
+// Now register it
+geo.registerFeature('d3', 'vector', geo.d3.vectorFeature);

--- a/testing/test-cases/selenium-tests/d3Vectors/include.css
+++ b/testing/test-cases/selenium-tests/d3Vectors/include.css
@@ -1,0 +1,3 @@
+body {
+    overflow: hidden;
+}

--- a/testing/test-cases/selenium-tests/d3Vectors/include.html
+++ b/testing/test-cases/selenium-tests/d3Vectors/include.html
@@ -1,0 +1,1 @@
+<div id='map'></div>

--- a/testing/test-cases/selenium-tests/d3Vectors/include.js
+++ b/testing/test-cases/selenium-tests/d3Vectors/include.js
@@ -7,17 +7,23 @@ window.startTest = function (done) {
 
   function draw(citieslatlon) {
     var layer = myMap.createLayer('feature', {'renderer' : 'd3'});
+    // var color = d3.scale.category20().domain(d3.range(20));
 
     var vectors = layer.createFeature('vector')
       .data(citieslatlon)
-      .origin(function (d) { return { x: d.lon, y: d.lat }; });
+      .origin(function (d) { return { x: d.lon, y: d.lat }; })
+      .style('strokeColor', function () {
+        // return color(i % 20); // <- fix arrow colors
+        return 'black';
+      })
+      .style('strokeWidth', 2.5);
 
     function setDelta() {
       var center = myMap.center();
       vectors.delta(function (d) {
         return {
           x: center.x - d.lon,
-          y: d.lat - center.y
+          y: center.y - d.lat
         };
       }).draw();
     }

--- a/testing/test-cases/selenium-tests/d3Vectors/include.js
+++ b/testing/test-cases/selenium-tests/d3Vectors/include.js
@@ -1,0 +1,33 @@
+window.startTest = function (done) {
+  'use strict';
+
+  var mapOptions = { center : { y: 40, x: -105 } };
+
+  var myMap = window.geoTests.createOsmMap(mapOptions);
+
+  function draw(citieslatlon) {
+    var layer = myMap.createLayer('feature', {'renderer' : 'd3'});
+
+    var vectors = layer.createFeature('vector')
+      .data(citieslatlon)
+      .origin(function (d) { return { x: d.lon, y: d.lat }; });
+
+    function setDelta() {
+      var center = myMap.center();
+      vectors.delta(function (d) {
+        return {
+          x: center.x - d.lon,
+          y: d.lat - center.y
+        };
+      }).draw();
+    }
+
+    setDelta();
+    myMap.draw();
+
+    myMap.onIdle(done);
+    layer.geoOn(geo.event.pan, setDelta);
+  }
+
+  window.geoTests.loadCitiesData(draw, 30);
+};

--- a/testing/test-cases/selenium-tests/d3Vectors/testd3Vectors.py
+++ b/testing/test-cases/selenium-tests/d3Vectors/testd3Vectors.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python
+
+from selenium_test import FirefoxTest, ChromeTest,\
+    setUpModule, tearDownModule
+
+
+class d3VectorsBase(object):
+    testCase = ('d3Vectors',)
+    testRevision = 5
+
+    def loadPage(self):
+        self.resizeWindow(640, 480)
+        self.loadURL('d3Vectors/index.html')
+        self.wait()
+
+    def testd3DrawVectors(self):
+        self.loadPage()
+
+        testName = 'd3DrawVectorss'
+        self.screenshotTest(testName)
+
+
+class FirefoxOSM(d3VectorsBase, FirefoxTest):
+    testCase = d3VectorsBase.testCase + ('firefox',)
+
+
+class ChromeOSM(d3VectorsBase, ChromeTest):
+    testCase = d3VectorsBase.testCase + ('chrome',)
+
+
+if __name__ == '__main__':
+    import unittest
+    unittest.main()


### PR DESCRIPTION
@aashish24 Here is a first pass at the vector feature.  I decided to implement it via svg `marker` elements because it makes the code extremely simple.  The problem I found is that `marker`'s can't inherit styles yet.  This feature has been defined in SVG2 with `context-fill` with `context-stroke`, but it hasn't appeared in any browsers yet.  For the moment, the vector lines can be colored with `strokeColor`, but the arrows will always be black.  I think I will backfill the `context-stroke` property by using the method used in [this example](http://bl.ocks.org/kenpenn/8d782030e4be9d832be7).

The API works like this:
```javascript
layer.createFeature('vector')
  .data(...)
  .origin(...) // The origin of the vector in world coordinates
  .delta(...) // The vector (dx/dy) in arbitrary coordinates (see explanation)
```

This is the default style
```javascript
{
  strokeColor: 'black',
  strokeWidth: 2,
  strokeOpacity: 1,
  scale: null
}
```

The scale is a factor that is multiplied by each of the vector deltas to get the length in pixels.  A null value indicates that the renderer will decide how to scale based on the current zoom, density of the vectors, etc.  This is designed to be analogous to quiver plots in matplotlib.  We could also add a special value to indicate the delta is in world coordinates as well.

One final thing that I want to add is a style attribute for the arrows.  This will enable creating the sorts of arrows that meteorologists like to use that indicate wind speed.

![vectors](https://cloud.githubusercontent.com/assets/31890/6151639/2def32d8-b1e5-11e4-9831-e0d275efa01d.png)