### PR TITLE
Gruntfile improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,8 @@ script:
     - git submodule init
     - git submodule update
     - npm install
-    - grunt default docs
-    - grunt serve-test &
+    - ./node_modules/.bin/grunt default docs
+    - ./node_modules/.bin/grunt serve-test &
     - sleep 1
     - mkdir _build
     - cd _build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -308,7 +308,11 @@ if(${JS_HINT_TESTS})
     WORKING_DIRECTORY "${GEOJS_DEPLOY_DIR}"
     COMMAND "${JSHINT_EXECUTABLE}" "--exclude" "src/vgl" "src"
   )
-
+  add_test(
+    NAME "jshint-gruntfile"
+    WORKING_DIRECTORY "${GEOJS_DEPLOY_DIR}"
+    COMMAND "${JSHINT_EXECUTABLE}" "Gruntfile.js"
+  )
 endif() # JS_HINT_TESTS
 
 if(${JSCS_TESTS})
@@ -322,6 +326,11 @@ if(${JSCS_TESTS})
     NAME "jscs"
     WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
     COMMAND "${JSCS_EXECUTABLE}" "src"
+  )
+  add_test(
+    NAME "jscs-gruntfile"
+    WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+    COMMAND "${JSCS_EXECUTABLE}" "Gruntfile.js"
   )
 
 endif() # JSCS_TESTS

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,4 +1,4 @@
-/* global module, require */
+/* global module, require, process */
 
 module.exports = function (grunt) {
   'use strict';
@@ -56,6 +56,8 @@ module.exports = function (grunt) {
   };
 
   grunt.config.init({
+    env: grunt.option('env') || process.env.GRUNT_ENV || 'development',
+
     pkg: pkg,
 
     template: {
@@ -297,6 +299,13 @@ module.exports = function (grunt) {
       var dir = path.dirname(ex);
       var exname = path.basename(dir);
       var data = grunt.file.readJSON(ex);
+
+      // Use geo.js unless using the production environment.
+      var geolib = '../../built/geo.js';
+      if (grunt.config('env') === 'production') {
+        geolib = '../../built/geo.min.js';
+      }
+
       if (data.exampleJs.length) {
         data.docHTML = path.join(
           'doc',
@@ -321,7 +330,7 @@ module.exports = function (grunt) {
             ];
             data.defaultJs = [
               '../../built/geo.ext.min.js',
-              '../../built/geo.min.js',
+              geolib,
               '../common/js/bootstrap.min.js',
               '../common/js/examples.js'
             ];

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -3,6 +3,14 @@
 module.exports = function (grunt) {
   'use strict';
 
+  /* first check that vgl is checked out */
+  if (!grunt.file.exists('vgl/package.json')) {
+    grunt.fail.fatal(
+      'The vgl submodule not checked out.\n'  +
+      'Please run "git submodule update --init" first.'
+    );
+  }
+
   var sources, geojsVersion, vgl, geo, port, sourceList, templateData, pkg;
 
   pkg = grunt.file.readJSON('package.json');

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -259,8 +259,8 @@ module.exports = function (grunt) {
     },
 
     clean: {
-      source: [ 'dist/src', 'src/core/version.js' ],
-      all: [ 'dist', 'src/core/version.js' ]
+      source: ['dist/src', 'src/core/version.js'],
+      all: ['dist', 'src/core/version.js']
     },
 
     express: {
@@ -274,7 +274,7 @@ module.exports = function (grunt) {
 
     jade: {
       options: {
-        pretty: true,
+        pretty: true
       }
     }
   });


### PR DESCRIPTION
This make a few improvements to the gruntfile for building.
1. Tests the file with `jscs` and `jshint`
2. Reports an error when trying to build when `vgl` is not checked out.
3. Adds an option (`--env=production|development`) to switch between minified or concatenated source for the examples.