### PR TITLE
Use native arrays rather than vec3 and mat4.

### DIFF
--- a/src/core/camera.js
+++ b/src/core/camera.js
@@ -54,13 +54,13 @@
      * The view matrix
      * @protected
      */
-    this._view = mat4.create();
+    this._view = geo.util.mat4AsArray();
 
     /**
      * The projection matrix
      * @protected
      */
-    this._proj = mat4.create();
+    this._proj = geo.util.mat4AsArray();
 
     /**
      * The projection type (one of `this.constructor.projection`)
@@ -72,13 +72,13 @@
      * The transform matrix (view * proj)
      * @protected
      */
-    this._transform = mat4.create();
+    this._transform = geo.util.mat4AsArray();
 
     /**
      * The inverse transform matrix (view * proj)^-1
      * @protected
      */
-    this._inverse = mat4.create();
+    this._inverse = geo.util.mat4AsArray();
 
     /**
      * Cached bounds object recomputed on demand.
@@ -229,7 +229,7 @@
       get: function () {
         if (this._world === null) {
           this._world = mat4.invert(
-            mat4.create(),
+            geo.util.mat4AsArray(),
             this.display
           );
         }
@@ -310,22 +310,18 @@
         // apply scaling to the view matrix to account for the new aspect ratio
         // without changing the apparent zoom level
         if (this._viewport.width && this._viewport.height) {
-          this._scale(
-            vec3.fromValues(
+          this._scale([
               this._viewport.width / viewport.width,
               this._viewport.height / viewport.height,
               1
-            )
-          );
+          ]);
 
           // translate by half the difference to keep the center the same
-          this._translate(
-            vec3.fromValues(
+          this._translate([
               (viewport.width - this._viewport.width) / 2,
               (viewport.height - this._viewport.height) / 2,
               0
-            )
-          );
+          ]);
         }
 
         this._viewport = {width: viewport.width, height: viewport.height};
@@ -350,7 +346,7 @@
     /**
      * Uses `mat4.translate` to translate the camera by the given vector amount.
      * @protected
-     * @param {vec3} offset The camera translation vector
+     * @param {vec3|Array} offset The camera translation vector
      * @returns {this} Chainable
      */
     this._translate = function (offset) {
@@ -360,7 +356,7 @@
     /**
      * Uses `mat4.scale` to scale the camera by the given vector amount.
      * @protected
-     * @param {vec3} scale The scaling vector
+     * @param {vec3|Array} scale The scaling vector
      * @returns {this} Chainable
      */
     this._scale = function (scale) {
@@ -563,8 +559,8 @@
      */
     this._setBounds = function (bounds) {
 
-      var translate = vec3.create(),
-          scale = vec3.create(),
+      var translate = geo.util.vec3AsArray(),
+          scale = geo.util.vec3AsArray(),
           c_ar, v_ar, w, h;
 
       bounds.near = bounds.near || 0;
@@ -611,11 +607,14 @@
      * @param {number} [offset.z=0]
      */
     this.pan = function (offset) {
-      this._translate(vec3.fromValues(
+      if (!offset.x && !offset.y && !offset.z) {
+        return;
+      }
+      this._translate([
         offset.x,
         offset.y,
         offset.z || 0
-      ));
+      ]);
       this._update();
     };
 
@@ -625,13 +624,11 @@
      * @param {number} zoom The zoom scale to apply
      */
     this.zoom = function (zoom) {
-      mat4.scale(this._view, this._view,
-        vec3.fromValues(
+      mat4.scale(this._view, this._view, [
           zoom,
           zoom,
           zoom
-        )
-      );
+      ]);
       this._update();
     };
 
@@ -805,7 +802,7 @@
    * @returns {mat4} The new transform matrix
    */
   geo.camera.affine = function (pre, scale, post) {
-    var mat = mat4.create();
+    var mat = geo.util.mat4AsArray();
 
     // Note: mat4 operations are applied to the right side of the current
     // transform, so the first applied here is the last applied to the
@@ -841,7 +838,7 @@
    * @returns {mat4} A * B
    */
   geo.camera.combine = function (A, B) {
-    return mat4.mul(mat4.create(), A, B);
+    return mat4.mul(geo.util.mat4AsArray(), A, B);
   };
 
   inherit(geo.camera, geo.object);

--- a/src/gl/ellipsoid.js
+++ b/src/gl/ellipsoid.js
@@ -28,9 +28,8 @@ geo.ellipsoid = function (x, y, z) {
   }
 
   var m_this = this,
-      m_radii = new vec3.fromValues(x, y, z),
-      m_radiiSquared = new vec3.fromValues(
-        x * x, y * y, z * z),
+      m_radii = [x, y, z],
+      m_radiiSquared = [x * x, y * y, z * z],
       m_minimumRadius = Math.min(x, y, z),
       m_maximumRadius = Math.max(x, y, z);
 
@@ -95,7 +94,7 @@ geo.ellipsoid = function (x, y, z) {
     }
 
     var cosLatitude = Math.cos(lat),
-        result = vec3.create();
+        result = geo.util.vec3AsArray();
 
     result[0] = cosLatitude * Math.cos(lon);
     result[1] = cosLatitude * Math.sin(lon);
@@ -121,9 +120,9 @@ geo.ellipsoid = function (x, y, z) {
     lon = lon * (Math.PI / 180.0);
 
     var n = m_this.computeGeodeticSurfaceNormal(lat, lon),
-        k = vec3.create(),
+        k = geo.util.vec3AsArray(),
         gamma  = Math.sqrt(vec3.dot(n, k)),
-        result = vec3.create();
+        result = geo.util.vec3AsArray();
 
     vec3.multiply(k, m_radiiSquared, n);
     vec3.scale(k, k, 1 / gamma);
@@ -160,8 +159,8 @@ geo.ellipsoid = function (x, y, z) {
         gamma = null,
         n = null,
         j = 0,
-        k = vec3.create(),
-        result = vec3.create();
+        k = geo.util.vec3AsArray(),
+        result = geo.util.vec3AsArray();
 
     stride /= sizeOfDataType;
     offset /= sizeOfDataType;

--- a/src/gl/vglRenderer.js
+++ b/src/gl/vglRenderer.js
@@ -138,16 +138,16 @@ geo.gl.vglRenderer = function (arg) {
     if (proj[15]) {
       /* we want positive z to be closer to the camera, but webGL does the
        * converse, so reverse the z coordinates. */
-      proj = mat4.scale(mat4.create(), proj, [1, 1, -1]);
+      proj = mat4.scale(geo.util.mat4AsArray(), proj, [1, 1, -1]);
     }
     /* A similar kluge as in the base camera class worldToDisplay4.  With this,
      * we can show z values from 0 to 1. */
-    proj = mat4.translate(mat4.create(), proj,
+    proj = mat4.translate(geo.util.mat4AsArray(), proj,
                           [0, 0, camera.constructor.bounds.far]);
 
     renderWindow.renderers().forEach(function (renderer) {
       var cam = renderer.camera();
-      cam.setViewMatrix(view);
+      cam.setViewMatrix(view, true);
       cam.setProjectionMatrix(proj);
       if (proj[1] || proj[2] || proj[3] || proj[4] || proj[6] || proj[7] ||
           proj[8] || proj[9] || proj[11] || proj[15] !== 1 ||

--- a/src/util/init.js
+++ b/src/util/init.js
@@ -214,6 +214,33 @@
       a.y = (a.y || 0) * Math.pow(b.y || 1, pow);
       a.z = (a.z || 0) * Math.pow(b.z || 1, pow);
       return a;
+    },
+
+    /**
+     * Create a vec3 that is always an array.  This should only be used if it
+     * will not be used in a WebGL context.  Plain arrays usually use 64-bit
+     * float values, whereas vec3 defaults to 32-bit floats.
+     *
+     * @returns {Array} zeroed-out vec3 compatible array.
+     */
+    vec3AsArray: function () {
+      return [0, 0, 0];
+    },
+
+    /**
+     * Create a mat4 that is always an array.  This should only be used if it
+     * will not be used in a WebGL context.  Plain arrays usually use 64-bit
+     * float values, whereas mat4 defaults to 32-bit floats.
+     *
+     * @returns {Array} identity mat4 compatible array.
+     */
+    mat4AsArray: function () {
+      return [
+        1, 0, 0, 0,
+        0, 1, 0, 0,
+        0, 0, 1, 0,
+        0, 0, 0, 1
+      ];
     }
   };
 


### PR DESCRIPTION
vec3 and mat4 create Float32Array data types by default.  These are lower precision than native arrays, and should only be used if the loss of precision is acceptable or the values must be passed to a WebGL context.

Rather than use vec3.fromValues, in most cases a plain array can be used.  I've added two new utility functions to create vec3 and mat4 compatible arrays that are just native arrays.

If the speed/memory benefit of an explicit array type is beneficial, these could use Float64Array instead (we would have to test if this is actually faster).

For the full benefit of this, the vgl branch of view-array-type is required.  Without that, it will still have some benefit.

I've tested this (with the vgl branch) up to zoom levels 30, and the results look smooth and flawless.