### PR TITLE
Simplify travis test setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,12 @@ node_js:
     - "0.10"
 
 before_install:
-    - sudo apt-get update -qq
-    - sudo apt-get install -y cmake
+  - pushd "${HOME}"
+  - curl "http://www.cmake.org/files/v3.2/cmake-3.2.0-rc2-Linux-x86_64.tar.gz" | gunzip -c | tar x
+  - cd cmake-*/bin && export PATH="${PWD}:${PATH}"
+  - popd
+  - cmake --version
+  - env
 
 script:
     - git submodule init
@@ -15,5 +19,8 @@ script:
     - mkdir _build
     - cd _build
     - cmake ..
-    - ctest -VV -S ../cmake/travis_build.cmake
+    - ctest -VV -S ../cmake/travis_build.cmake || true
     - ctest -VV -S ../cmake/travis_submit.cmake
+    - if [ -f test_failed ] ; then false ; fi
+
+sudo: False

--- a/cmake/travis_build.cmake
+++ b/cmake/travis_build.cmake
@@ -13,6 +13,8 @@ ctest_test(PARALLEL_LEVEL 1 RETURN_VALUE res)
 ctest_coverage()
 file(REMOVE ${CTEST_BINARY_DIRECTORY}/coverage.xml)
 
+file(REMOVE "${CTEST_BINARY_DIRECTORY}/test_failed")
 if(NOT res EQUAL 0)
+  file(WRITE "${CTEST_BINARY_DIRECTORY}/test_failed" "error")
   message(FATAL_ERROR "Test failures occurred.")
 endif()

--- a/testing/test-cases/phantomjs-tests/mapInteractor.js
+++ b/testing/test-cases/phantomjs-tests/mapInteractor.js
@@ -102,6 +102,7 @@ describe('mapInteractor', function () {
 
     var interactor = geo.mapInteractor({
       map: map,
+      momentum: {enabled: false},
       panMoveButton: 'left',
       panWheelEnabled: false,
       zoomMoveButton: null,
@@ -179,6 +180,7 @@ describe('mapInteractor', function () {
 
     var interactor = geo.mapInteractor({
       map: map,
+      momentum: {enabled: false},
       panMoveButton: null,
       panWheelEnabled: false,
       zoomMoveButton: null,


### PR DESCRIPTION
Removing sudo allows travis to use a light weight [container](http://docs.travis-ci.com/user/workers/container-based-infrastructure/) to run the tests.