### PR TITLE
Tweaking the examples for a new release

### DIFF
--- a/examples/common/css/examples.css
+++ b/examples/common/css/examples.css
@@ -4,8 +4,9 @@ html, body {
 }
 
 #map {
+  top: -21px;
   width: 100%;
   height: calc(100% - 60px);
-  position: absolute;
-  top: 60px;
+  position: relative;
+  overflow: hidden;
 }

--- a/examples/contour/main.js
+++ b/examples/contour/main.js
@@ -58,7 +58,7 @@ $(function () {
       x: -157.965,
       y: 21.482
     },
-    zoom: 8
+    zoom: 10
   });
 
   // Add the osm layer

--- a/examples/dynamicData/main.js
+++ b/examples/dynamicData/main.js
@@ -3,7 +3,7 @@ $(function () {
   'use strict';
 
   // Create a map object
-  var map = geo.map({node: '#map'});
+  var map = geo.map({node: '#map', zoom: 3});
 
   // Add and start a clock
   var clock = map.clock();

--- a/examples/geoJSON/main.css
+++ b/examples/geoJSON/main.css
@@ -1,7 +1,7 @@
 .CodeMirror {
-  position: absolute;
+  position: absolute !important;
   left: 10px;
-  top: 1px;
+  top: 80px;
   width: calc(50% - 10px);
   height: calc(100% - 100px) !important;
   z-index: 50;

--- a/examples/geoJSON/main.js
+++ b/examples/geoJSON/main.js
@@ -10,7 +10,7 @@ $(function () {
       x: -125,
       y: 36.5
     },
-    zoom: 1
+    zoom: 4
   });
 
   // Add the osm layer with a custom tile url

--- a/examples/hurricanes/main.js
+++ b/examples/hurricanes/main.js
@@ -349,7 +349,7 @@ $(function () {
       x: 0,
       y: 0
     },
-    zoom: 0
+    zoom: 3
   });
 
   // Add the osm layer with a custom tile url

--- a/examples/jquery-plugin/main.js
+++ b/examples/jquery-plugin/main.js
@@ -20,7 +20,7 @@ $(function () {
       x: -100,
       y: 40
     },
-    zoom: 1,
+    zoom: 4,
     layers: [{
       renderer: 'd3',
       features: [{

--- a/examples/layerEvents/main.js
+++ b/examples/layerEvents/main.js
@@ -37,7 +37,7 @@ $(function () {
       x: -98.0,
       y: 39.5
     },
-    zoom: 1
+    zoom: 4
   });
 
   // Add a base layer

--- a/examples/layers/main.js
+++ b/examples/layers/main.js
@@ -125,7 +125,7 @@ $(function () {
       x: -98.0,
       y: 39.5
     },
-    zoom: 1
+    zoom: 4
   });
 
   // Add a base layer

--- a/examples/legend/main.js
+++ b/examples/legend/main.js
@@ -4,7 +4,8 @@ $(function () {
 
   // Create a map object
   var map = geo.map({
-    node: '#map'
+    node: '#map',
+    zoom: 3
   });
 
   // Add the osm layer with a custom tile url

--- a/examples/osm/main.js
+++ b/examples/osm/main.js
@@ -9,7 +9,7 @@ $(function () {
       x: -98.0,
       y: 39.5
     },
-    zoom: 1
+    zoom: 3
   });
 
   // Add the osm layer with a custom tile url

--- a/examples/picking/example.json
+++ b/examples/picking/example.json
@@ -1,9 +1,0 @@
-{
-  "path": "picking",
-  "title": "Mouse picking for points and lines",
-  "exampleCss": ["main.css"],
-  "exampleJs": ["main.js", "widget.js"],
-  "about": {
-    "text": "This example demonstrates how to attach handlers to various mouse interactions that allow the users to select features.  Try moving the mouse over the features and clicking.  Also try shift-click and draging to select a region"
-  }
-}

--- a/examples/picking/main.js
+++ b/examples/picking/main.js
@@ -9,7 +9,7 @@ $(function () {
       x: -98.0,
       y: 39.5
     },
-    zoom: 2
+    zoom: 4
   }),
   over = 0;
 

--- a/examples/points/main.js
+++ b/examples/points/main.js
@@ -49,7 +49,7 @@ $(function () {
       x: -98.0,
       y: 39.5
     },
-    zoom: 2
+    zoom: 4.9
   });
 
   // Create an osm layer with custom tile url for a white background.

--- a/examples/ui/main.js
+++ b/examples/ui/main.js
@@ -9,7 +9,7 @@ $(function () {
       x: -98.0,
       y: 39.5
     },
-    zoom: 1
+    zoom: 4
   });
 
   // Add the osm layer

--- a/examples/wms/main.js
+++ b/examples/wms/main.js
@@ -5,7 +5,7 @@ $(function () {
   // Create a map object
   var map = geo.map({
     node: '#map',
-    zoom: 2,
+    zoom: 4,
     center: {x: -98.0, y: 39.5}
   });
 


### PR DESCRIPTION
I'm preparing to release version 0.5.0, and I want to update the examples on the github.io page.  These changes just fix some positioning and zoom issues that appeared in the core library changes since the last release.  Also, I removed one of the examples with line picking that was kind of pointless.