### PR TITLE
Adding a link to the new api docs

### DIFF
--- a/examples/index.jade
+++ b/examples/index.jade
@@ -20,7 +20,8 @@ block prepend headerButtons
         li
           a(href="https://github.com/OpenGeoscience/geojs") Source
           a(href="https://github.com/OpenGeoscience/geojs/issues") Bugs
-          a(href="http://geojs.readthedocs.org/en/latest/") Documentation
+          a(href="http://opengeoscience.github.io/geojs/apidocs/") Documentation
+          a(href="http://geojs.readthedocs.org/en/latest/") Developers guide
           a(href="http://my.cdash.org/index.php?project=geojs") Testing
 
 block mainContent


### PR DESCRIPTION
I uploaded the latest jsdoc generated [documentation](http://opengeoscience.github.io/geojs/apidocs/).  There is still a long way to go in writing out the docstrings across the classes and making them consistent, but they are starting to get better.  I also need to look into customizing the output template to both make the docs look better with our class structure.