### PR TITLE
Increase the default tile cache size.

### DIFF
--- a/src/core/tileLayer.js
+++ b/src/core/tileLayer.js
@@ -136,7 +136,7 @@
     options = $.extend(true, {}, this.constructor.defaults, options || {});
     if (!options.cacheSize) {
       // this size should be sufficient for a 4k display
-      options.cacheSize = options.keepLower ? 400 : 200;
+      options.cacheSize = options.keepLower ? 600 : 200;
     }
     if ($.type(options.subdomains) === 'string') {
       options.subdomains = options.subdomains.split('');


### PR DESCRIPTION
Since we can now zoom to level 42, the tile cache could need to be larger.  For a 4k display where we include the lower tiles, we could have as many as 409 tiles on the display.  I've rounded up, as caching the tiles beyond that has benefits, too.

The number of tiles per level is ((ceil(width / tile_size) + 1) * (ceil(hieght / tile_size) + 1)).  For a 4k display that is actually 4096 x 2304 pixels, this works out to 17 * 10 + 9 * 6 + 5 * 4 + 3 * 3 + 2 * 2 * (max_level - 3) tiles.

We could make the default tile cache take into account the window size and max level and thus make it as small as possible while still large enough.  It would require potentially expanding or contracting it upon window resize or max level change.  If anyone thinks that is a useful feature, create an issue and we can implement it.