### PR TITLE
Add a wrapLongitude option to the contourFeature.

### DIFF
--- a/src/core/contourFeature.js
+++ b/src/core/contourFeature.js
@@ -238,7 +238,7 @@ geo.contourFeature = function (arg) {
       if (skipColumn === undefined) {
         val = parseFloat(valueFunc(data[i]));
       } else {
-        j = parseInt(Math.floor(i / gridW));
+        j = Math.floor(i / gridW);
         origI = i - j * gridW;
         origI += (origI > skipColumn ? -2 : 0);
         if (origI >= gridWorig) {
@@ -412,10 +412,10 @@ layer.createFeature('contour', {
     in the value array>,
   wrapLongitude: <boolean (default true).  If true, AND the position array is
     not used, assume the x coordinates is longitude and should be adjusted to
-    be within -180 to 180.  If the data spans 180 dgrees, the points or squares
-    will be duplicated to ensure that the map is covered from -180 to 180 as
-    appropriate.  Set this to false if using a non longitude x coordinate.
-    This is ignored if the position array is used.>,
+    be within -180 to 180.  If the data spans 180 degrees, the points or
+    squares will be duplicated to ensure that the map is covered from -180 to
+    180 as appropriate.  Set this to false if using a non longitude x
+    coordinate.  This is ignored if the position array is used.>,
   min: <optional minimum contour value, otherwise taken from style.value>,
   max: <optional maximum contour value, otherwise taken from style.value>,
   minColor: <color for any value below the minimum>,

--- a/testing/test-cases/jasmine-tests/contourWrap.js
+++ b/testing/test-cases/jasmine-tests/contourWrap.js
@@ -1,0 +1,81 @@
+/*global describe, it, expect, geo*/
+
+describe('Contour Feature', function () {
+  'use strict';
+
+  var map, width = 800, height = 800, layer;
+
+  // create an osm map layer
+  map = geo.map({
+    'node': '#map',
+    'center': [0, 0],
+    'zoom': 3
+  });
+  map.createLayer('osm', {'tileUrl': function () {
+    return '/data/white.jpg';
+  }});
+  layer = map.createLayer('feature', {'renderer': 'vgl'});
+  map.resize(0, 0, width, height);
+  map.draw();
+
+  it('Create a contour', function () {
+    var contour1 = {
+      gridWidth: 7, gridHeight: 2, x0: -30, y0: -30, dx: 6, dy: 6,
+      values: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]
+    };
+    var contour = layer.createFeature('contour').data(
+        contour1.values).contour(contour1).style({
+        value: function (d) { return d; }});
+    var result = contour.createContours();
+    expect(result.minValue).toBe(0);
+    expect(result.maxValue).toBe(13);
+    expect(result.elements.length).toBe(36); /* 6 sq. * 2 tri. * 3 pts. */
+    expect(result.pos.length).toBe(42); /* 14 distinct points * 3 coor. */
+  });
+
+  it('Create a contour that will wrap and close', function () {
+    var contour1 = {
+      gridWidth: 6, gridHeight: 2, x0: 30, y0: -30, dx: 60, dy: 60,
+      values: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
+    };
+    var contour = layer.createFeature('contour').data(
+        contour1.values).contour(contour1).style({
+        value: function (d) { return d; }});
+    var result = contour.createContours();
+    console.log(contour, result);
+    expect(result.elements.length).toBe(42); /* 5 + 2 sq. * 2 tri. * 3 pts. */
+    expect(result.pos.length).toBe(54); /* 12 + 6 distinct points * 3 coor. */
+    expect(result.pos[48]).toBe(-30);  /* wrapped coordinate */
+    expect(result.pos[51]).toBe(30);  /* wrapped coordinate */
+  });
+
+  it('Create a contour and ask it to not wrap', function () {
+    var contour1 = {
+      gridWidth: 6, gridHeight: 2, x0: 30, y0: -30, dx: 60, dy: 60,
+      values: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11],
+      wrapLongitude: false
+    };
+    var contour = layer.createFeature('contour').data(
+        contour1.values).contour(contour1).style({
+        value: function (d) { return d; }});
+    var result = contour.createContours();
+    expect(result.elements.length).toBe(30); /* 5 sq. * 2 tri. * 3 pts. */
+    expect(result.pos.length).toBe(36); /* 12 distinct points * 3 coor. */
+    expect(result.pos[33]).toBe(330);  /* unwrapped coordinate */
+  });
+
+  it('Create a contour that will wrap but not close', function () {
+    var contour1 = {
+      gridWidth: 6, gridHeight: 2, x0: 55, y0: -25, dx: 50, dy: 50,
+      values: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
+    };
+    var contour = layer.createFeature('contour').data(
+        contour1.values).contour(contour1).style({
+        value: function (d) { return d; }});
+    var result = contour.createContours();
+    expect(result.elements.length).toBe(36); /* 5 + 1 sq. * 2 tri. * 3 pts. */
+    expect(result.pos.length).toBe(48); /* 12 + 4 distinct points * 3 coor. */
+    expect(result.pos[45]).toBe(-55);  /* wrapped coordinate */
+  });
+
+});


### PR DESCRIPTION
I am defaulting this to true, such that if stride positioning is used (x0, y0, dx, dy), if the data spans 180 degrees (plus or minus), it will be wrapped around so that part of the contour is at negative longitude and part is at positive longitude.  If the grid appears to span 360 degrees, join the ends (but only if wrapping was necessary).

In the general case, we might want to check the map coordinate system and only default to true if the x coordinate system is degree based (or even adjust it to the coordinate system so you could use gradians).

Added a jasmine test to make sure wrapping behaves as expected.

This fixes issue #427.