### PR TITLE
Don't create needless arrays.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -241,6 +241,9 @@ if(SELENIUM_TESTS)
     endif()
   endforeach()
 
+  set_property(TEST "selenium:glPointsSpeed" APPEND PROPERTY ENVIRONMENT "LOAD_SPEED_THRESHOLD=1000")
+  set_property(TEST "selenium:glPointsSpeed" APPEND PROPERTY ENVIRONMENT "FRAMERATE_THRESHOLD=10")
+
   set(jasmine_runner ${CMAKE_CURRENT_BINARY_DIR}/test/selenium_jasmine_runner.py)
   set(JASMINE_DEPLOY_URL /test/jasmine)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -243,6 +243,9 @@ if(SELENIUM_TESTS)
 
   set_property(TEST "selenium:glPointsSpeed" APPEND PROPERTY ENVIRONMENT "LOAD_SPEED_THRESHOLD=1000")
   set_property(TEST "selenium:glPointsSpeed" APPEND PROPERTY ENVIRONMENT "FRAMERATE_THRESHOLD=10")
+  
+  set_property(TEST "selenium:glLinesSpeed" APPEND PROPERTY ENVIRONMENT "LOAD_SPEED_THRESHOLD=1000")
+  set_property(TEST "selenium:glLinesSpeed" APPEND PROPERTY ENVIRONMENT "FRAMERATE_THRESHOLD=10")
 
   set(jasmine_runner ${CMAKE_CURRENT_BINARY_DIR}/test/selenium_jasmine_runner.py)
   set(JASMINE_DEPLOY_URL /test/jasmine)

--- a/src/gl/lineFeature.js
+++ b/src/gl/lineFeature.js
@@ -189,27 +189,26 @@ geo.gl.lineFeature = function (arg) {
         vert[1].strokeWidth = strkWidthFunc(lineItemData, j, lineItem, i);
         vert[1].strokeColor = strkColorFunc(lineItemData, j, lineItem, i);
         vert[1].strokeOpacity = strkOpacityFunc(lineItemData, j, lineItem, i);
-        if (!j) {
-          continue;
-        }
-        for (k = 0; k < order.length; k += 1, dest += 1, dest3 += 3) {
-          v = vert[order[k][0]];
-          posBuf[dest3]     = position[v.pos];
-          posBuf[dest3 + 1] = position[v.pos + 1];
-          posBuf[dest3 + 2] = position[v.pos + 2];
-          prevBuf[dest3]     = position[v.prev];
-          prevBuf[dest3 + 1] = position[v.prev + 1];
-          prevBuf[dest3 + 2] = position[v.prev + 2];
-          nextBuf[dest3]     = position[v.next];
-          nextBuf[dest3 + 1] = position[v.next + 1];
-          nextBuf[dest3 + 2] = position[v.next + 2];
-          offsetBuf[dest] = order[k][1];
-          indicesBuf[dest] = dest;
-          strokeWidthBuf[dest] = v.strokeWidth;
-          strokeColorBuf[dest3]     = v.strokeColor.r;
-          strokeColorBuf[dest3 + 1] = v.strokeColor.g;
-          strokeColorBuf[dest3 + 2] = v.strokeColor.b;
-          strokeOpacityBuf[dest] = v.strokeOpacity;
+        if (j) {
+          for (k = 0; k < order.length; k += 1, dest += 1, dest3 += 3) {
+            v = vert[order[k][0]];
+            posBuf[dest3]     = position[v.pos];
+            posBuf[dest3 + 1] = position[v.pos + 1];
+            posBuf[dest3 + 2] = position[v.pos + 2];
+            prevBuf[dest3]     = position[v.prev];
+            prevBuf[dest3 + 1] = position[v.prev + 1];
+            prevBuf[dest3 + 2] = position[v.prev + 2];
+            nextBuf[dest3]     = position[v.next];
+            nextBuf[dest3 + 1] = position[v.next + 1];
+            nextBuf[dest3 + 2] = position[v.next + 2];
+            offsetBuf[dest] = order[k][1];
+            indicesBuf[dest] = dest;
+            strokeWidthBuf[dest] = v.strokeWidth;
+            strokeColorBuf[dest3]     = v.strokeColor.r;
+            strokeColorBuf[dest3 + 1] = v.strokeColor.g;
+            strokeColorBuf[dest3 + 2] = v.strokeColor.b;
+            strokeOpacityBuf[dest] = v.strokeOpacity;
+          }
         }
       }
     }

--- a/src/gl/lineFeature.js
+++ b/src/gl/lineFeature.js
@@ -31,79 +31,79 @@ geo.gl.lineFeature = function (arg) {
       s_update = this._update;
 
   function createVertexShader() {
-      var vertexShaderSource = [
-        '#ifdef GL_ES',
-        '  precision highp float;',
-        '#endif',
-        'attribute vec3 pos;',
-        'attribute vec3 prev;',
-        'attribute vec3 next;',
-        'attribute float offset;',
+    var vertexShaderSource = [
+      '#ifdef GL_ES',
+      '  precision highp float;',
+      '#endif',
+      'attribute vec3 pos;',
+      'attribute vec3 prev;',
+      'attribute vec3 next;',
+      'attribute float offset;',
 
-        'attribute vec3 strokeColor;',
-        'attribute float strokeOpacity;',
-        'attribute float strokeWidth;',
+      'attribute vec3 strokeColor;',
+      'attribute float strokeOpacity;',
+      'attribute float strokeWidth;',
 
-        'uniform mat4 modelViewMatrix;',
-        'uniform mat4 projectionMatrix;',
-        'uniform float pixelWidth;',
+      'uniform mat4 modelViewMatrix;',
+      'uniform mat4 projectionMatrix;',
+      'uniform float pixelWidth;',
 
-        'varying vec3 strokeColorVar;',
-        'varying float strokeWidthVar;',
-        'varying float strokeOpacityVar;',
+      'varying vec3 strokeColorVar;',
+      'varying float strokeWidthVar;',
+      'varying float strokeOpacityVar;',
 
-        'void main(void)',
-        '{',
-        /* If any vertex has been deliberately set to a negative opacity,
-         * skip doing computations on it. */
-        '  if (strokeOpacity < 0.0) {',
-        '    gl_Position = vec4(2, 2, 0, 1);',
-        '    return;',
-        '  }',
-        '  const float PI = 3.14159265358979323846264;',
-        '  vec4 worldPos = projectionMatrix * modelViewMatrix * vec4(pos.xyz, 1);',
-        '  if (worldPos.w != 0.0) {',
-        '    worldPos = worldPos/worldPos.w;',
-        '  }',
-        '  vec4 worldNext = projectionMatrix * modelViewMatrix * vec4(next.xyz, 1);',
-        '  if (worldNext.w != 0.0) {',
-        '    worldNext = worldNext/worldNext.w;',
-        '  }',
-        '  vec4 worldPrev = projectionMatrix* modelViewMatrix * vec4(prev.xyz, 1);',
-        '  if (worldPrev.w != 0.0) {',
-        '    worldPrev = worldPrev/worldPrev.w;',
-        '  }',
-        '  strokeColorVar = strokeColor;',
-        '  strokeWidthVar = strokeWidth;',
-        '  strokeOpacityVar = strokeOpacity;',
-        '  vec2 deltaNext = worldNext.xy - worldPos.xy;',
-        '  vec2 deltaPrev = worldPos.xy - worldPrev.xy;',
-        '  float angleNext = PI * 0.5;',
-        '  if (deltaNext.y < 0.0) { angleNext = -angleNext; } ',
-        '  if (deltaNext.x != 0.0) {',
-        '    angleNext = atan(deltaNext.y, deltaNext.x);',
-        '  }',
-        '  float anglePrev = PI * 0.5;',
-        '  if (deltaPrev.y < 0.0) { anglePrev = -anglePrev; } ',
-        '  if (deltaPrev.x != 0.0) {',
-        '    anglePrev = atan(deltaPrev.y, deltaPrev.x);',
-        '  }',
-        '  if (deltaPrev.xy == vec2(0.0, 0.0)) anglePrev = angleNext;',
-        '  if (deltaNext.xy == vec2(0.0, 0.0)) angleNext = anglePrev;',
-        '  float angle = (anglePrev + angleNext) / 2.0;',
-        '  float cosAngle = cos(anglePrev - angle);',
-        '  if (cosAngle < 0.1) { cosAngle = sign(cosAngle) * 1.0; angle = 0.0; }',
-        '  float distance = (offset * strokeWidth * pixelWidth) /',
-        '                    cosAngle;',
-        '  worldPos.x += distance * sin(angle);',
-        '  worldPos.y -= distance * cos(angle);',
-        '  gl_Position = worldPos;',
-        '}'
-      ].join('\n'),
-      shader = new vgl.shader(gl.VERTEX_SHADER);
-      shader.setShaderSource(vertexShaderSource);
-      return shader;
-    }
+      'void main(void)',
+      '{',
+      /* If any vertex has been deliberately set to a negative opacity,
+       * skip doing computations on it. */
+      '  if (strokeOpacity < 0.0) {',
+      '    gl_Position = vec4(2, 2, 0, 1);',
+      '    return;',
+      '  }',
+      '  const float PI = 3.14159265358979323846264;',
+      '  vec4 worldPos = projectionMatrix * modelViewMatrix * vec4(pos.xyz, 1);',
+      '  if (worldPos.w != 0.0) {',
+      '    worldPos = worldPos/worldPos.w;',
+      '  }',
+      '  vec4 worldNext = projectionMatrix * modelViewMatrix * vec4(next.xyz, 1);',
+      '  if (worldNext.w != 0.0) {',
+      '    worldNext = worldNext/worldNext.w;',
+      '  }',
+      '  vec4 worldPrev = projectionMatrix* modelViewMatrix * vec4(prev.xyz, 1);',
+      '  if (worldPrev.w != 0.0) {',
+      '    worldPrev = worldPrev/worldPrev.w;',
+      '  }',
+      '  strokeColorVar = strokeColor;',
+      '  strokeWidthVar = strokeWidth;',
+      '  strokeOpacityVar = strokeOpacity;',
+      '  vec2 deltaNext = worldNext.xy - worldPos.xy;',
+      '  vec2 deltaPrev = worldPos.xy - worldPrev.xy;',
+      '  float angleNext = PI * 0.5;',
+      '  if (deltaNext.y < 0.0) { angleNext = -angleNext; } ',
+      '  if (deltaNext.x != 0.0) {',
+      '    angleNext = atan(deltaNext.y, deltaNext.x);',
+      '  }',
+      '  float anglePrev = PI * 0.5;',
+      '  if (deltaPrev.y < 0.0) { anglePrev = -anglePrev; } ',
+      '  if (deltaPrev.x != 0.0) {',
+      '    anglePrev = atan(deltaPrev.y, deltaPrev.x);',
+      '  }',
+      '  if (deltaPrev.xy == vec2(0.0, 0.0)) anglePrev = angleNext;',
+      '  if (deltaNext.xy == vec2(0.0, 0.0)) angleNext = anglePrev;',
+      '  float angle = (anglePrev + angleNext) / 2.0;',
+      '  float cosAngle = cos(anglePrev - angle);',
+      '  if (cosAngle < 0.1) { cosAngle = sign(cosAngle) * 1.0; angle = 0.0; }',
+      '  float distance = (offset * strokeWidth * pixelWidth) /',
+      '                    cosAngle;',
+      '  worldPos.x += distance * sin(angle);',
+      '  worldPos.y -= distance * cos(angle);',
+      '  gl_Position = worldPos;',
+      '}'
+    ].join('\n'),
+    shader = new vgl.shader(gl.VERTEX_SHADER);
+    shader.setShaderSource(vertexShaderSource);
+    return shader;
+  }
 
   function createFragmentShader() {
     var fragmentShaderSource = [
@@ -123,162 +123,108 @@ geo.gl.lineFeature = function (arg) {
   }
 
   function createGLLines() {
-    var i = null,
-        j = null,
-        k = null,
-        v,
-        prev = [],
-        next = [],
-        numPts = m_this.data().length,
-        itemIndex = 0,
-        lineItemIndex = 0,
-        lineItem = null,
-        currIndex = null,
-        lineSegments = [],
-        pos = null,
-        posTmp = null,
-        strkColor = null,
-        start = null,
+    var data = m_this.data(),
+        i, j, k, v,
+        numSegments = 0,
+        lineItem, lineItemData,
+        vert = [{}, {}], vertTemp,
+        pos, posIdx3,
         position = [],
-        strkWidthArr = [],
-        strkColorArr = [],
-        strkOpacityArr = [],
-        geom = vgl.geometryData(),
         posFunc = m_this.position(),
         strkWidthFunc = m_this.style.get('strokeWidth'),
         strkColorFunc = m_this.style.get('strokeColor'),
         strkOpacityFunc = m_this.style.get('strokeOpacity'),
-        buffers = vgl.DataBuffers(1024),
-        // Sources
-        posData = vgl.sourceDataP3fv({'name': 'pos'}),
-        prvPosData = vgl.sourceDataAnyfv(
-            3, vgl.vertexAttributeKeysIndexed.Four, {'name': 'prev'}),
-        nxtPosData = vgl.sourceDataAnyfv(
-            3, vgl.vertexAttributeKeysIndexed.Five, {'name': 'next'}),
-        offPosData = vgl.sourceDataAnyfv(
-            1, vgl.vertexAttributeKeysIndexed.Six, {'name': 'offset'}),
-        strkWidthData = vgl.sourceDataAnyfv(
-            1, vgl.vertexAttributeKeysIndexed.One, {'name': 'strokeWidth'}),
-        strkColorData = vgl.sourceDataAnyfv(
-            3, vgl.vertexAttributeKeysIndexed.Two, {'name': 'strokeColor'}),
-        strkOpacityData = vgl.sourceDataAnyfv(
-            1, vgl.vertexAttributeKeysIndexed.Three,
-            {'name': 'strokeOpacity'}),
-        // Primitive indices
-        triangles = vgl.triangles(),
         order = m_this.featureVertices(),
-        addVert = function (prevPos, currPos, nextPos, offset,
-                            width, color, opacity) {
-          buffers.write('prev', prevPos, currIndex, 1);
-          buffers.write('pos', currPos, currIndex, 1);
-          buffers.write('next', nextPos, currIndex, 1);
-          buffers.write('offset', [offset], currIndex, 1);
-          buffers.write('indices', [currIndex], currIndex, 1);
-          buffers.write('strokeWidth', [width], currIndex, 1);
-          buffers.write('strokeColor', color, currIndex, 1);
-          buffers.write('strokeOpacity', [opacity], currIndex, 1);
-          currIndex += 1;
-        };
+        buffers,
+        posBuf, nextBuf, prevBuf, offsetBuf, indicesBuf,
+        strokeWidthBuf, strokeColorBuf, strokeOpacityBuf,
+        dest, dest3,
+        geom = m_mapper.geometryData();
 
-    m_this.data().forEach(function (item) {
-      lineItem = m_this.line()(item, itemIndex);
-      lineSegments.push(lineItem.length);
-      lineItem.forEach(function (lineItemData) {
-        pos = posFunc(lineItemData, lineItemIndex, item, itemIndex);
+    for (i = 0; i < data.length; i += 1) {
+      lineItem = m_this.line()(data[i], i);
+      numSegments += lineItem.length - 1;
+      for (j = 0; j < lineItem.length; j += 1) {
+        pos = posFunc(lineItem[j], j, lineItem, i);
         if (pos instanceof geo.latlng) {
-          position.push([pos.x(), pos.y(), 0.0]);
+          position.push(pos.x());
+          position.push(pos.y());
+          position.push(0.0);
         } else {
-          position.push([pos.x, pos.y, pos.z || 0.0]);
+          position.push(pos.x);
+          position.push(pos.y);
+          position.push(pos.z || 0.0);
         }
-        strkWidthArr.push(strkWidthFunc(lineItemData, lineItemIndex,
-                                        item, itemIndex));
-        strkColor = strkColorFunc(lineItemData, lineItemIndex,
-                                  item, itemIndex);
-        strkColorArr.push([strkColor.r, strkColor.g, strkColor.b]);
-        strkOpacityArr.push(strkOpacityFunc(lineItemData, lineItemIndex,
-                                            item, itemIndex));
-
-        // Assuming that we will have atleast two points
-        if (lineItemIndex === 0) {
-          posTmp = position[position.length - 1];
-          prev.push(posTmp);
-        } else {
-          prev.push(position[position.length - 2]);
-          next.push(position[position.length - 1]);
-        }
-
-        lineItemIndex += 1;
-      });
-      next.push(position[position.length - 1]);
-      lineItemIndex = 0;
-      itemIndex += 1;
-    });
+      }
+    }
 
     position = geo.transform.transformCoordinates(
                  m_this.gcs(), m_this.layer().map().gcs(),
                  position, 3);
-    prev = geo.transform.transformCoordinates(
-                 m_this.gcs(), m_this.layer().map().gcs(),
-                 prev, 3);
-    next = geo.transform.transformCoordinates(
-                 m_this.gcs(), m_this.layer().map().gcs(),
-                 next, 3);
 
-    buffers.create('pos', 3);
-    buffers.create('next', 3);
-    buffers.create('prev', 3);
-    buffers.create('offset', 1);
-    buffers.create('indices', 1);
-    buffers.create('strokeWidth', 1);
-    buffers.create('strokeColor', 3);
-    buffers.create('strokeOpacity', 1);
+    buffers = vgl.DataBuffers(numSegments * order.length);
+    posBuf           = buffers.create('pos', 3);
+    nextBuf          = buffers.create('next', 3);
+    prevBuf          = buffers.create('prev', 3);
+    offsetBuf        = buffers.create('offset', 1);
+    indicesBuf       = buffers.create('indices', 1);
+    strokeWidthBuf   = buffers.create('strokeWidth', 1);
+    strokeColorBuf   = buffers.create('strokeColor', 3);
+    strokeOpacityBuf = buffers.create('strokeOpacity', 1);
 
-    numPts = position.length;
-
-    start = buffers.alloc(numPts * 6);
-    currIndex = start;
-
-    i = 0;
-    k = 0;
-    for (j = 0; j < lineSegments.length; j += 1) {
-      i += 1;
-      for (k = 0; k < lineSegments[j] - 1; k += 1) {
-        for (v = 0; v < order.length; v += 1) {
-          addVert(prev[i + order[v][0]], position[i + order[v][0]],
-                  next[i + order[v][0]], order[v][1],
-                  strkWidthArr[i + order[v][0]],
-                  strkColorArr[i + order[v][0]],
-                  strkOpacityArr[i + order[v][0]]);
+    for (i = posIdx3 = dest = dest3 = 0; i < data.length; i += 1) {
+      lineItem = m_this.line()(data[i], i);
+      for (j = 0; j < lineItem.length; j += 1, posIdx3 += 3) {
+        lineItemData = lineItem[j];
+        /* swap entries in vert so that vert[0] is the first vertex, and
+         * vert[1] will be reused for the second vertex */
+        if (j) {
+          vertTemp = vert[0];
+          vert[0] = vert[1];
+          vert[1] = vertTemp;
         }
-        i += 1;
+        vert[1].pos = posIdx3;
+        vert[1].prev = posIdx3 - (j ? 3 : 0);
+        vert[1].next = posIdx3 + (j + 1 < lineItem.length ? 3 : 0);
+        vert[1].strokeWidth = strkWidthFunc(lineItemData, j, lineItem, i);
+        vert[1].strokeColor = strkColorFunc(lineItemData, j, lineItem, i);
+        vert[1].strokeOpacity = strkOpacityFunc(lineItemData, j, lineItem, i);
+        if (!j) {
+          continue;
+        }
+        for (k = 0; k < order.length; k += 1, dest += 1, dest3 += 3) {
+          v = vert[order[k][0]];
+          posBuf[dest3]     = position[v.pos];
+          posBuf[dest3 + 1] = position[v.pos + 1];
+          posBuf[dest3 + 2] = position[v.pos + 2];
+          prevBuf[dest3]     = position[v.prev];
+          prevBuf[dest3 + 1] = position[v.prev + 1];
+          prevBuf[dest3 + 2] = position[v.prev + 2];
+          nextBuf[dest3]     = position[v.next];
+          nextBuf[dest3 + 1] = position[v.next + 1];
+          nextBuf[dest3 + 2] = position[v.next + 2];
+          offsetBuf[dest] = order[k][1];
+          indicesBuf[dest] = dest;
+          strokeWidthBuf[dest] = v.strokeWidth;
+          strokeColorBuf[dest3]     = v.strokeColor.r;
+          strokeColorBuf[dest3 + 1] = v.strokeColor.g;
+          strokeColorBuf[dest3 + 2] = v.strokeColor.b;
+          strokeOpacityBuf[dest] = v.strokeOpacity;
+        }
       }
     }
 
-    posData.pushBack(buffers.get('pos'));
-    geom.addSource(posData);
-
-    prvPosData.pushBack(buffers.get('prev'));
-    geom.addSource(prvPosData);
-
-    nxtPosData.pushBack(buffers.get('next'));
-    geom.addSource(nxtPosData);
-
-    strkWidthData.pushBack(buffers.get('strokeWidth'));
-    geom.addSource(strkWidthData);
-
-    strkColorData.pushBack(buffers.get('strokeColor'));
-    geom.addSource(strkColorData);
-
-    strkOpacityData.pushBack(buffers.get('strokeOpacity'));
-    geom.addSource(strkOpacityData);
-
-    offPosData.pushBack(buffers.get('offset'));
-    geom.addSource(offPosData);
-
-    triangles.setIndices(buffers.get('indices'));
-    geom.addPrimitive(triangles);
-
-    m_mapper.setGeometryData(geom);
+    geom.sourceByName('pos').setData(buffers.get('pos'));
+    geom.sourceByName('prev').setData(buffers.get('prev'));
+    geom.sourceByName('next').setData(buffers.get('next'));
+    geom.sourceByName('strokeWidth').setData(buffers.get('strokeWidth'));
+    geom.sourceByName('strokeColor').setData(buffers.get('strokeColor'));
+    geom.sourceByName('strokeOpacity').setData(buffers.get('strokeOpacity'));
+    geom.sourceByName('offset').setData(buffers.get('offset'));
+    geom.primitive(0).setIndices(buffers.get('indices'));
+    geom.boundsDirty(true);
+    m_mapper.modified();
+    m_mapper.boundsDirtyTimestamp().modified();
   }
 
   ////////////////////////////////////////////////////////////////////////////
@@ -289,7 +235,7 @@ geo.gl.lineFeature = function (arg) {
    */
   ////////////////////////////////////////////////////////////////////////////
   this.featureVertices = function () {
-    return [[-1, 1], [0, -1], [-1, -1], [-1, 1], [0, 1], [0, -1]];
+    return [[0, 1], [1, -1], [0, -1], [0, 1], [1, 1], [1, -1]];
   };
 
   ////////////////////////////////////////////////////////////////////////////
@@ -322,7 +268,25 @@ geo.gl.lineFeature = function (arg) {
         strkOpacityAttr = vgl.vertexAttribute('strokeOpacity'),
         // Shader uniforms
         mviUnif = new vgl.modelViewUniform('modelViewMatrix'),
-        prjUnif = new vgl.projectionUniform('projectionMatrix');
+        prjUnif = new vgl.projectionUniform('projectionMatrix'),
+        geom = vgl.geometryData(),
+        // Sources
+        posData = vgl.sourceDataP3fv({'name': 'pos'}),
+        prvPosData = vgl.sourceDataAnyfv(
+            3, vgl.vertexAttributeKeysIndexed.Four, {'name': 'prev'}),
+        nxtPosData = vgl.sourceDataAnyfv(
+            3, vgl.vertexAttributeKeysIndexed.Five, {'name': 'next'}),
+        offPosData = vgl.sourceDataAnyfv(
+            1, vgl.vertexAttributeKeysIndexed.Six, {'name': 'offset'}),
+        strkWidthData = vgl.sourceDataAnyfv(
+            1, vgl.vertexAttributeKeysIndexed.One, {'name': 'strokeWidth'}),
+        strkColorData = vgl.sourceDataAnyfv(
+            3, vgl.vertexAttributeKeysIndexed.Two, {'name': 'strokeColor'}),
+        strkOpacityData = vgl.sourceDataAnyfv(
+            1, vgl.vertexAttributeKeysIndexed.Three,
+            {'name': 'strokeOpacity'}),
+        // Primitive indices
+        triangles = vgl.triangles();
 
     m_pixelWidthUnif =  new vgl.floatUniform('pixelWidth',
                           1.0 / m_this.renderer().width());
@@ -351,6 +315,16 @@ geo.gl.lineFeature = function (arg) {
     m_actor = vgl.actor();
     m_actor.setMaterial(m_material);
     m_actor.setMapper(m_mapper);
+
+    geom.addSource(posData);
+    geom.addSource(prvPosData);
+    geom.addSource(nxtPosData);
+    geom.addSource(strkWidthData);
+    geom.addSource(strkColorData);
+    geom.addSource(strkOpacityData);
+    geom.addSource(offPosData);
+    geom.addPrimitive(triangles);
+    m_mapper.setGeometryData(geom);
   };
 
   ////////////////////////////////////////////////////////////////////////////

--- a/src/util/init.js
+++ b/src/util/init.js
@@ -98,6 +98,10 @@
      * Convert a color from hex value or css name to rgb objects
      */
     convertColor: function (color) {
+      if (color.r !== undefined && color.g !== undefined &&
+          color.b !== undefined) {
+        return color;
+      }
       if (typeof color === "string") {
         if (geo.util.cssColors.hasOwnProperty(color)) {
           color = geo.util.cssColors[color];

--- a/testing/test-cases/selenium-tests/glLinesSpeed/include.css
+++ b/testing/test-cases/selenium-tests/glLinesSpeed/include.css
@@ -1,0 +1,3 @@
+body {
+    overflow: hidden;
+}

--- a/testing/test-cases/selenium-tests/glLinesSpeed/include.html
+++ b/testing/test-cases/selenium-tests/glLinesSpeed/include.html
@@ -1,0 +1,1 @@
+<div id='map'></div>

--- a/testing/test-cases/selenium-tests/glLinesSpeed/testGlLinesSpeed.py
+++ b/testing/test-cases/selenium-tests/glLinesSpeed/testGlLinesSpeed.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python
+
+import math
+import os
+import unittest
+
+import selenium_test
+from selenium_test import FirefoxTest, ChromeTest, ThresholdException
+
+
+setUpModule = selenium_test.setUpModule
+tearDownModule = selenium_test.tearDownModule
+
+
+class glLinesSpeedBase(object):
+
+    testCase = ('glLinesSpeed',)
+    testRevision = 1
+
+    def loadPage(self):
+        self.resizeWindow(640, 480)
+        self.loadURL('glLinesSpeed/index.html')
+        self.wait()
+
+    def testGlLinesSpeed(self):
+        self.loadPage()
+
+        testName = 'drawGlLinesSpeed'
+        self.loadTimeTest(testName)
+        self.framerateTest(testName)
+
+    def loadTimeTest(self, testName, revision=None):
+        # Threshold is in milliseconds.  We need the value to be less than the
+        # threshold.
+        el = self.getElement('#loadResults')
+        value = float(el.get_attribute('results'))
+        threshold = float(os.environ.get('LOAD_SPEED_THRESHOLD', '1000'))
+        print 'Average load time %1.0f ms (must be at least %1.0f ms)' % (
+            value, threshold)
+        if value > threshold or math.isnan(value):
+            raise ThresholdException({'value': value, 'threshold': threshold})
+
+    def framerateTest(self, testName, revision=None):
+        # Threshold is in frames-per-second.  We need the value to be greater
+        # than the threshold.
+        el = self.getElement('#framerateResults')
+        value = float(el.get_attribute('results'))  # in milliseconds
+        threshold = float(os.environ.get('FRAMERATE_THRESHOLD', '10'))
+        print 'Average framerate %4.2f fps (must be less than %4.2f fps)' % (
+            value, threshold)
+        if value < threshold or math.isnan(value):
+            raise ThresholdException({'value': value, 'threshold': threshold})
+
+
+class FirefoxOSM(glLinesSpeedBase, FirefoxTest):
+    testCase = glLinesSpeedBase.testCase + ('firefox',)
+
+
+class ChromeOSM(glLinesSpeedBase, ChromeTest):
+    testCase = glLinesSpeedBase.testCase + ('chrome',)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/testing/test-cases/selenium-tests/glPointsSpeed/include.css
+++ b/testing/test-cases/selenium-tests/glPointsSpeed/include.css
@@ -1,0 +1,3 @@
+body {
+    overflow: hidden;
+}

--- a/testing/test-cases/selenium-tests/glPointsSpeed/include.html
+++ b/testing/test-cases/selenium-tests/glPointsSpeed/include.html
@@ -1,0 +1,1 @@
+<div id='map'></div>

--- a/testing/test-cases/selenium-tests/glPointsSpeed/include.js
+++ b/testing/test-cases/selenium-tests/glPointsSpeed/include.js
@@ -1,0 +1,129 @@
+window.startTest = function (done) {
+  'use strict';
+
+  var mapOptions = { center: { y: 40.0, x: -105.0 } };
+
+  var myMap = window.geoTests.createOsmMap(mapOptions);
+
+  var layer = myMap.createLayer('feature');
+  var feature = layer.createFeature('point');
+
+  window.geoTests.loadCitiesData(function (citieslatlon) {
+    var numPoints = 250000,
+        points = [], i, times = [], starttime, stoptime, totaltime = 0,
+        frames = 0, pass = 0, dx = 0, dy = 0, animTimes = [];
+
+    function postLoadTest() {
+      times.sort(function (a, b) { return a - b; });
+      if (times.length > 5) {
+        times = times.slice(1, times.length - 1);
+      }
+      for (i = 0; i < times.length; i += 1) {
+        totaltime += times[i];
+      }
+      totaltime /= times.length;
+      console.log('Load time ' + totaltime + ' ms (average across ' +
+                  times.length + ' loads)');
+      console.log(times);
+      /* Test animation time. */
+      starttime = new Date().getTime();
+      animationFrame();
+      $('#map').append($('<div style="display: none" id="loadResults">')
+        .attr('results', totaltime));
+    }
+
+    function postAnimationTest() {
+      var vpf, opac, i, j, v, fps, frametime;
+
+      console.log('Average framerate ' +
+        (frames * 1000.0 / (stoptime - starttime)));
+
+      vpf = feature.verticesPerFeature();
+      opac = feature.actors()[0].mapper().getSourceBuffer('fillOpacity');
+      for (i = v = 0; i < numPoints; i += 1) {
+        for (j = 0; j < vpf; j += 1, v += 1) {
+          opac[v] = 0.05;
+        }
+      }
+      feature.actors()[0].mapper().updateSourceBuffer('fillOpacity');
+      myMap.draw();
+
+      for (i = animTimes.length - 1; i > 0; i -= 1) {
+        animTimes[i] -= animTimes[i - 1];
+      }
+
+      animTimes = animTimes.slice(1);
+      animTimes.sort(function (a, b) { return a - b; });
+      frametime = animTimes[parseInt(0.99 * animTimes.length)];
+      fps = 1000.0 / frametime;
+      console.log('Usable framerate ' + fps);
+      console.log(animTimes);
+      $('#map').append($('<div style="display: none" id="framerateResults">')
+        .attr('results', fps));
+
+      myMap.onIdle(done);
+    }
+
+    function loadTest() {
+      starttime = new Date().getTime();
+      feature.data(points)
+        .style({
+          fillColor: 'black',
+          fillOpacity: 0.05,
+          stroke: false,
+          radius: 5
+        });
+      myMap.draw();
+      stoptime = new Date().getTime();
+      times.push(stoptime - starttime);
+      if (times.length < 12 && stoptime - starttime < 10000) {
+        window.setTimeout(loadTest, 1);
+      } else {
+        postLoadTest();
+      }
+    }
+
+    function animationFrame() {
+      var vpf, opac, vis, i, j, v;
+
+      vpf = feature.verticesPerFeature();
+      opac = feature.actors()[0].mapper().getSourceBuffer('fillOpacity');
+      for (i = v = 0; i < numPoints; i += 1) {
+        /* show 20% of the points each frame */
+        vis = (i % 5) === (frames % 5) ? 0.1 : 0.0;
+        for (j = 0; j < vpf; j += 1, v += 1) {
+          opac[v] = vis;
+        }
+      }
+      feature.actors()[0].mapper().updateSourceBuffer('fillOpacity');
+      myMap.draw();
+      frames += 1;
+      stoptime = new Date().getTime();
+      animTimes.push(stoptime);
+      if (animTimes.length < 2 || (animTimes.length < 201 &&
+          stoptime - animTimes[0] < 10000)) {
+        window.setTimeout(animationFrame, 1);
+      } else {
+        postAnimationTest();
+      }
+    }
+
+    /* Duplicate the data, offsetting the additional points */
+    while (points.length < numPoints) {
+      for (i = 0; i < citieslatlon.length && points.length < numPoints;
+           i += 1) {
+        points.push({
+          x: citieslatlon[i].lon + dx,
+          y: citieslatlon[i].lat + dy,
+          z: citieslatlon[i].elev
+        });
+      }
+      pass += 1;
+      dx = Math.cos(pass) * 0.2;
+      dy = Math.sin(pass) * 0.2;
+    }
+
+    loadTest();
+
+  });
+};

--- a/testing/test-cases/selenium-tests/glPointsSpeed/testGlPointsSpeed.py
+++ b/testing/test-cases/selenium-tests/glPointsSpeed/testGlPointsSpeed.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python
+
+import math
+import os
+import unittest
+
+import selenium_test
+from selenium_test import FirefoxTest, ChromeTest, ThresholdException
+
+
+setUpModule = selenium_test.setUpModule
+tearDownModule = selenium_test.tearDownModule
+
+
+class glPointsSpeedBase(object):
+
+    testCase = ('glPointsSpeed',)
+    testRevision = 1
+
+    def loadPage(self):
+        self.resizeWindow(640, 480)
+        self.loadURL('glPointsSpeed/index.html')
+        self.wait()
+
+    def testGlPointsSpeed(self):
+        self.loadPage()
+
+        testName = 'drawGlPointsSpeed'
+        self.loadTimeTest(testName)
+        self.framerateTest(testName)
+
+    def loadTimeTest(self, testName, revision=None):
+        # Threshold is in milliseconds.  We need the value to be less than the
+        # threshold.
+        el = self.getElement('#loadResults')
+        value = float(el.get_attribute('results'))
+        threshold = float(os.environ.get('LOAD_SPEED_THRESHOLD', '1000'))
+        print 'Average load time %1.0f ms (must be at least %1.0f ms)' % (
+            value, threshold)
+        if value > threshold or math.isnan(value):
+            raise ThresholdException({'value': value, 'threshold': threshold})
+
+    def framerateTest(self, testName, revision=None):
+        # Threshold is in frames-per-second.  We need the value to be greater
+        # than the threshold.
+        el = self.getElement('#framerateResults')
+        value = float(el.get_attribute('results'))  # in milliseconds
+        threshold = float(os.environ.get('FRAMERATE_THRESHOLD', '10'))
+        print 'Average framerate %4.2f fps (must be less than %4.2f fps)' % (
+            value, threshold)
+        if value < threshold or math.isnan(value):
+            raise ThresholdException({'value': value, 'threshold': threshold})
+
+
+class FirefoxOSM(glPointsSpeedBase, FirefoxTest):
+    testCase = glPointsSpeedBase.testCase + ('firefox',)
+
+
+class ChromeOSM(glPointsSpeedBase, ChromeTest):
+    testCase = glPointsSpeedBase.testCase + ('chrome',)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/testing/test-runners/selenium_test.py.in
+++ b/testing/test-runners/selenium_test.py.in
@@ -92,6 +92,32 @@ class ImageDifferenceException(BaseException):
         return '\n'.join(s)
 
 
+class ThresholdException(BaseException):
+    '''
+    Exception to be raised when a test doesn't meet a threshold value.
+    '''
+    def __init__(self, **kw):
+        self.stats = kw
+        s = 'Value %f doesn\'t meet threshold.' % kw.get('value', float('inf'))
+        super(ThresholdException, self).__init__(s)
+
+    def __str__(self):
+        s = [BaseException.__str__(self)]
+        if 'threshold' in self.stats:
+            s.append(
+                '<ThresholdValue value="' +
+                self.stats['threshold'] +
+                '</ThresholdValue>'
+            )
+        if 'value' in self.stats:
+            s.append(
+                '<ActualValue value="' +
+                self.stats['value'] +
+                '</ActualValue>'
+            )
+        return '\n'.join(s)
+
+
 def _chromeOptions():
     opts = webdriver.ChromeOptions()
     opts.add_argument('--test-type')
@@ -101,7 +127,19 @@ def _chromeOptions():
 
 drivers = {
     'firefox': (webdriver.Firefox, {}),
+    'firefoxRemote': (webdriver.Remote, {
+        'command_executor': 'http://%s:%d/wd/hub' % (SELENIUM_HOST,
+                                                     SELENIUM_PORT),
+        'desired_capabilities': webdriver.common.desired_capabilities.
+            DesiredCapabilities.FIREFOX
+    }),
     'chrome': (webdriver.Chrome, _chromeOptions()),
+    'chromeRemote': (webdriver.Remote, {
+        'command_executor': 'http://%s:%d/wd/hub' % (SELENIUM_HOST,
+                                                     SELENIUM_PORT),
+        'desired_capabilities': webdriver.common.desired_capabilities.
+            DesiredCapabilities.CHROME
+    }),
     'opera': (webdriver.Opera, {}),
     'phantomjs': (webdriver.PhantomJS, {}),
     'safari': (webdriver.Safari, {}),
@@ -192,6 +230,8 @@ class BaseTest(TestCase):
 
     #: The root URL of the test webserver.
     testBaseURL = 'http://' + testHost + ':' + str(testPort)
+    if testHost == '0.0.0.0':
+        testBaseURL = 'http://127.0.0.1:' + str(testPort)
 
     #: A tuple giving the selenium test root relative to both
     #: :py:attr:`testBaseURL` and :py:attr:`deploy_path`.
@@ -715,6 +755,8 @@ class FirefoxTest(BaseTest):
     turn off all tests derived from here.
     '''
     driverName = 'firefox'
+    if SELENIUM_HOST not in ('localhost', '127.0.0.1'):
+        driverName = 'firefoxRemote'
 
 
 @unittest.skipIf(
@@ -731,6 +773,8 @@ class ChromeTest(BaseTest):
     enable them.
     '''
     driverName = 'chrome'
+    if SELENIUM_HOST not in ('localhost', '127.0.0.1'):
+        driverName = 'chromeRemote'
 
 
 def setUpModule():


### PR DESCRIPTION
We create arrays using the vgl.DataBuffers.  Except for positions, which need to be transformed, load this data buffers directly.  Prior to this, the data was loaded into javascript arrays, and then that was copied to the data buffers.

Fill buffers much more efficiently by doing it directly instead of calling buffers.write and buffers.repeat

Move code from createGLPoints to _init and from createGLLines to _init.  Don't do things more than once if they can be done just once.

The point vertexShader wasn't explicitly asking for highp floats.

Added an early-exit clause to convertColor to speed up handling colors that are already in the preferred format.

Update the reference to vgl.

I will add speed test for this in geojs in another PR.

This vastly speeds up my tests in the geoapp taxi application:

Test | Loading 1,000,000 Points | Loading 1,000,000 Lines
---|---|---
Before changes | 5.7s average | 27.6s average
After changes | 0.8s average | 4.0s average