### PR TITLE
Mark tiles as fetched.

### DIFF
--- a/src/core/imageTile.js
+++ b/src/core/imageTile.js
@@ -75,7 +75,9 @@
         this._image.src = this._url;
 
         // attach a promise interface to `this`
-        defer.promise(this);
+        defer.then(function () {
+          this._fetched = true;
+        }.bind(this)).promise(this);
       }
       return this;
     };

--- a/src/core/tile.js
+++ b/src/core/tile.js
@@ -72,9 +72,20 @@
      */
     this.fetch = function () {
       if (!this._fetched) {
-        $.get(this._url).promise(this);
+        $.get(this._url).then(function () {
+          this._fetched = true;
+        }.bind(this)).promise(this);
       }
       return this;
+    };
+
+    /**
+     * Return whether this tile has been fetched already.
+     *
+     * @returns {boolean} True if the tile has been fetched.
+     */
+    this.fetched = function () {
+      return this._fetched;
     };
 
     /**

--- a/src/core/tileLayer.js
+++ b/src/core/tileLayer.js
@@ -900,18 +900,10 @@
       this._tileTree = {};
 
       tiles.forEach(function (tile) {
-        tile.then(function () {
-          if (tile !== this.cache.get(tile.toString())) {
-            /* If the tile has fallen out of the cache, don't draw it -- it is
-             * untracked.  This may be an indication that a larger cache should
-             * have been used. */
-            return;
-          }
-          /* Check if a tile is still desired.  Don't draw it if it isn't. */
-          var mapZoom = map.zoom(),
-              zoom = this._options.tileRounding(mapZoom),
-              bounds = this._getViewBounds();
-          if (this._canPurge(tile, bounds, zoom)) {
+        if (tile.fetched()) {
+          /* if we have already fetched the tile, don't recompute the map zoom
+           *  and view bounds, as we can use what we currently have. */
+          if (this._canPurge(tile, view, zoom)) {
             this.remove(tile);
             return;
           }
@@ -920,9 +912,31 @@
 
           // mark the tile as covered
           this._setTileTree(tile);
-        }.bind(this));
+        } else {
+          tile.then(function () {
+            if (tile !== this.cache.get(tile.toString())) {
+              /* If the tile has fallen out of the cache, don't draw it -- it
+               * is untracked.  This may be an indication that a larger cache
+               * should have been used. */
+              return;
+            }
+            /* Check if a tile is still desired.  Don't draw it if it isn't. */
+            var mapZoom = map.zoom(),
+                zoom = this._options.tileRounding(mapZoom),
+                view = this._getViewBounds();
+            if (this._canPurge(tile, view, zoom)) {
+              this.remove(tile);
+              return;
+            }
 
-        this.addPromise(tile);
+            this.drawTile(tile);
+
+            // mark the tile as covered
+            this._setTileTree(tile);
+          }.bind(this));
+
+          this.addPromise(tile);
+        }
       }.bind(this));
 
       // purge all old tiles when the new tiles are loaded (successfully or not)


### PR DESCRIPTION
When tiles have been fetched, do less work by not recomputing bounds for each tile.  This results in fewer GC cycles.

This helps issue #474, though it isn't any of the advised changes.