### PR TITLE
Fixing jshint tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -305,12 +305,12 @@ if(${JS_HINT_TESTS})
   )
   add_test(
     NAME "jshint"
-    WORKING_DIRECTORY "${GEOJS_DEPLOY_DIR}"
+    WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
     COMMAND "${JSHINT_EXECUTABLE}" "--exclude" "src/vgl" "src"
   )
   add_test(
     NAME "jshint-gruntfile"
-    WORKING_DIRECTORY "${GEOJS_DEPLOY_DIR}"
+    WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
     COMMAND "${JSHINT_EXECUTABLE}" "Gruntfile.js"
   )
 endif() # JS_HINT_TESTS

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -306,7 +306,7 @@ if(${JS_HINT_TESTS})
   add_test(
     NAME "jshint"
     WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
-    COMMAND "${JSHINT_EXECUTABLE}" "--exclude" "src/vgl" "src"
+    COMMAND "${JSHINT_EXECUTABLE}" "src"
   )
   add_test(
     NAME "jshint-gruntfile"


### PR DESCRIPTION
Changed to use the correct path to js source files in jshint tests.  The main source files were being tested before because they are copied over to `/dist` for the unit tests, but the `Gruntfile.js` test was not running because jshint returns status `0` for a missing file.  :angry: 