### PR TITLE
Do less work to convert constant colors.

### DIFF
--- a/src/core/feature.js
+++ b/src/core/feature.js
@@ -307,14 +307,20 @@ geo.feature = function (arg) {
       }
       return all;
     }
-    out = geo.util.ensureFunction(m_style[key]);
     if (key.toLowerCase().match(/color$/)) {
-      tmp = out;
-      out = function () {
-        return geo.util.convertColor(
-          tmp.apply(this, arguments)
-        );
-      };
+      if (geo.util.isFunction(m_style[key])) {
+        tmp = geo.util.ensureFunction(m_style[key]);
+        out = function () {
+          return geo.util.convertColor(
+            tmp.apply(this, arguments)
+          );
+        };
+      } else {
+        // if the color is not a function, only convert it once
+        out = geo.util.ensureFunction(geo.util.convertColor(m_style[key]));
+      }
+    } else {
+      out = geo.util.ensureFunction(m_style[key]);
     }
     return out;
   };


### PR DESCRIPTION
When we access a style, we always return a function.  Colors are passed through the util.convertColor function.  This was always wrapped util.covertColor(util.ensureFunction(color)).  However, if the color was not a function, it is more efficient to use util.ensureFunction(util.covertColor(color)), as we know the conversion only needs to be performed once.