### PR TITLE
Discrete zoom and mouse event throttling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,6 +120,12 @@ if(PHANTOMJS_TESTS)
     COPYONLY
   )
 
+  configure_file(
+    ${CMAKE_CURRENT_SOURCE_DIR}/node_modules/phantomjs-polyfill/bind-polyfill.js
+    ${GEOJS_DEPLOY_DIR}/test/lib/bind-polyfill.js
+    COPYONLY
+  )
+
   file(GLOB JS_UNIT_TEST_CASES
     ${CMAKE_CURRENT_SOURCE_DIR}/testing/test-cases/phantomjs-tests/*.js
   )

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "jsdoc": "^3.4",
     "jshint": "~2.8",
     "phantomjs": "~1.9",
+    "phantomjs-polyfill": "0.0.1",
     "xmlbuilder": "^4.1.0"
   },
   "scripts": {

--- a/sources.json
+++ b/sources.json
@@ -50,7 +50,8 @@
         "wigglemaps.js",
         "leaflet.js",
         "clustering.js",
-        "scales.js"
+        "scales.js",
+        "throttle.js"
       ]
     },
     "geo.gl": {

--- a/src/core/map.js
+++ b/src/core/map.js
@@ -1139,6 +1139,7 @@ geo.map = function (arg) {
       if (m_discreteZoom) {
         m_this.zoom(Math.round(m_this.zoom()));
       }
+      m_this.interactor().options({discreteZoom: m_discreteZoom});
     }
     return m_this;
   };
@@ -1386,7 +1387,7 @@ geo.map = function (arg) {
   // Now update to the correct center and zoom level
   this.center($.extend({}, arg.center || m_center), undefined);
 
-  this.interactor(arg.interactor || geo.mapInteractor());
+  this.interactor(arg.interactor || geo.mapInteractor({discreteZoom: m_discreteZoom}));
   this.clock(arg.clock || geo.clock());
 
   function resizeSelf() {

--- a/src/core/mapInteractor.js
+++ b/src/core/mapInteractor.js
@@ -347,12 +347,7 @@ geo.mapInteractor = function (args) {
     m_callZoom = debounced_zoom();
 
     // add event handlers
-    if (m_options.throttle > 0) {
-      $node.on('wheel.geojs', m_this._handleMouseWheel);
-    } else {
-      $node.on('wheel.geojs', m_this._handleMouseWheel);
-    }
-
+    $node.on('wheel.geojs', m_this._handleMouseWheel);
     $node.on('mousemove.geojs', m_this._handleMouseMove);
     $node.on('mousedown.geojs', m_this._handleMouseDown);
     $node.on('mouseup.geojs', m_this._handleMouseUp);

--- a/src/core/mapInteractor.js
+++ b/src/core/mapInteractor.js
@@ -91,7 +91,7 @@ geo.mapInteractor = function (args) {
 
   // options supported:
   // {
-  //   // throttle mouse events to at most this many milliseconds each (default 200)
+  //   // throttle mouse events to at most this many milliseconds each (default 30)
   //   throttle: number
   //
   //   // Clamp zoom events to discrete (integer) zoom levels.  If a number is

--- a/src/core/mapInteractor.js
+++ b/src/core/mapInteractor.js
@@ -371,6 +371,8 @@ geo.mapInteractor = function (args) {
       $node.off('.geojs');
       $node = null;
     }
+    m_this._handleMouseWheel = function () {};
+    m_callZoom = function () {};
     return m_this;
   };
 

--- a/src/util/throttle.js
+++ b/src/util/throttle.js
@@ -1,0 +1,211 @@
+/**
+ * @file
+ * Based on the following jquery throttle / debounce plugin:
+ *
+ * jQuery throttle / debounce - v1.1 - 3/7/2010
+ * http://benalman.com/projects/jquery-throttle-debounce-plugin/
+ *
+ * @copyright 2010 "Cowboy" Ben Alman
+ * Dual licensed under the MIT and GPL licenses.
+ * http://benalman.com/about/license/
+ *
+ * The implementation included here is modified to support a callback
+ * method that can accumulate values between actual invocations of
+ * the throttled method.
+ */
+
+(function (window, undefined) {
+  'use strict';
+
+  // Internal method reference.
+  var _throttle;
+
+  /**
+   * Throttle execution of a function. Especially useful for rate limiting
+   * execution of handlers on events like resize and scroll. If you want to
+   * rate-limit execution of a function to a single time see
+   * {@link geo.util.debounce}.
+   *
+   * In this visualization, | is a throttled-function call and X is the actual
+   * callback execution:
+   *
+   * ::
+   *   Throttled with `no_trailing` specified as false or unspecified:
+   *   ||||||||||||||||||||||||| (pause) |||||||||||||||||||||||||
+   *   X    X    X    X    X    X        X    X    X    X    X    X
+   *
+   *   Throttled with `no_trailing` specified as true:
+   *   ||||||||||||||||||||||||| (pause) |||||||||||||||||||||||||
+   *   X    X    X    X    X             X    X    X    X    X
+   *
+   * @function geo.util.throttle
+   * @param {number} delay A zero-or-greater delay in milliseconds. For event
+   *    callbacks, values around 100 or 250 (or even higher) are most useful.
+   * @param {boolean} [no_trailing=false] If no_trailing is
+   *    true, callback will only execute every `delay` milliseconds while the
+   *    throttled-function is being called. If no_trailing is false or
+   *    unspecified, callback will be executed one final time after the last
+   *    throttled-function call. (After the throttled-function has not been
+   *    called for `delay` milliseconds, the internal counter is reset)
+   * @param {function} callback A function to be executed after `delay`
+   *    milliseconds. The `this` context and all arguments are passed through,
+   *    as-is, to `callback` when the throttled-function is executed.
+   * @param {function} [accumulator] A function to be executed (synchronously)
+   *    during **each** call to the wrapped function.  Typically, this
+   *    this method is used to accumulate values that the callback uses
+   *    when it finally executes.
+   *
+   * @returns {function} The throttled version of `callback`
+   *
+   * @example
+   * var throttled = geo.util.throttle( delay, [ no_trailing, ] callback );
+   * $('selector').bind( 'someevent', throttled );
+   * $('selector').unbind( 'someevent', throttled );
+   */
+  geo.util.throttle = function (delay, no_trailing,
+                                callback, accumulator, debounce_mode) {
+    // After wrapper has stopped being called, this timeout ensures that
+    // `callback` is executed at the proper times in `throttle` and `end`
+    // debounce modes.
+    var timeout_id,
+
+      // Keep track of the last time `callback` was executed.
+      last_exec = 0;
+
+    // `no_trailing` defaults to falsy.
+    if (typeof no_trailing !== 'boolean') {
+      debounce_mode = accumulator;
+      accumulator = callback;
+      callback = no_trailing;
+      no_trailing = undefined;
+    }
+
+    // accumulator defaults to no-op
+    if (typeof accumulator !== 'function') {
+      debounce_mode = accumulator;
+      accumulator = function () {};
+    }
+
+    // The `wrapper` function encapsulates all of the throttling / debouncing
+    // functionality and when executed will limit the rate at which `callback`
+    // is executed.
+    function wrapper() {
+      var that = this, // jshint ignore: line
+        elapsed = +new Date() - last_exec,
+        args = arguments;
+
+      // Execute `callback` and update the `last_exec` timestamp.
+      function exec() {
+        last_exec = +new Date();
+        callback.apply(that, args);
+      }
+
+      // If `debounce_mode` is true (at_begin) this is used to clear the flag
+      // to allow future `callback` executions.
+      function clear() {
+        timeout_id = undefined;
+      }
+
+      // always call the accumulator first
+      accumulator.apply(that, args);
+
+      if (debounce_mode && !timeout_id) {
+        // Since `wrapper` is being called for the first time and
+        // `debounce_mode` is true (at_begin), execute `callback`.
+        exec();
+      }
+
+      // Clear any existing timeout.
+      void(
+        timeout_id && clearTimeout(timeout_id)
+      );
+
+      if (debounce_mode === undefined && elapsed > delay) {
+        // In throttle mode, if `delay` time has been exceeded, execute
+        // `callback`.
+        exec();
+
+      } else if (no_trailing !== true) {
+        // In trailing throttle mode, since `delay` time has not been
+        // exceeded, schedule `callback` to execute `delay` ms after most
+        // recent execution.
+        //
+        // If `debounce_mode` is true (at_begin), schedule `clear` to execute
+        // after `delay` ms.
+        //
+        // If `debounce_mode` is false (at end), schedule `callback` to
+        // execute after `delay` ms.
+        timeout_id = setTimeout(
+          debounce_mode ?
+            clear :
+            exec,
+          debounce_mode === undefined ?
+            delay - elapsed :
+            delay
+        );
+      }
+    }
+
+    // Return the wrapper function.
+    return wrapper;
+  };
+
+  _throttle = geo.util.throttle;
+
+  /**
+   * Debounce execution of a function. Debouncing, unlike throttling,
+   * guarantees that a function is only executed a single time, either at the
+   * very beginning of a series of calls, or at the very end. If you want to
+   * simply rate-limit execution of a function, see the <jQuery.throttle>
+   * method.
+   *
+   * In this visualization, | is a debounced-function call and X is the actual
+   * callback execution:
+   *
+   * ::
+   *
+   *   Debounced with `at_begin` specified as false or unspecified:
+   *   ||||||||||||||||||||||||| (pause) |||||||||||||||||||||||||
+   *                            X                                 X
+   *
+   *   Debounced with `at_begin` specified as true:
+   *   ||||||||||||||||||||||||| (pause) |||||||||||||||||||||||||
+   *   X                                 X
+   *
+   *
+   * @param {number} delay A zero-or-greater delay in milliseconds. For event
+   *    callbacks, values around 100 or 250 (or even higher) are most useful.
+   * @param {boolean} [at_begin=false] If at_begin is false or
+   *    unspecified, callback will only be executed `delay` milliseconds after
+   *    the last debounced-function call. If at_begin is true, callback will be
+   *    executed only at the first debounced-function call. (After the
+   *    throttled-function has not been called for `delay` milliseconds, the
+   *    internal counter is reset)
+   * @param {function} callback A function to be executed after delay milliseconds.
+   *    The `this` context and all arguments are passed through, as-is, to
+   *    `callback` when the debounced-function is executed.
+   * @param {function} [accumulator] A function to be executed (synchronously)
+   *    during **each** call to the wrapped function.  Typically, this
+   *    this method is used to accumulate values that the callback uses
+   *    when it finally executes.
+   *
+   * @returns {function} A new, debounced, function.
+   *
+   * @example
+   * var debounced = geo.util.debounce( delay, [ at_begin, ] callback );
+   * $('selector').bind( 'someevent', debounced );
+   * $('selector').unbind( 'someevent', debounced );
+   *
+   */
+
+  geo.util.debounce = function (delay, at_begin, callback, accumulator) {
+    if (typeof at_begin !== 'boolean') {
+      accumulator = callback;
+      callback = at_begin;
+      at_begin = false;
+    }
+    accumulator = accumulator || function () {};
+    return _throttle(delay, false, callback, accumulator, !!at_begin);
+  };
+
+})(this);

--- a/testing/test-cases/phantomjs-tests/mapInteractor.js
+++ b/testing/test-cases/phantomjs-tests/mapInteractor.js
@@ -60,13 +60,13 @@ describe('mapInteractor', function () {
 
   beforeEach(function () {
     // create a new div
-    $('body').append('<div id="mapNode1" class="mapNode"></div>');
-    $('body').append('<div id="mapNode2" class="mapNode"></div>');
+    $('body').append('<div id="mapNode1" class="mapNode testNode"></div>');
+    $('body').append('<div id="mapNode2" class="mapNode testNode"></div>');
   });
 
   afterEach(function () {
     // delete the div
-    $('.mapNode').remove();
+    $('.testNode').remove();
   });
 
   it('Test initialization with given node.', function () {
@@ -107,7 +107,8 @@ describe('mapInteractor', function () {
       panMoveButton: 'left',
       panWheelEnabled: false,
       zoomMoveButton: null,
-      zoomWheelEnabled: false
+      zoomWheelEnabled: false,
+      throttle: false
     });
 
     // initiate a pan
@@ -185,7 +186,8 @@ describe('mapInteractor', function () {
       panMoveButton: null,
       panWheelEnabled: false,
       zoomMoveButton: null,
-      zoomWheelEnabled: true
+      zoomWheelEnabled: true,
+      throttle: false
     });
 
     // initialize the mouse position
@@ -218,7 +220,8 @@ describe('mapInteractor', function () {
       panMoveButton: null,
       panWheelEnabled: false,
       zoomMoveButton: 'right',
-      zoomWheelEnabled: false
+      zoomWheelEnabled: false,
+      throttle: false
     });
 
     // initialize the zoom
@@ -278,7 +281,7 @@ describe('mapInteractor', function () {
     });
     it('ignores mouse down', function () {
       var map = mockedMap('#mapNode1'),
-          interactor = geo.mapInteractor({map: map});
+          interactor = geo.mapInteractor({map: map, throttle: false});
 
       interactor.pause(true);
       interactor.simulateEvent(
@@ -307,7 +310,7 @@ describe('mapInteractor', function () {
     });
     it('ignores mouse move', function () {
       var map = mockedMap('#mapNode1'),
-          interactor = geo.mapInteractor({map: map});
+          interactor = geo.mapInteractor({map: map, throttle: false});
 
       interactor.simulateEvent(
         'mousedown',
@@ -336,7 +339,7 @@ describe('mapInteractor', function () {
     });
     it('ignores mouse up', function () {
       var map = mockedMap('#mapNode1'),
-          interactor = geo.mapInteractor({map: map});
+          interactor = geo.mapInteractor({map: map, throttle: false});
 
       interactor.simulateEvent(
         'mousedown',
@@ -373,7 +376,7 @@ describe('mapInteractor', function () {
     });
     it('ignores mouse wheel', function () {
       var map = mockedMap('#mapNode1'),
-          interactor = geo.mapInteractor({map: map});
+          interactor = geo.mapInteractor({map: map, throttle: false});
 
       interactor.pause(true);
       interactor.simulateEvent(
@@ -395,7 +398,8 @@ describe('mapInteractor', function () {
             map: map,
             click: {
               enabled: false
-            }
+            },
+            throttle: false
           }), triggered = false;
 
       map.geoOn(geo.event.mouseclick, function () {
@@ -417,7 +421,8 @@ describe('mapInteractor', function () {
             map: map,
             click: {
               enabled: true
-            }
+            },
+            throttle: false
           }), triggered = 0;
 
       map.geoOn(geo.event.mouseclick, function () {
@@ -441,7 +446,8 @@ describe('mapInteractor', function () {
               enabled: true,
               cancelOnMove: false,
               duration: 1000
-            }
+            },
+            throttle: false
           }), triggered = 0;
 
       map.geoOn(geo.event.mouseclick, function () {
@@ -468,7 +474,8 @@ describe('mapInteractor', function () {
               enabled: true,
               cancelOnMove: false,
               duration: 10
-            }
+            },
+            throttle: false
           }), triggered = 0;
 
       map.geoOn(geo.event.mouseclick, function () {
@@ -495,7 +502,8 @@ describe('mapInteractor', function () {
               enabled: true,
               cancelOnMove: false,
               duration: 500
-            }
+            },
+            throttle: false
           }), triggered = 0;
 
       map.geoOn(geo.event.mouseclick, function () {
@@ -523,7 +531,8 @@ describe('mapInteractor', function () {
               enabled: true,
               cancelOnMove: true,
               duration: 500
-            }
+            },
+            throttle: false
           }), triggered = 0;
 
       map.geoOn(geo.event.mouseclick, function () {
@@ -552,7 +561,8 @@ describe('mapInteractor', function () {
               cancelOnMove: true,
               duration: 500,
               buttons: {left: false}
-            }
+            },
+            throttle: false
           }), triggered = 0;
 
       map.geoOn(geo.event.mouseclick, function () {
@@ -584,7 +594,8 @@ describe('mapInteractor', function () {
             click: {
               enabled: true,
               cancelOnMove: false
-            }
+            },
+            throttle: false
           });
       interactor.simulateEvent('mousedown', {
         map: {x: 20, y: 20},
@@ -607,7 +618,8 @@ describe('mapInteractor', function () {
             click: {
               enabled: true,
               cancelOnMove: false
-            }
+            },
+            throttle: false
           }), ncalls = 0;
       interactor.simulateEvent('mousedown', {
         map: {x: 20, y: 20},
@@ -626,6 +638,132 @@ describe('mapInteractor', function () {
       });
       $(document).trigger('testevent');
       expect(ncalls).toBe(0);
+    });
+  });
+  describe('throttled map interactions', function () {
+    it('pan', function (done) {
+      var map = mockedMap('#mapNode1'),
+          interactor = geo.mapInteractor({
+            map: map,
+            throttle: 100,
+            click: {
+              enabled: false
+            },
+            momentum: {
+              enabled: false
+            }
+          });
+
+      interactor.simulateEvent(
+        'mousedown',
+        {
+          map: {x: 20, y: 20},
+          button: 'left'
+        }
+      );
+      interactor.simulateEvent(
+        'mousemove',
+        {
+          map: {x: 25, y: 25},
+          button: 'left'
+        }
+      );
+      interactor.simulateEvent(
+        'mousemove',
+        {
+          map: {x: 20, y: 30},
+          button: 'left'
+        }
+      );
+
+      window.setTimeout(function () {
+        interactor.simulateEvent(
+          'mousemove',
+          {
+            map: {x: 100, y: 100},
+            button: 'left'
+          }
+        );
+        interactor.simulateEvent(
+          'mousemove',
+          {
+            map: {x: 25, y: 25},
+            button: 'left'
+          }
+        );
+
+        window.setTimeout(function () {
+          expect(map.info.pan).toBe(2);
+          expect(map.info.panArgs).toEqual({x: 0, y: 0});
+
+          interactor.simulateEvent(
+            'mouseup',
+            {
+              map: {x: 25, y: 25},
+              button: 'left'
+            }
+          );
+
+          done();
+        }, 100);
+      }, 50);
+
+      // the first event is syncronous all others will be async
+      expect(map.info.pan).toBe(1);
+      expect(map.info.panArgs).toEqual({x: 5, y: 5});
+    });
+    it('zoom', function (done) {
+      var map = mockedMap('#mapNode1'),
+          interactor = geo.mapInteractor({
+            map: map,
+            throttle: 100,
+            momentum: {
+              enabled: false
+            }
+          });
+
+      interactor.simulateEvent(
+        'wheel',
+        {
+          wheelDelta: {x: 20, y: -10},
+          wheelMode: 0
+        }
+      );
+      interactor.simulateEvent(
+        'wheel',
+        {
+          wheelDelta: {x: 20, y: -10},
+          wheelMode: 0
+        }
+      );
+
+      window.setTimeout(function () {
+        interactor.simulateEvent(
+          'wheel',
+          {
+            wheelDelta: {x: 20, y: -10},
+            wheelMode: 0
+          }
+        );
+        interactor.simulateEvent(
+          'wheel',
+          {
+            wheelDelta: {x: 20, y: -10},
+            wheelMode: 0
+          }
+        );
+
+        window.setTimeout(function () {
+          expect(map.info.zoom).toBe(2);
+          expect(map.info.zoomArgs).toBe(2 + 30 / 120);
+
+          done();
+        }, 100);
+      }, 50);
+
+      // the first event is syncronous all others will be async
+      expect(map.info.zoom).toBe(1);
+      expect(map.info.zoomArgs).toBe(2 + 10 / 120);
     });
   });
 });

--- a/testing/test-cases/phantomjs-tests/mapInteractor.js
+++ b/testing/test-cases/phantomjs-tests/mapInteractor.js
@@ -22,6 +22,8 @@ describe('mapInteractor', function () {
     return new $.Event(type, args);
   };
 
+  var zoomFactor = 120;
+
   function mockedMap(node) {
 
     var map = geo.object();
@@ -209,7 +211,7 @@ describe('mapInteractor', function () {
 
     // check the zoom event was called
     expect(map.info.zoom).toBe(1);
-    expect(map.info.zoomArgs).toBe(2 + 10 / 120);
+    expect(map.info.zoomArgs).toBe(2 + 10 / zoomFactor);
   });
 
   it('Test zoom right click event propagation', function () {
@@ -244,7 +246,7 @@ describe('mapInteractor', function () {
 
     // check the zoom event was called
     expect(map.info.zoom).toBe(1);
-    expect(map.info.zoomArgs).toBe(2 + 10 / 120);
+    expect(map.info.zoomArgs).toBe(2 + 10 / zoomFactor / 3);
 
     z = map.zoom();
 
@@ -259,7 +261,7 @@ describe('mapInteractor', function () {
 
     // check the zoom event was called
     expect(map.info.zoom).toBe(2);
-    expect(map.info.zoomArgs).toBe(z - 15 / 120);
+    expect(map.info.zoomArgs).toBe(z - 15 / zoomFactor / 3);
   });
 
   describe('pause state', function () {
@@ -755,7 +757,7 @@ describe('mapInteractor', function () {
 
         window.setTimeout(function () {
           expect(map.info.zoom).toBe(2);
-          expect(map.info.zoomArgs).toBe(2 + 30 / 120);
+          expect(map.info.zoomArgs).toBe(2 + 30 / zoomFactor);
 
           done();
         }, 100);
@@ -763,7 +765,7 @@ describe('mapInteractor', function () {
 
       // the first event is syncronous all others will be async
       expect(map.info.zoom).toBe(1);
-      expect(map.info.zoomArgs).toBe(2 + 10 / 120);
+      expect(map.info.zoomArgs).toBe(2 + 10 / zoomFactor);
     });
   });
 });

--- a/testing/test-cases/phantomjs-tests/mapInteractor.js
+++ b/testing/test-cases/phantomjs-tests/mapInteractor.js
@@ -246,7 +246,7 @@ describe('mapInteractor', function () {
 
     // check the zoom event was called
     expect(map.info.zoom).toBe(1);
-    expect(map.info.zoomArgs).toBe(2 + 10 / zoomFactor / 3);
+    expect(map.info.zoomArgs).toBe(2 + 10 / zoomFactor);
 
     z = map.zoom();
 
@@ -261,7 +261,7 @@ describe('mapInteractor', function () {
 
     // check the zoom event was called
     expect(map.info.zoom).toBe(2);
-    expect(map.info.zoomArgs).toBe(z - 15 / zoomFactor / 3);
+    expect(map.info.zoomArgs).toBe(z - 15 / zoomFactor);
   });
 
   describe('pause state', function () {

--- a/testing/test-cases/phantomjs-tests/throttle.js
+++ b/testing/test-cases/phantomjs-tests/throttle.js
@@ -1,0 +1,369 @@
+/*global describe, it, expect, geo*/
+
+/**
+ * @class
+ * A helper class for testing async behavior of throttling.
+ */
+var Helper = function () {
+  'use strict';
+
+  var accum_calls = [],
+      delay_calls = [];
+
+  return $.extend(this, {
+    accum: function () {
+      var args = [].splice.call(arguments, 0);
+      accum_calls.push([this].concat(args));
+    },
+    delay: function () {
+      var args = [].splice.call(arguments, 0);
+      delay_calls.push([this].concat(args));
+    },
+    _get: function (callback) {
+      if (callback === 'accum') {
+        callback = accum_calls;
+      } else if (callback === 'delay') {
+        callback = delay_calls;
+      } else {
+        throw new Error('Invalid callback');
+      }
+      return callback;
+    },
+    _expect: function (callback, icall, obj) {
+      (this._get(callback)[icall] || []).forEach(function (arg, i) {
+        expect(arg).toBe(obj[i]);
+      });
+    }.bind(this),
+    expect: function (callback, arr) {
+      arr = arr || [];
+      expect(this._get(callback).length).toBe(arr.length);
+      arr.forEach(function (obj, icall) {
+        this._expect(callback, icall, obj);
+      }.bind(this));
+    }.bind(this)
+  });
+};
+
+describe('geo.util.debounce', function () {
+  'use strict';
+
+  it('at_begin=false, accumulator=undefined', function (done) {
+    var helper = new Helper();
+    var wrapped = geo.util.debounce(100, helper.delay);
+    var that = {}, arg1 = {}, args = [];
+
+    helper.expect('delay');
+    helper.expect('accum');
+
+    function exec() {
+      wrapped.call(that);
+      args.push([that]);
+    }
+
+    function exec_arg() {
+      wrapped.call(that, arg1);
+      args.push([that, arg1]);
+    }
+
+    exec();
+    window.setTimeout(exec_arg, 0);
+
+    exec();
+    window.setTimeout(exec, 5);
+    window.setTimeout(exec_arg, 5);
+
+    window.setTimeout(exec_arg, 15);
+    window.setTimeout(exec, 250);
+
+    helper.expect('delay');
+    helper.expect('accum');
+
+    window.setTimeout(function () {
+      helper.expect('delay', [[that, arg1]]);
+      helper.expect('accum');
+    }, 200);
+
+    window.setTimeout(function () {
+      helper.expect('delay', [[that, arg1], [that]]);
+      helper.expect('accum');
+      done();
+    }, 600);
+  });
+
+  it('at_begin=false, accumulator=defined', function (done) {
+    var helper = new Helper();
+    var wrapped = geo.util.debounce(100, helper.delay, helper.accum);
+    var that = {}, arg1 = {}, args = [];
+
+    helper.expect('delay');
+    helper.expect('accum');
+
+    function exec() {
+      wrapped.call(that);
+      args.push([that]);
+    }
+
+    function exec_arg() {
+      wrapped.call(that, arg1);
+      args.push([that, arg1]);
+    }
+
+    exec();
+    window.setTimeout(exec_arg, 0);
+
+    exec();
+    window.setTimeout(exec, 5);
+    window.setTimeout(exec_arg, 5);
+
+    window.setTimeout(exec_arg, 15);
+    window.setTimeout(exec, 250);
+
+    helper.expect('delay');
+    helper.expect('accum', args);
+
+    window.setTimeout(function () {
+      helper.expect('delay', [[that, arg1]]);
+      helper.expect('accum', args);
+    }, 200);
+
+    window.setTimeout(function () {
+      helper.expect('delay', [[that, arg1], [that]]);
+      helper.expect('accum', args);
+      done();
+    }, 600);
+  });
+
+  it('at_begin=true, accumulator=undefined', function (done) {
+    var helper = new Helper();
+    var wrapped = geo.util.debounce(100, true, helper.delay);
+    var that = {}, arg1 = {}, args = [];
+
+    helper.expect('delay');
+    helper.expect('accum');
+
+    function exec() {
+      wrapped.call(that);
+      args.push([that]);
+    }
+
+    function exec_arg() {
+      wrapped.call(that, arg1);
+      args.push([that, arg1]);
+    }
+
+    exec();
+    window.setTimeout(exec_arg, 0);
+
+    exec();
+    window.setTimeout(exec, 5);
+    window.setTimeout(exec_arg, 5);
+
+    window.setTimeout(exec_arg, 15);
+    window.setTimeout(exec, 250);
+
+    helper.expect('delay', [[that, arg1]]);
+    helper.expect('accum');
+
+    window.setTimeout(function () {
+      helper.expect('delay', [[that, arg1]]);
+      helper.expect('accum');
+    }, 200);
+
+    window.setTimeout(function () {
+      helper.expect('delay', [[that, arg1], [that]]);
+      helper.expect('accum');
+      done();
+    }, 600);
+  });
+
+  it('at_begin=true, accumulator=defined', function (done) {
+    var helper = new Helper();
+    var wrapped = geo.util.debounce(100, true, helper.delay, helper.accum);
+    var that = {}, arg1 = {}, args = [];
+
+    helper.expect('delay');
+    helper.expect('accum');
+
+    function exec() {
+      wrapped.call(that);
+      args.push([that]);
+    }
+
+    function exec_arg() {
+      wrapped.call(that, arg1);
+      args.push([that, arg1]);
+    }
+
+    exec();
+    window.setTimeout(exec_arg, 0);
+
+    exec();
+    window.setTimeout(exec, 5);
+    window.setTimeout(exec_arg, 5);
+
+    window.setTimeout(exec_arg, 15);
+    window.setTimeout(exec, 250);
+
+    helper.expect('delay', [[that, arg1]]);
+    helper.expect('accum', args);
+
+    window.setTimeout(function () {
+      helper.expect('delay', [[that, arg1]]);
+      helper.expect('accum', args);
+    }, 200);
+
+    window.setTimeout(function () {
+      helper.expect('delay', [[that, arg1], [that]]);
+      helper.expect('accum', args);
+      done();
+    }, 600);
+  });
+});
+
+describe('geo.util.throttle', function () {
+  'use strict';
+
+  it('accumulator=undefined, no_trailing=false', function (done) {
+    var helper = new Helper();
+    var wrapped = geo.util.throttle(200, helper.delay);
+    var arg1 = {}, arg2 = {}, that = {};
+
+    helper.expect('delay');
+    helper.expect('accum');
+
+    wrapped.call(that, arg1, arg1);
+    wrapped.call(that, arg2);
+    wrapped.call(that);
+
+    helper.expect('delay', [[that, arg1, arg1]]);
+    helper.expect('accum');
+
+    setTimeout(function () {
+      helper.expect('delay', [
+        [that, arg1, arg1],
+        [that, arg2]
+      ]);
+      helper.expect('accum');
+      done();
+    }, 250);
+  });
+
+  it('accumulator=defined, no_trailing=false', function (done) {
+    var helper = new Helper();
+    var wrapped = geo.util.throttle(200, helper.delay, helper.accum);
+    var arg1 = '#1', arg2 = '#2', that = {};
+
+    helper.expect('delay');
+    helper.expect('accum');
+
+    wrapped.call(that, arg1, arg1);
+    helper.expect('accum', [[that, arg1, arg1]]);
+
+    wrapped.call(that, arg2);
+    helper.expect('accum', [
+      [that, arg1, arg1],
+      [that, arg2]
+    ]);
+
+    wrapped.call(that);
+    helper.expect('accum', [
+      [that, arg1, arg1],
+      [that, arg2],
+      [that]
+    ]);
+
+    wrapped.call(that, arg1, arg2);
+    helper.expect('accum', [
+      [that, arg1, arg1],
+      [that, arg2],
+      [that],
+      [that, arg1, arg2]
+    ]);
+    helper.expect('delay', [[that, arg1, arg1]]);
+
+    setTimeout(function () {
+      helper.expect('delay', [
+        [that, arg1, arg1],
+        [that, arg1, arg2]
+      ]);
+      helper.expect('accum', [
+        [that, arg1, arg1],
+        [that, arg2],
+        [that],
+        [that, arg1, arg2]
+      ]);
+      done();
+    }, 250);
+  });
+
+  it('accumulator=undefined, no_trailing=true', function (done) {
+    var helper = new Helper();
+    var wrapped = geo.util.throttle(200, true, helper.delay);
+    var arg1 = {}, arg2 = {}, that = {};
+
+    helper.expect('delay');
+    helper.expect('accum');
+
+    wrapped.call(that, arg1, arg1);
+    wrapped.call(that, arg2);
+    wrapped.call(that);
+
+    helper.expect('delay', [[that, arg1, arg1]]);
+    helper.expect('accum');
+
+    setTimeout(function () {
+      helper.expect('delay', [
+        [that, arg1, arg1]
+      ]);
+      helper.expect('accum');
+      done();
+    }, 250);
+  });
+
+  it('accumulator=defined, no_trailing=tree', function (done) {
+    var helper = new Helper();
+    var wrapped = geo.util.throttle(200, true, helper.delay, helper.accum);
+    var arg1 = '#1', arg2 = '#2', that = {};
+
+    helper.expect('delay');
+    helper.expect('accum');
+
+    wrapped.call(that, arg1, arg1);
+    helper.expect('accum', [[that, arg1, arg1]]);
+
+    wrapped.call(that, arg2);
+    helper.expect('accum', [
+      [that, arg1, arg1],
+      [that, arg2]
+    ]);
+
+    wrapped.call(that);
+    helper.expect('accum', [
+      [that, arg1, arg1],
+      [that, arg2],
+      [that]
+    ]);
+
+    wrapped.call(that, arg1, arg2);
+    helper.expect('accum', [
+      [that, arg1, arg1],
+      [that, arg2],
+      [that],
+      [that, arg1, arg2]
+    ]);
+    helper.expect('delay', [[that, arg1, arg1]]);
+
+    setTimeout(function () {
+      helper.expect('delay', [
+        [that, arg1, arg1]
+      ]);
+      helper.expect('accum', [
+        [that, arg1, arg1],
+        [that, arg2],
+        [that],
+        [that, arg1, arg2]
+      ]);
+      done();
+    }, 250);
+  });
+});

--- a/testing/test-runners/jasmine-runner.html.in
+++ b/testing/test-runners/jasmine-runner.html.in
@@ -18,6 +18,7 @@
 <link href=http://jasmine.github.io/css/docco.css rel=stylesheet>
 <link href=http://jasmine.github.io/css/jasmine_docco.css rel=stylesheet>
 <link href=http://jasmine.github.io/2.0/lib/jasmine.css rel=stylesheet>
+<script src=/test/lib/bind-polyfill.js></script>
 <script src=http://jasmine.github.io/2.0/lib/jasmine.js></script>
 <script src=http://jasmine.github.io/2.0/lib/jasmine-html.js></script>
 <script src=/test/lib/jasmine-boot.js></script>

--- a/testing/test-runners/jasmine-runner.html.in
+++ b/testing/test-runners/jasmine-runner.html.in
@@ -14,6 +14,10 @@
         width: 100%;
         height: 100%;
   }
+
+  .mapNode {
+        pointer-events: none;
+  }
 </style>
 <link href=http://jasmine.github.io/css/docco.css rel=stylesheet>
 <link href=http://jasmine.github.io/css/jasmine_docco.css rel=stylesheet>
@@ -28,35 +32,8 @@
 <script src=/test/lib/aggregate-json-reporter.js></script>
 </head>
 <body>
-<div id=map-container><div id=map></div></div>
+<div id=map-container><div id=map class=mapNode></div></div>
 <script>
-if (!Function.prototype.bind) {
-  Function.prototype.bind = function(oThis) {
-    if (typeof this !== 'function') {
-      // closest thing possible to the ECMAScript 5
-      // internal IsCallable function
-      throw new TypeError('Function.prototype.bind - what is trying to be bound is not callable');
-    }
-
-    var aArgs   = Array.prototype.slice.call(arguments, 1),
-        fToBind = this,
-        fNOP    = function() {},
-        fBound  = function() {
-          return fToBind.apply(this instanceof fNOP
-                 ? this
-                 : oThis,
-                 aArgs.concat(Array.prototype.slice.call(arguments)));
-        };
-
-    if (this.prototype) {
-      // native functions don't have a prototype
-      fNOP.prototype = this.prototype;
-    }
-    fBound.prototype = new fNOP();
-
-    return fBound;
-  };
-}
 @TEST_SOURCE@
 
 </script>

--- a/testing/test-runners/selenium-test-utils.js
+++ b/testing/test-runners/selenium-test-utils.js
@@ -46,7 +46,8 @@ window.geoTests = {
     map.createLayer('osm', osmDefaults);
 
     map.interactor().options({
-      momentum: false
+      momentum: false,
+      throttle: 0
     });
 
     if (osmDefaults.m_baseUrl) {


### PR DESCRIPTION
This adds new utility methods for throttling and debouncing functions.  These methods are used in the map interactor to throttle all mouse events to improve rendering performance.  In addition, zoom events are debounced to fix discrete zooming on touch devices, which fire small continuous scroll events rather than large discrete events like a traditional mouse wheel.

The interaction with discrete zooming isn't great for a couple of reasons.

1.  There is a significant delay that occurs while the map is rendering
2.  There is no indication that the zoom is doing anything at intermediate values

It may help to implement a "snap to discrete values" feature, but that is out of scope of this PR.  You can try the new behavior at the following link.

http://jsbin.com/feduco/3