### PR TITLE
Move grunt build step to npm build

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "xmlbuilder": "^3.1.0"
   },
   "scripts": {
-    "postinstall": "./node_modules/.bin/bower --quiet install"
+    "postinstall": "bower --quiet install",
+    "build": "grunt init library"
   },
   "keywords": [
     "map",


### PR DESCRIPTION
It seems that putting a `grunt` build step in `postinstall` is a [bad idea](https://docs.npmjs.com/misc/scripts#best-practices) as it causes all sorts of [problems](https://github.com/npm/npm/issues/1341) due to npm's dependency resolution rules.  We should modify the release workflow to put the build step in `prepublish` instead so that built files are added to the npm release.

This is a temporary fix to allow [other projects](https://github.com/Kitware/minerva/pull/167) to depend on geojs without hitting build issues.  These projects will need to execute `npm install; npm run build` manually to build the library.