### PR TITLE
Added a function to change baseUrl.

### DIFF
--- a/src/core/osmLayer.js
+++ b/src/core/osmLayer.js
@@ -308,6 +308,7 @@ geo.osmLayer = function (arg) {
     tile.LOADED = false;
     tile.REMOVED = false;
     tile.REMOVING = false;
+    tile.INVALID = false;
 
     tile.crossOrigin = "anonymous";
     tile.zoom = zoom;
@@ -548,6 +549,9 @@ geo.osmLayer = function (arg) {
       m_this.addDeferred(defer);
 
       return function () {
+        if (tile.INVALID) {
+          return;
+        }
         tile.LOADING = false;
         tile.LOADED = true;
         if ((tile.REMOVING || tile.REMOVED) &&
@@ -714,6 +718,7 @@ geo.osmLayer = function (arg) {
         for (x in m_tiles[zoom]) {
           for (y in m_tiles[zoom][x]) {
             tile = m_tiles[zoom][x][y];
+            tile.INVALID = true;
             m_this.deleteFeature(tile.feature);
           }
         }

--- a/src/core/osmLayer.js
+++ b/src/core/osmLayer.js
@@ -708,26 +708,26 @@ geo.osmLayer = function (arg) {
     }
     if (baseUrl !== m_baseUrl) {
       m_baseUrl = baseUrl;
-      /* Move all current tiles to a 'zoom' of 'old' so that they will not be
-       * used and will eventually be discarded.  It places them at an index
-       * of (0, y) so that each is in a distinct key within the m_tiles
-       object. */
-      var tile, x, y, zoom, i, old_tiles = [];
 
+      var tile, x, y, zoom;
       for (zoom in m_tiles) {
         for (x in m_tiles[zoom]) {
           for (y in m_tiles[zoom][x]) {
             tile = m_tiles[zoom][x][y];
-            tile.zoom = "old";
-            tile.index_x = 0;
-            tile.index_y = old_tiles.length;
-            old_tiles.push(tile);
+            m_this.deleteFeature(tile.feature);
           }
         }
       }
-      m_tiles = {"old": {0: {}}};
-      for (i = 0; i < old_tiles.length; i += 1) {
-        m_tiles.old[0][i] = old_tiles[i];
+      m_tiles = {};
+      m_pendingNewTiles = [];
+      m_pendingInactiveTiles = [];
+      m_numberOfCachedTiles = 0;
+      m_visibleTilesRange = {};
+      m_pendingNewTilesStat = {};
+
+      if (m_updateTimerId !== null) {
+        clearTimeout(m_updateTimerId);
+        m_updateTimerId = null;
       }
       this._update();
     }

--- a/src/core/osmLayer.js
+++ b/src/core/osmLayer.js
@@ -95,7 +95,6 @@ geo.osmLayer = function (arg) {
     return false;
   }
 
-
   ////////////////////////////////////////////////////////////////////////////
   /**
    * Draw new tiles and remove the old ones
@@ -328,7 +327,6 @@ geo.osmLayer = function (arg) {
     return tile;
   };
 
-
   ////////////////////////////////////////////////////////////////////////////
   /**
    * Clear tiles that are no longer required
@@ -518,7 +516,7 @@ geo.osmLayer = function (arg) {
 
     m_visibleTilesRange = {};
     m_visibleTilesRange[m_zoom] = { startX: currStartX, endX: currEndX,
-                                  startY: currStartY, endY: currEndY };
+                                    startY: currStartY, endY: currEndY };
 
     m_visibleTilesRange[m_lastVisibleZoom] =
                                 { startX: lastStartX, endX: lastEndX,
@@ -694,6 +692,44 @@ geo.osmLayer = function (arg) {
 
     /// Now call base class update
     s_update.call(m_this, request);
+  };
+
+  ////////////////////////////////////////////////////////////////////////////
+  /**
+   * Update baseUrl for map tiles.  Map all tiles as needing to be refreshed.
+   *
+   * @param baseUrl: the new baseUrl for the map.
+   */
+  ////////////////////////////////////////////////////////////////////////////
+  this.updateBaseUrl = function (baseUrl) {
+    if (baseUrl.charAt(m_baseUrl.length - 1) !== "/") {
+      baseUrl += "/";
+    }
+    if (baseUrl != m_baseUrl) {
+      m_baseUrl = baseUrl;
+      /* Move all current tiles to a 'zoom' of 'old' so that they will not be
+       * used and will eventually be discarded.  It places them at an index
+       * of (0, y) so that each is in a distinct key within the m_tiles
+       object. */
+      var tile, x, y, zoom, i, old_tiles = [];
+
+      for (zoom in m_tiles) {
+        for (x in m_tiles[zoom]) {
+          for (y in m_tiles[zoom][x]) {
+            tile = m_tiles[zoom][x][y];
+            tile.zoom = "old";
+            tile.index_x = 0;
+            tile.index_y = old_tiles.length;
+            old_tiles.push(tile);
+          }
+        }
+      }
+      m_tiles = {"old": {0: {}}};
+      for (i = 0; i < old_tiles.length; i += 1) {
+        m_tiles.old[0][i] = old_tiles[i];
+      }
+      this._update();
+    }
   };
 
   ////////////////////////////////////////////////////////////////////////////

--- a/src/core/osmLayer.js
+++ b/src/core/osmLayer.js
@@ -701,11 +701,12 @@ geo.osmLayer = function (arg) {
    * @param baseUrl: the new baseUrl for the map.
    */
   ////////////////////////////////////////////////////////////////////////////
+  /* jshint -W089 */
   this.updateBaseUrl = function (baseUrl) {
     if (baseUrl.charAt(m_baseUrl.length - 1) !== "/") {
       baseUrl += "/";
     }
-    if (baseUrl != m_baseUrl) {
+    if (baseUrl !== m_baseUrl) {
       m_baseUrl = baseUrl;
       /* Move all current tiles to a 'zoom' of 'old' so that they will not be
        * used and will eventually be discarded.  It places them at an index


### PR DESCRIPTION
To change the tile set, call updateBaseUrl on the osm layer.  This moves all existing tiles to the zoom level of 'old' so that they will not be used, then updates the layer.