### PR TITLE
Add attribution notice

### DIFF
--- a/src/core/layer.js
+++ b/src/core/layer.js
@@ -2,6 +2,8 @@
 /**
  * @class
  * @extends geo.sceneObject
+ * @param {Object?} arg An options argument
+ * @param {string} arg.attribution An attribution string to display
  * @returns {geo.layer}
  */
 //////////////////////////////////////////////////////////////////////////////
@@ -45,7 +47,8 @@ geo.layer = function (arg) {
       m_updateTime = geo.timestamp(),
       m_drawTime = geo.timestamp(),
       m_sticky = arg.sticky === undefined ? true : arg.sticky,
-      m_active = arg.active === undefined ? true : arg.active;
+      m_active = arg.active === undefined ? true : arg.active,
+      m_attribution = arg.attribution || null;
 
   ////////////////////////////////////////////////////////////////////////////
   /**
@@ -336,6 +339,26 @@ geo.layer = function (arg) {
   this.fromLocal = function (input) {
     return input;
   };
+
+  ////////////////////////////////////////////////////////////////////////////
+  /**
+   * Get or set the attribution html content that will displayed with the
+   * layer.  By default, nothing will be displayed.  Note, this content
+   * is **not** html escaped, so care should be taken when renderering
+   * user provided content.
+   * @param {string?} arg An html fragment
+   * @returns {string|this} Chainable as a setter
+   */
+  ////////////////////////////////////////////////////////////////////////////
+  this.attribution = function (arg) {
+    if (arg !== undefined) {
+      m_attribution = arg;
+      m_this.map().updateAttribution();
+      return m_this;
+    }
+    return m_attribution;
+  };
+
 
   ////////////////////////////////////////////////////////////////////////////
   /**

--- a/src/core/layer.js
+++ b/src/core/layer.js
@@ -373,9 +373,6 @@ geo.layer = function (arg) {
     // Create top level div for the layer
     m_node = $(document.createElement("div"));
     m_node.attr("id", m_name);
-    // TODO: need to position according to offsets from the map element
-    //       and maybe respond to events in case the map element moves
-    //       around the page.
     m_node.css("position", "absolute");
 
     if (m_map) {

--- a/src/core/map.js
+++ b/src/core/map.js
@@ -596,6 +596,7 @@ geo.map = function (arg) {
       throw 'Map require DIV node';
     }
 
+    m_node.css('position', 'relative');
     if (arg !== undefined && arg.layers !== undefined) {
       for (i = 0; i < arg.layers.length; i += 1) {
         if (i === 0) {
@@ -1049,7 +1050,6 @@ geo.map = function (arg) {
         right: '0px',
         bottom: '0px',
         'padding-right': '5px',
-        'padding-left': '5px',
         cursor: 'auto',
         font: '11px/1.5 "Helvetica Neue", Arial, Helvetica, sans-serif',
         'z-index': '1001',
@@ -1067,6 +1067,9 @@ geo.map = function (arg) {
       if (content) {
         $('<span/>')
           .addClass('geo-attribution-layer')
+          .css({
+            'padding-left': '5px',
+          })
           .html(content)
           .appendTo($a);
       }

--- a/src/core/map.js
+++ b/src/core/map.js
@@ -1068,7 +1068,7 @@ geo.map = function (arg) {
         $('<span/>')
           .addClass('geo-attribution-layer')
           .css({
-            'padding-left': '5px',
+            'padding-left': '5px'
           })
           .html(content)
           .appendTo($a);

--- a/src/core/map.js
+++ b/src/core/map.js
@@ -1021,6 +1021,61 @@ geo.map = function (arg) {
     return m_this;
   };
 
+  ////////////////////////////////////////////////////////////////////////////
+  /**
+   * Update the attribution notice displayed on the bottom right corner of
+   * the map.  The content of this notice is managed by individual layers.
+   * This method queries all of the visible layers and joins the individual
+   * attribution notices into a single element.  By default, this method
+   * is called on each of the following events:
+   *
+   *   * geo.event.layerAdd
+   *   * geo.event.layerRemove
+   *
+   * In addition, layers should call this method when their own attribution
+   * notices has changed.  Users, in general, should not need to call this.
+   * @returns {this} Chainable
+   */
+  ////////////////////////////////////////////////////////////////////////////
+  this.updateAttribution = function () {
+    // clear any existing attribution content
+    m_this.node().find('.geo-attribution').remove();
+
+    // generate a new attribution node
+    var $a = $('<div/>')
+      .addClass('geo-attribution')
+      .css({
+        position: 'absolute',
+        right: '0px',
+        bottom: '0px',
+        'padding-right': '5px',
+        'padding-left': '5px',
+        cursor: 'auto',
+        font: '11px/1.5 "Helvetica Neue", Arial, Helvetica, sans-serif',
+        'z-index': '1001',
+        background: 'rgba(255,255,255,0.7)',
+        clear: 'both',
+        display: 'block',
+        'pointer-events': 'auto'
+      }).on('mousedown', function (evt) {
+        evt.stopPropagation();
+      });
+
+    // append content from each layer
+    m_this.children().forEach(function (layer) {
+      var content = layer.attribution();
+      if (content) {
+        $('<span/>')
+          .addClass('geo-attribution-layer')
+          .html(content)
+          .appendTo($a);
+      }
+    });
+
+    $a.appendTo(m_this.node());
+    return m_this;
+  };
+
   this.interactor(arg.interactor || geo.mapInteractor());
   this.clock(arg.clock || geo.clock());
 
@@ -1031,6 +1086,12 @@ geo.map = function (arg) {
   if (arg.autoResize) {
     $(window).resize(resizeSelf);
   }
+
+  // attach attribution updates to layer events
+  m_this.geoOn([
+    geo.event.layerAdd,
+    geo.event.layerRemove
+  ], m_this.updateAttribution);
 
   return this;
 };

--- a/src/core/osmLayer.js
+++ b/src/core/osmLayer.js
@@ -11,10 +11,17 @@
  */
 //////////////////////////////////////////////////////////////////////////////
 geo.osmLayer = function (arg) {
-  "use strict";
+  'use strict';
 
   if (!(this instanceof geo.osmLayer)) {
     return new geo.osmLayer(arg);
+  }
+
+  // set a default attribution if no other is provided
+  arg = arg || {};
+  if (arg && arg.attribution === undefined) {
+    arg.attribution =
+      '&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors';
   }
   geo.featureLayer.call(this, arg);
 
@@ -35,9 +42,9 @@ geo.osmLayer = function (arg) {
     m_pendingInactiveTiles = [],
     m_numberOfCachedTiles = 0,
     m_tileCacheSize = 100,
-    m_baseUrl = "http://tile.openstreetmap.org/",
+    m_baseUrl = 'http://tile.openstreetmap.org/',
     m_mapOpacity = 1.0,
-    m_imageFormat = "png",
+    m_imageFormat = 'png',
     m_updateTimerId = null,
     m_lastVisibleZoom = null,
     m_visibleTilesRange = {},
@@ -48,14 +55,14 @@ geo.osmLayer = function (arg) {
     m_zoom = null,
     m_tileUrl,
     m_tileUrlFromTemplate,
-    m_crossOrigin = "anonymous";
+    m_crossOrigin = 'anonymous';
 
   if (arg && arg.baseUrl !== undefined) {
     m_baseUrl = arg.baseUrl;
   }
 
-  if (m_baseUrl.charAt(m_baseUrl.length - 1) !== "/") {
-    m_baseUrl += "/";
+  if (m_baseUrl.charAt(m_baseUrl.length - 1) !== '/') {
+    m_baseUrl += '/';
   }
 
   if (arg && arg.mapOpacity !== undefined) {
@@ -70,7 +77,7 @@ geo.osmLayer = function (arg) {
   }
 
   if (arg && arg.useCredentials !== undefined && arg.useCredentials) {
-    m_crossOrigin = "use-credentials";
+    m_crossOrigin = 'use-credentials';
   }
 
   ////////////////////////////////////////////////////////////////////////////
@@ -86,8 +93,8 @@ geo.osmLayer = function (arg) {
    */
   ////////////////////////////////////////////////////////////////////////////
   m_tileUrl = function (zoom, x, y) {
-    return m_baseUrl + zoom + "/" + x +
-      "/" + y + "." + m_imageFormat;
+    return m_baseUrl + zoom + '/' + x +
+      '/' + y + '.' + m_imageFormat;
   };
 
   ////////////////////////////////////////////////////////////////////////////
@@ -101,9 +108,9 @@ geo.osmLayer = function (arg) {
   ////////////////////////////////////////////////////////////////////////////
   m_tileUrlFromTemplate = function (base) {
     return function (zoom, x, y) {
-      return base.replace("<zoom>", zoom)
-        .replace("<x>", x)
-        .replace("<y>", y);
+      return base.replace('<zoom>', zoom)
+        .replace('<x>', x)
+        .replace('<y>', y);
     };
   };
 
@@ -160,7 +167,7 @@ geo.osmLayer = function (arg) {
   this.tileUrl = function (val) {
     if (val === undefined) {
       return m_tileUrl;
-    } else if (typeof val === "string") {
+    } else if (typeof val === 'string') {
       m_tileUrl = m_tileUrlFromTemplate(val);
     } else {
       m_tileUrl = val;
@@ -209,12 +216,12 @@ geo.osmLayer = function (arg) {
           }
         }
       } else if (input[0] instanceof Object &&
-                 "x" in input[0] && "y" in input[0] && "z" in input[0]) {
+                 'x' in input[0] && 'y' in input[0] && 'z' in input[0]) {
         /// Input is array of object
         output[i] = { x: input[i].x, y: geo.mercator.lat2y(input[i].y),
                       z: input[i].z };
       } else if (input[0] instanceof Object &&
-                 "x" in input[0] && "y" in input[0] && "z" in input[0]) {
+                 'x' in input[0] && 'y' in input[0] && 'z' in input[0]) {
         /// Input is array of object
         output[i] = { x: input[i].x, y: geo.mercator.lat2y(input[i].y)};
       } else if (input.length >= 2) {
@@ -610,11 +617,11 @@ geo.osmLayer = function (arg) {
     for (i = 0; i < m_pendingNewTiles.length; i += 1) {
       tile = m_pendingNewTiles[i];
       feature = m_this.createFeature(
-        "plane", {drawOnAsyncResourceLoad: false, onload: tileOnLoad(tile)})
+        'plane', {drawOnAsyncResourceLoad: false, onload: tileOnLoad(tile)})
         .origin([tile.llx, tile.lly])
         .upperLeft([tile.llx, tile.ury])
         .lowerRight([tile.urx, tile.lly])
-        .gcs("EPSG:3857")
+        .gcs('EPSG:3857')
         .style({image: tile, opacity: m_mapOpacity});
       tile.feature = feature;
       tile.feature._update();
@@ -692,13 +699,11 @@ geo.osmLayer = function (arg) {
   ////////////////////////////////////////////////////////////////////////////
   /**
    * Initialize
-   *
-   * Do not call parent _init method as its already been executed
    */
   ////////////////////////////////////////////////////////////////////////////
   this._init = function () {
     s_init.call(m_this);
-    m_this.gcs("EPSG:3857");
+    m_this.gcs('EPSG:3857');
     m_this.map().zoomRange({
       min: 0,
       max: 18
@@ -729,8 +734,8 @@ geo.osmLayer = function (arg) {
   ////////////////////////////////////////////////////////////////////////////
   /* jshint -W089 */
   this.updateBaseUrl = function (baseUrl) {
-    if (baseUrl && baseUrl.charAt(m_baseUrl.length - 1) !== "/") {
-      baseUrl += "/";
+    if (baseUrl && baseUrl.charAt(m_baseUrl.length - 1) !== '/') {
+      baseUrl += '/';
     }
     if (baseUrl !== m_baseUrl) {
 
@@ -815,4 +820,4 @@ geo.osmLayer = function (arg) {
 
 inherit(geo.osmLayer, geo.featureLayer);
 
-geo.registerLayer("osm", geo.osmLayer);
+geo.registerLayer('osm', geo.osmLayer);

--- a/src/gl/vglRenderer.js
+++ b/src/gl/vglRenderer.js
@@ -18,7 +18,6 @@ geo.gl.vglRenderer = function (arg) {
   geo.gl.renderer.call(this, arg);
 
   var m_this = this,
-      s_exit = this._exit,
       m_contextRenderer = null,
       m_viewer = null,
       m_width = 0,

--- a/src/gl/vglRenderer.js
+++ b/src/gl/vglRenderer.js
@@ -318,17 +318,6 @@ geo.gl.vglRenderer = function (arg) {
     return m_this;
   };
 
-  ////////////////////////////////////////////////////////////////////////////
-  /**
-   * Exit
-   * @todo remove all vgl objects
-   */
-  ////////////////////////////////////////////////////////////////////////////
-  this._exit = function () {
-    geo.gl.vglViewerInstance.deleteCache(m_viewer);
-    s_exit();
-  };
-
   this._updateRendererCamera = function () {
     var vglRenderer = m_this.contextRenderer(),
         renderWindow = m_viewer.renderWindow(),

--- a/src/plugin/jquery-plugin.js
+++ b/src/plugin/jquery-plugin.js
@@ -268,6 +268,7 @@
       layers: [],
       data: [],
       tileUrl: 'http://tile.openstreetmap.org/<zoom>/<x>/<y>.png',
+      attribution: undefined,
 
       // These options are for future use, but shouldn't
       // be changed at the moment, so they aren't documented.
@@ -300,7 +301,8 @@
         this.options.baseLayer,
         {
           renderer: this.options.baseRenderer,
-          tileUrl: this.options.tileUrl
+          tileUrl: this.options.tileUrl,
+          attribution: this.options.attribution
         }
       );
 

--- a/testing/test-cases/jasmine-tests/mapAttribution.js
+++ b/testing/test-cases/jasmine-tests/mapAttribution.js
@@ -1,0 +1,74 @@
+/*global describe, it, expect, geo*/
+
+describe('Test adding and remove attribution via layers', function () {
+  'use strict';
+
+  // Generate a new empty map
+  function createMap() {
+    return geo.map({node: '#map'});
+  }
+
+  // Return all attribution nodes
+  function getAttribution() {
+    return $('#map > .geo-attribution > .geo-attribution-layer');
+  }
+
+  it('Attribution added via constructor argument', function () {
+    var map = createMap();
+
+    map.createLayer('feature', {
+      attribution: '<div id="test-constructor"/>'
+    });
+
+    var $a = getAttribution();
+    expect($a.length).toBe(1);
+    expect($a.find('#test-constructor').length).toBe(1);
+  });
+  
+  it('Modifying an attribution after creation', function () {
+    var map = createMap();
+
+    var layer = map.createLayer('feature');
+
+
+    layer.attribution('<div id="test-setter"/>');
+
+    var $a = getAttribution();
+    expect($a.length).toBe(1);
+    expect($a.find('#test-setter').length).toBe(1);
+  });
+
+  it('Multiple attributions', function () {
+    var map = createMap();
+
+    var layer = map.createLayer('feature');
+    layer.attribution('<div id="test-1"/>');
+
+    layer = map.createLayer('feature');
+    layer.attribution('<div id="test-2"/>');
+
+    layer = map.createLayer('feature');
+    layer.attribution('<div id="test-3"/>');
+
+    var $a = getAttribution();
+    expect($a.length).toBe(3);
+    expect($a.find('#test-1').length).toBe(1);
+    expect($a.find('#test-2').length).toBe(1);
+    expect($a.find('#test-3').length).toBe(1);
+  });
+  
+  it('Remove attribution on remove layer', function () {
+    var map = createMap();
+
+    var layer = map.createLayer('feature');
+    layer.attribution('<div id="test"/>');
+
+    var $a = getAttribution();
+    expect($a.length).toBe(1);
+
+    map.deleteLayer(layer);
+
+    var $a = getAttribution();
+    expect($a.length).toBe(0);
+  });
+});

--- a/testing/test-cases/selenium-tests/jqueryPlugin/include.js
+++ b/testing/test-cases/selenium-tests/jqueryPlugin/include.js
@@ -7,6 +7,7 @@ window.startTest = function (done) {
       center: {latitude: 10, longitude: -10},
       zoom: 4.1,
       tileUrl: '/data/grid.jpg',
+      attribution: null,
       layers: [{
         renderer: 'vgl',
         features: [{

--- a/testing/test-cases/selenium-tests/multipleMaps/testTwoMaps.py
+++ b/testing/test-cases/selenium-tests/multipleMaps/testTwoMaps.py
@@ -6,7 +6,7 @@ from selenium_test import FirefoxTest, ChromeTest,\
 
 class osmBase(object):
     testCase = ('multipleMaps',)
-    testRevision = 3
+    testRevision = 4
 
     def loadPage(self):
         self.resizeWindow(320, 480)

--- a/testing/test-cases/selenium-tests/osmLayer/include.js
+++ b/testing/test-cases/selenium-tests/osmLayer/include.js
@@ -1,6 +1,9 @@
 
 window.startTest = function(done) {
-    window.gjsmap = window.geoTests.createOsmMap();
+    window.gjsmap = window.geoTests.createOsmMap(
+        {},
+        {attribution: '&copy; <a href="http://some-unvisited-domain.org">OpenStreetMap</a> contributors'}
+    );
 
     // give the tiles a chance to load
     window.gjsmap.onIdle(done);

--- a/testing/test-cases/selenium-tests/osmLayer/testDrawOsm.py
+++ b/testing/test-cases/selenium-tests/osmLayer/testDrawOsm.py
@@ -6,7 +6,7 @@ from selenium_test import FirefoxTest, ChromeTest,\
 
 class osmBase(object):
     testCase = ('osmLayer',)
-    testRevision = 10
+    testRevision = 11
 
     def waitForIdle(self, timeout=5):
         self.runScript(

--- a/testing/test-runners/selenium-test-utils.js
+++ b/testing/test-runners/selenium-test-utils.js
@@ -24,7 +24,8 @@ window.geoTests = {
     $.extend(true, mapDefaults, mapOpts);
 
     var osmDefaults = {
-      baseUrl: '/data/tiles/'
+      baseUrl: '/data/tiles/',
+      attribution: null
     };
 
     if (notiles) {


### PR DESCRIPTION
This is long overdue.  It adds the ability to provide attribution notices per layer.  The map just combines them together and places them in the lower left corner as usual.  The osm layer is the only one that will have an attribution by default.

Fixes #281.