### PR TITLE
Expose a method to set map extent

### DIFF
--- a/src/core/map.js
+++ b/src/core/map.js
@@ -859,23 +859,71 @@ geo.map = function (arg) {
 
   ////////////////////////////////////////////////////////////////////////////
   /**
-   * Get the locations of the current map corners as latitudes/longitudes.
-   * The return value of this function is an object as follows: ::
+   * Get/set the locations of the current map corners as latitudes/longitudes.
+   * When provided the argument should be an object containing the keys
+   * lowerLeft and upperRight declaring the desired new map bounds.  The
+   * new bounds will contain at least the min/max lat/lngs provided.  In any
+   * case, the actual new bounds will be returned by this function.
    *
-   *    {
-   *        lowerLeft: {x: ..., y: ...},
-   *        upperLeft: {x: ..., y: ...},
-   *        lowerRight: {x: ..., y: ...},
-   *        upperRight: {x: ..., y: ...}
-   *    }
-   *
-   * @todo Provide a setter
+   * @param {geo.geoBounds} [bds] The requested map bounds
+   * @return {geo.geoBounds} The actual new map bounds
    */
   ////////////////////////////////////////////////////////////////////////////
-  this.bounds = function () {
+  this.bounds = function (bds) {
+    var nav;
+
+    if (bds === undefined) {
+      return m_bounds;
+    }
+
+    nav = m_this.zoomAndCenterFromBounds(bds);
+    m_this.zoom(nav.zoom);
+    m_this.center(nav.center);
     return m_bounds;
   };
 
+  ////////////////////////////////////////////////////////////////////////////
+  /**
+   * Get the center zoom level necessary to display the given lat/lon bounds.
+   *
+   * @param {geo.geoBounds} [bds] The requested map bounds
+   * @return {object} Object containing keys "center" and "zoom"
+   */
+  ////////////////////////////////////////////////////////////////////////////
+  this.zoomAndCenterFromBounds = function (bds) {
+    var ll, ur, dx, dy, zx, zy, center;
+
+    // Caveat:
+    // Much of the following is invalid for alternative map projections.  These
+    // computations should really be defered to the base layer, but there is
+    // no clear path for doing that with the current base layer api.
+
+    // extract bounds info and check for validity
+    ll = geo.util.normalizeCoordinates(bds.lowerLeft || {});
+    ur = geo.util.normalizeCoordinates(bds.upperRight || {});
+
+    if (ll.x >= ur.x || ll.y >= ur.y) {
+      throw new Error("Invalid bounds provided");
+    }
+
+    center = {
+      x: (ll.x + ur.x) / 2,
+      y: (ll.y + ur.y) / 2
+    };
+
+    // calculate the current extend
+    dx = m_bounds.upperRight.x - m_bounds.lowerLeft.x;
+    dy = m_bounds.upperRight.y - m_bounds.lowerLeft.y;
+
+    // calculate the zoom levels necessary to fit x and y bounds
+    zx = m_zoom - Math.log2((ur.x - ll.x) / dx);
+    zy = m_zoom - Math.log2((ur.y - ll.y) / dy);
+
+    return {
+      zoom: Math.min(zx, zy),
+      center: center
+    };
+  };
 
   this.interactor(arg.interactor || geo.mapInteractor());
   this.clock(arg.clock || geo.clock());

--- a/testing/test-cases/selenium-tests/mapBounds/include.css
+++ b/testing/test-cases/selenium-tests/mapBounds/include.css
@@ -1,0 +1,3 @@
+body {
+    overflow: hidden;
+}

--- a/testing/test-cases/selenium-tests/mapBounds/include.html
+++ b/testing/test-cases/selenium-tests/mapBounds/include.html
@@ -1,0 +1,1 @@
+<div id='map'></div>

--- a/testing/test-cases/selenium-tests/mapBounds/include.js
+++ b/testing/test-cases/selenium-tests/mapBounds/include.js
@@ -1,0 +1,12 @@
+window.startTest = function (done) {
+  'use strict';
+
+  var options = { center: { x: -85, y: 30 }, zoom: 1 };
+  var myMap = window.geoTests.createOsmMap(options).draw();
+
+  window.setTimeout(function () {
+    myMap.bounds({lowerLeft: {x: 111, y: -40}, upperRight: {x: 154, y: -5}});
+    myMap.onIdle(done);
+  }, 250);
+
+};

--- a/testing/test-cases/selenium-tests/mapBounds/testMapBounds.py
+++ b/testing/test-cases/selenium-tests/mapBounds/testMapBounds.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python
+
+from selenium_test import FirefoxTest, ChromeTest,\
+    setUpModule, tearDownModule
+
+
+class Base(object):
+    testCase = ('mapBounds',)
+    testRevision = 1
+
+    def loadPage(self):
+        self.resizeWindow(1024, 600)
+        self.loadURL('mapBounds/index.html')
+        self.wait()
+
+    def test_set_bounds(self):
+        testName = 'set_new_bounds'
+        self.loadPage()
+        self.screenshotTest(testName)
+
+
+class FirefoxTestCls(Base, FirefoxTest):
+    testCase = Base.testCase + ('firefox',)
+
+
+class ChromeTestCls(Base, ChromeTest):
+    testCase = Base.testCase + ('chrome',)
+
+
+if __name__ == '__main__':
+    import unittest
+    unittest.main()


### PR DESCRIPTION
It is only an approximation for now.  To compute the extents exactly, we will need to do some refactoring of the base layer/base renderer api.  Two new methods supported:

```javascript
// go directly to the new extent
map.bounds({
  lowerLeft: {x: 10, y: 10},
  upperRight: {x: 20, y: 20}
});
```
or
```javascript
// compute the new center and zoom for given bounds
var nav = map.zoomAndCenterFromBounds({
  lowerLeft: {x: 10, y: 10},
  upperRight: {x: 20, y: 20}
});

// this allows animated transitions
nav.interp = d3.interpolateZoom
map.transition(nav);
```

You can try it [here](http://jsbin.com/zoticu/3/edit).