### PR TITLE
Only calculate the range tree as needed.

### DIFF
--- a/src/core/pointFeature.js
+++ b/src/core/pointFeature.js
@@ -23,8 +23,8 @@ geo.pointFeature = function (arg) {
   var m_this = this,
       s_init = this._init,
       m_rangeTree = null,
+      m_rangeTreeTime = geo.timestamp(),
       s_data = this.data,
-      s_style = this.style,
       m_maxRadius = 0;
 
   ////////////////////////////////////////////////////////////////////////////
@@ -52,6 +52,9 @@ geo.pointFeature = function (arg) {
    */
   ////////////////////////////////////////////////////////////////////////////
   this._updateRangeTree = function () {
+    if (m_rangeTreeTime.getMTime() >= m_this.dataTime().getMTime()) {
+      return;
+    }
     var pts, position,
         radius = m_this.style.get("radius"),
         stroke = m_this.style.get("stroke"),
@@ -76,6 +79,7 @@ geo.pointFeature = function (arg) {
     });
 
     m_rangeTree = new geo.util.RangeTree(pts);
+    m_rangeTreeTime.modified();
   };
 
   ////////////////////////////////////////////////////////////////////////////
@@ -121,6 +125,7 @@ geo.pointFeature = function (arg) {
 
     // Find points inside the bounding box
     box = new geo.util.Box(geo.util.vect(min.x, min.y), geo.util.vect(max.x, max.y));
+    m_this._updateRangeTree();
     m_rangeTree.search(box).forEach(function (q) {
       idx.push(q.idx);
     });
@@ -182,20 +187,6 @@ geo.pointFeature = function (arg) {
     s_data(data);
     return m_this;
   };
-
-  ////////////////////////////////////////////////////////////////////////////
-  /**
-   * Overloaded style method that updates the internal range tree on write.
-   */
-  ////////////////////////////////////////////////////////////////////////////
-  this.style = function (arg1, arg2) {
-    var val = s_style(arg1, arg2);
-    if (val === m_this && m_this.selectionAPI()) {
-      m_this._updateRangeTree();
-    }
-    return val;
-  };
-  this.style.get = s_style.get;
 
   ////////////////////////////////////////////////////////////////////////////
   /**


### PR DESCRIPTION
The range tree was being prepared ahead of time coupled to the style call.  This would often (always?) calculate the range tree multiple times even when the data had not changed.  Since calculating the range tree is expensive (multiple seconds for a few hundred thousand points), this is undesirable.

Now, the range tree has a date stamp, and is only calculated when needed and stale.

Also, refactored the RangeNode so that it does lazy memory allocation and sorting.  This speeds up the initial construction substantially, plus uses less memory in all but a few degenerate cases.

For reference, I was seeing _updateRangeTree called 2 or 3 times when constructing an initial point set.  For 250,000 points this took roughly 5 seconds per call.  Now, it is only called once (and possibly not even then, if the mouse never tracks across the map), and the initial call takes 300 ms.  Of this 300 ms, roughly 60% of the time is in sorting the points along the x coordinate and 40% is in constructing the RangeNodes.  It now feels responsive on a 250,000 point set.

Lastly, I noticed the vgl reference was for the pull request.  I've updated it to the current master sha (there is no change, but now you can browse the master branch without it appearing as a difference to git).