### PR TITLE
Changes to the selenium test runners

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ script:
     - git submodule update
     - npm install
     - grunt default docs
+    - grunt serve-test &
     - mkdir _build
     - cd _build
     - cmake ..

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ node_js:
 
 before_install:
   - pushd "${HOME}"
-  - curl "http://www.cmake.org/files/v3.2/cmake-3.2.0-rc2-Linux-x86_64.tar.gz" | gunzip -c | tar x
+  - curl "http://www.cmake.org/files/v3.2/cmake-3.2.1-Linux-x86_64.tar.gz" | gunzip -c | tar x
   - cd cmake-*/bin && export PATH="${PWD}:${PATH}"
   - popd
   - cmake --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ script:
     - npm install
     - grunt default docs
     - grunt serve-test &
+    - sleep 1
     - mkdir _build
     - cd _build
     - cmake ..

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,8 +32,6 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 # set the path where grunt builds the sources
 set(GEOJS_DEPLOY_DIR "${CMAKE_CURRENT_SOURCE_DIR}/dist")
 
-
-# add a test with a resource lock for the web server
 function(add_geojs_test test_name)
   add_test(
     NAME "${test_name}"
@@ -42,7 +40,6 @@ function(add_geojs_test test_name)
             ${CMAKE_CURRENT_BINARY_DIR}/test/geojs_test_runner.py
             ${ARGN}
   )
-  set_property(TEST "${test_name}" APPEND PROPERTY RESOURCE_LOCK webserver)
   if (COVERAGE_TESTS)
     set_property(TEST "${test_name}" APPEND PROPERTY DEPENDS "coverage-reset")
     set_property(TEST "coverage-report" APPEND PROPERTY DEPENDS "${test_name}")
@@ -229,7 +226,6 @@ if(SELENIUM_TESTS)
         WORKING_DIRECTORY "${GEOJS_DEPLOY_DIR}"
         COMMAND ${PYTHON_EXECUTABLE} -m unittest discover -v -s "${dir}"
       )
-      set_property(TEST "selenium:${f}" APPEND PROPERTY RESOURCE_LOCK webserver)
 
       if (COVERAGE_TESTS)
         set_property(TEST "selenium:${f}" APPEND PROPERTY DEPENDS "coverage-reset")
@@ -242,10 +238,10 @@ if(SELENIUM_TESTS)
   endforeach()
 
   set_property(TEST "selenium:glPointsSpeed" APPEND PROPERTY ENVIRONMENT "LOAD_SPEED_THRESHOLD=1000")
-  set_property(TEST "selenium:glPointsSpeed" APPEND PROPERTY ENVIRONMENT "FRAMERATE_THRESHOLD=10")
+  set_property(TEST "selenium:glPointsSpeed" APPEND PROPERTY ENVIRONMENT "FRAMERATE_THRESHOLD=5")
   
   set_property(TEST "selenium:glLinesSpeed" APPEND PROPERTY ENVIRONMENT "LOAD_SPEED_THRESHOLD=1000")
-  set_property(TEST "selenium:glLinesSpeed" APPEND PROPERTY ENVIRONMENT "FRAMERATE_THRESHOLD=10")
+  set_property(TEST "selenium:glLinesSpeed" APPEND PROPERTY ENVIRONMENT "FRAMERATE_THRESHOLD=2")
 
   set(jasmine_runner ${CMAKE_CURRENT_BINARY_DIR}/test/selenium_jasmine_runner.py)
   set(JASMINE_DEPLOY_URL /test/jasmine)
@@ -282,7 +278,6 @@ if(SELENIUM_TESTS)
       NAME "selenium:jasmine:${base}"
       COMMAND ${PYTHON_EXECUTABLE} ${jasmine_runner} ${base}
     )
-    set_property(TEST "selenium:jasmine:${base}" APPEND PROPERTY RESOURCE_LOCK webserver)
     if(COVERAGE_TESTS)
       set_property(TEST "selenium:jasmine:${base}" APPEND PROPERTY DEPENDS "coverage-reset")
       set_property(TEST "coverage-report" APPEND PROPERTY DEPENDS "selenium:jasmine:${base}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,10 +22,11 @@ set(COVERAGE_TESTS OFF CACHE BOOL "Generate coverage reports.")
 set(SELENIUM_TESTS OFF CACHE BOOL "Generate selenium unit tests.")
 
 find_package(PythonInterp REQUIRED)
+site_name(HOSTNAME)
 
-set(TESTING_HOST localhost CACHE STRING "The host to connect to for unit tests")
-mark_as_advanced(TESTING_HOST)
+set(TESTING_HOST "${HOSTNAME}" CACHE STRING "The host to connect to for unit tests")
 set(TESTING_PORT 50100 CACHE STRING "The port number to use for the testing web server")
+mark_as_advanced(TESTING_PORT)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -431,9 +431,30 @@ module.exports = function (grunt) {
   ]);
 
   grunt.registerTask(
-      'serve',
-      'Serve the content at http://localhost:8082, ' +
-      'use the --port option to override the default port',
-      ['express', 'watch']
+    'serve',
+    'Serve the content at http://localhost:8082, ' +
+    'use the --port option to override the default port',
+    ['express', 'watch']
+  );
+
+  grunt.registerTask(
+    'serve-test',
+    'Serve the content for testing.  This starts on port 50100 by ' +
+    'default and does not rebuild sources automatically.',
+    function () {
+      grunt.config.set('express.server.options.hostname', '0.0.0.0');
+      if (!grunt.option('port')) {
+        grunt.config.set('express.server.options.port', 50100);
+      }
+      // make sure express doesn't change the port
+      var test_port = grunt.config.get('express.server.options.port');
+      grunt.event.on('express:server:started', function () {
+        if (grunt.config.get('express.server.options.port') !== test_port) {
+          grunt.fail.fatal('Port ' + test_port + ' unavailable.');
+        }
+      });
+
+      grunt.task.run(['express', 'express-keepalive']);
+    }
   );
 };

--- a/docs/developers.rst
+++ b/docs/developers.rst
@@ -2,6 +2,22 @@
 Developer's guide
 =================
 
+The testing infrastructure of Geojs is run via CTest, it assumes
+that the testing "server" is started prior to execution.  To start the
+server, just run ::
+
+    grunt serve-test
+
+This will start a server on the default port of ``50100``.  The port
+and selenium host names are configurable with cmake.  For example inside
+the Kitware firewall, you can run the following to test on the selenium
+node on ``garant`` ::
+
+    cmake -DSELENIUM_TESTS=ON -DCHROME_TESTS=ON -DSELENIUM_HOST=garant ..
+
+You may need to also set the variable ``TESTING_HOST`` to your computer's
+IP address reachable by the selenium node.
+
 Geojs employs several different frameworks for unit testing.  These
 frameworks have been designed to make it easy for developers to
 add more tests as new features are added to the api.
@@ -35,7 +51,7 @@ test runner, which sets it's return status to ``0`` if (and only if)
 all tests passed.  You can run these tests manually in the browser by
 starting up a test server ::
 
-    python test/geojs_test_runner.py
+    grunt serve-test
 
 and navigating to `<http://localhost:50100/test/phantomjs>`_ in your
 browser.

--- a/testing/test-runners/geojs_test_runner.py.in
+++ b/testing/test-runners/geojs_test_runner.py.in
@@ -26,76 +26,14 @@ PORT = @TESTING_PORT@
 server = None
 
 
-class Handler(BlanketHandler, HTTPHandler):
-
-    def __init__(self, *arg, **kw):
-        os.chdir(DEPLOY_PATH)
-        HTTPHandler.__init__(self, *arg, **kw)
-
-    def log_message(self, *arg, **kw):
-        pass
-
-    def do_GET(self):
-        if self.path == '/coverage':
-            BlanketHandler.do_GET(self)
-        else:
-            HTTPHandler.do_GET(self)
-
-    def do_PUT(self):
-        if self.path == '/coverage':
-            BlanketHandler.do_PUT(self)
-        else:
-            HTTPHandler.do_PUT(self)
-
-
-class _Server(SocketServer.ThreadingMixIn, SocketServer.TCPServer):
-    allow_reuse_address = True
-
-
-class TestServer(object):
-
-    @classmethod
-    def start(cls, host='localhost', port='8000', block=False):
-        print('Starting test server at: http://%s:%s' % (host, port))
-        cls.server = _Server(
-            (host, port),
-            Handler
-        )
-        if block:
-            cls.server.serve_forever()
-        else:
-            cls.server_thread = threading.Thread(
-                target=cls.server.serve_forever
-            )
-            cls.server_thread.start()
-
-            time.sleep(0.5)
-
-    @classmethod
-    def stop(cls):
-        print('Stopping test server')
-        cls.server.shutdown()
-        cls.server_thread.join(1)
-
-
 def main():
     status = 0
-
-    block = not len(sys.argv[1:])
-    testServer = TestServer()
-
-    try:
-        testServer.start(HOST, PORT, block)
-    except KeyboardInterrupt:
-        print('Stopping test server')
-        sys.exit(0)
-
     if len(sys.argv[1:]):
         status = 1
         try:
             status = subprocess.call(sys.argv[1:])
-        finally:
-            testServer.stop()
+        except Exception:
+            pass
 
     return status
 

--- a/testing/test-runners/selenium_test.py.in
+++ b/testing/test-runners/selenium_test.py.in
@@ -30,7 +30,6 @@ from selenium.webdriver.support.wait import WebDriverWait
 from selenium.webdriver.common.action_chains import ActionChains
 from PIL import Image, ImageStat, ImageChops
 
-from geojs_test_runner import TestServer
 from midas_handler import MidasHandler
 
 # to be set by cmake:
@@ -291,17 +290,16 @@ class BaseTest(TestCase):
     @classmethod
     def startServer(cls):
         '''
-        Start a local web server.
+        Start a local web server. (depreciated)
         '''
-        cls.server = TestServer()
-        cls.server.start(cls.testHost, cls.testPort)
+        pass
 
     @classmethod
     def stopServer(cls):
         '''
-        Stop the local webserver.
+        Stop the local webserver. (depreciated)
         '''
-        cls.server.stop()
+        pass
 
     def setUp(self):
         '''


### PR DESCRIPTION
This is a small change to the selenium testing that does the following:
  1. Requires starting the test server manually, but allows running the tests in parallel
  2. Fixes running tests on a remote selenium node.
  3. Adds an example in the documentation of running on the selenium node I'm hosting for geojs testing within Kitware