### PR TITLE
Add `--allow-root` to bower instantiation

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "xmlbuilder": "^3.1.0"
   },
   "scripts": {
-    "postinstall": "bower --quiet install",
+    "postinstall": "bower --quiet --allow-root install",
     "build": "grunt init library"
   },
   "keywords": [


### PR DESCRIPTION
This is necessary to install geojs as the root user.  It is the equivalent of `--unsafe-perm` for npm.

@mgrauer @kotfic