### PR TITLE
Use the standard wheelevent

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -213,7 +213,6 @@ module.exports = function (grunt) {
         files: {
           'dist/built/geo.ext.min.js': [
             'bower_components/jquery/dist/jquery.js',
-            'bower_components/jquery-mousewheel/jquery.mousewheel.js',
             'bower_components/gl-matrix/dist/gl-matrix.js',
             'bower_components/proj4/dist/proj4-src.js',
             'bower_components/d3/d3.js',

--- a/bower.json
+++ b/bower.json
@@ -15,7 +15,6 @@
     "d3": "~3.3",
     "gl-matrix": "~2.1",
     "jquery": "~2.1",
-    "jquery-mousewheel": "^3.1.12",
     "proj4": "~2.2",
     "bootstrap": "~3.3.0",
     "bootswatch": "~3.3"

--- a/docs/users.rst
+++ b/docs/users.rst
@@ -31,8 +31,6 @@ list of libraries used by GeoJS.
     +---------------------------+------------+---------------------------+
     | `pnltri`_                 | 2.1        | GL renderer               |
     +---------------------------+------------+---------------------------+
-    | `jQuery mousewheel`_      | 3.1        | Mouse interactor          |
-    +---------------------------+------------+---------------------------+
     | `d3`_                     | 3.3        | D3 renderer, UI widgets   |
     +---------------------------+------------+---------------------------+
 
@@ -45,7 +43,6 @@ list of libraries used by GeoJS.
 .. _proj4: http://proj4js.org/
 .. _GL matrix: http://glmatrix.net/
 .. _pnltri: https://github.com/jahting/pnltri.js/
-.. _jQuery mousewheel: https://github.com/jquery/jquery-mousewheel/
 .. _d3: http://d3js.org/
 
 

--- a/examples/layerEvents/main.js
+++ b/examples/layerEvents/main.js
@@ -97,7 +97,7 @@ $(function () {
   // Add a blue box that blocks the mouse wheel.
   addEventBox(3 * width / 4, height / 2, 'Blocking wheel')
     .style('fill', 'steelblue')
-    .on('mousewheel', function () {
+    .on('wheel', function () {
       d3.event.stopPropagation();
     });
 

--- a/testing/test-cases/phantomjs-tests/mapInteractor.js
+++ b/testing/test-cases/phantomjs-tests/mapInteractor.js
@@ -197,15 +197,16 @@ describe('mapInteractor', function () {
 
     // trigger a zoom
     interactor.simulateEvent(
-      'mousewheel',
+      'wheel',
       {
         wheelDelta: {x: 20, y: -10},
+        wheelMode: 0
       }
     );
 
     // check the zoom event was called
     expect(map.info.zoom).toBe(1);
-    expect(map.info.zoomArgs).toBe(2 - 10 / 120);
+    expect(map.info.zoomArgs).toBe(2 + 10 / 120);
   });
 
   it('Test zoom right click event propagation', function () {


### PR DESCRIPTION
It looks like the [WheelEvent](https://developer.mozilla.org/en-US/docs/Web/API/WheelEvent) is now supported uniformly across all major browsers now.  As a result, this PR removes jquery-mousewheel in favor of the standard interface.  Fixes #364.

This will also serve as the first real world test of the new buildbot integration.  :pray: