### PR TITLE
Implemented a tile fetch queue.

### DIFF
--- a/sources.json
+++ b/sources.json
@@ -24,6 +24,7 @@
         "imageTile.js",
         "tileCache.js",
         "tileLayer.js",
+        "fetchQueue.js",
         "fileReader.js",
         "jsonReader.js",
         "map.js",

--- a/src/core/fetchQueue.js
+++ b/src/core/fetchQueue.js
@@ -1,0 +1,211 @@
+(function () {
+  'use strict';
+
+  //////////////////////////////////////////////////////////////////////////////
+  /**
+   * This class implements a queue for Deferred objects.  Whenever one of the
+   * objects in the queue completes (resolved or rejected), another item in the
+   * queue is processed.  The number of concurrently processing items can be
+   * adjusted.  At this time (2015-12-29) most major browsers support 6
+   * concurrent requests from any given server, so, when using the queue for
+   * tile images, thie number of concurrent requests should be 6 * (number of
+   * subdomains serving tiles).
+   *
+   * @class
+   *
+   * @param {Object?} [options] A configuration object for the queue
+   * @param {Number} [options.size=6] The maximum number of concurrent deferred
+   *    objects.
+   * @param {Number} [options.track=600] The number of objects that are tracked
+   *    that trigger checking if any of them have been abandoned.  The fetch
+   *    queue can grow to the greater of this size and the number of items that
+   *    are still needed.  Setting this to a low number will increase
+   *    processing time, to a high number can increase memory.  Ideally, it
+   *    should reflect the number of items that are kept in memory elsewhere.
+   *    If needed is null, this is ignored.
+   * @param {function} [options.needed=null] If set, this function is passed a
+   *    Deferred object and must return a truthy value if the object is still
+   *    needed.
+   */
+  //////////////////////////////////////////////////////////////////////////////
+  geo.fetchQueue = function (options) {
+    if (!(this instanceof geo.fetchQueue)) {
+      return new geo.fetchQueue(options);
+    }
+    options = options || {};
+    this._size = options.size || 6;
+    this._track = options.track || 600;
+    this._needed = options.needed || null;
+    this._batch = false;
+
+    var m_this = this,
+        m_next_batch = 1;
+
+    /**
+     * Get/set the maximum concurrent deferred object size.
+     */
+    Object.defineProperty(this, 'size', {
+      get: function () { return this._size; },
+      set: function (n) {
+        this._size = n;
+        this.next_item();
+      }
+    });
+
+    /**
+     * Get the current queue size.
+     */
+    Object.defineProperty(this, 'length', {
+      get: function () { return this._queue.length; }
+    });
+
+    /**
+     * Get the current number of processing items.
+     */
+    Object.defineProperty(this, 'processing', {
+      get: function () { return this._processing; }
+    });
+
+    /**
+     * Remove all items from the queue.
+     */
+    this.clear = function () {
+      this._queue = [];
+      this._processing = 0;
+      return this;
+    };
+
+    /**
+     * Add a Deferred object to the queue.
+     * @param {Deferred} defer Deferred object to add to the queue.
+     * @param {function} callback a function to call when the item's turn is
+     *  granted.
+     * @param {boolean} atEnd if false, add the item to the front of the queue
+     *  if batching is turned off or at the end of the current batch if it is
+     *  turned on.  If true, always add the item to the end of the queue.
+     */
+    this.add = function (defer, callback, atEnd) {
+      if (defer.__fetchQueue) {
+        var pos = $.inArray(defer, this._queue);
+        if (pos >= 0) {
+          this._queue.splice(pos, 1);
+          this._addToQueue(defer, atEnd);
+          return defer;
+        }
+      }
+      var wait = new $.Deferred();
+      var process = new $.Deferred();
+      wait.then(function () {
+        $.when(callback.call(defer)).always(process.resolve);
+      }, process.resolve);
+      defer.__fetchQueue = wait;
+      this._addToQueue(defer, atEnd);
+      $.when(wait, process).always(function () {
+        if (m_this._processing > 0) {
+          m_this._processing -= 1;
+        }
+        m_this.next_item();
+      }).promise(defer);
+      m_this.next_item();
+      return defer;
+    };
+
+    /**
+     * Add an item to the queue.  If batches are being used, add it at after
+     * other items in the same batch.
+     * @param {Deferred} defer Deferred object to add to the queue.
+     * @param {boolean} atEnd if false, add the item to the front of the queue
+     *  if batching is turned off or at the end of the current batch if it is
+     *  turned on.  If true, always add the item to the end of the queue.
+     */
+    this._addToQueue = function (defer, atEnd) {
+      defer.__fetchQueue._batch = this._batch;
+      if (atEnd) {
+        this._queue.push(defer);
+      } else if (!this._batch) {
+        this._queue.unshift(defer);
+      } else {
+        for (var i = 0; i < this._queue.length; i += 1) {
+          if (this._queue[i].__fetchQueue._batch !== this._batch) {
+            break;
+          }
+        }
+        this._queue.splice(i, 0, defer);
+      }
+    };
+
+    /**
+     * Remove a Deferred object from the queue.
+     * @param {Deferred} defer Deferred object to add to the queue.
+     * @returns {bool} true if the object was removed
+     */
+    this.remove = function (defer) {
+      var pos = $.inArray(defer, this._queue);
+      if (pos >= 0) {
+        this._queue.splice(pos, 1);
+        return true;
+      }
+      return false;
+    };
+
+    /**
+     * Start a new batch or clear using batches.
+     * @param {boolean} start true to start a new batch, false to turn off
+     *                        using batches.  Undefined to return the current
+     *                        state of batches.
+     * @return {Number|boolean|Object} the current batch state or this object.
+     */
+    this.batch = function (start) {
+      if (start === undefined) {
+        return this._batch;
+      }
+      if (!start) {
+        this._batch = false;
+      } else {
+        this._batch = m_next_batch;
+        m_next_batch += 1;
+      }
+      return this;
+    };
+
+    /**
+     * Check if any items are queued and if there if there are not too many
+     * deferred objects being processed.  If so, process more items.
+     */
+    this.next_item = function () {
+      if (m_this._innextitem) {
+        return;
+      }
+      m_this._innextitem = true;
+      /* if the queue is greater than the track size, check each item to see
+       * if it is still needed. */
+      if (m_this._queue.length > m_this._track && this._needed) {
+        for (var i = m_this._queue.length - 1; i >= 0; i -= 1) {
+          if (!m_this._needed(m_this._queue[i])) {
+            var discard = m_this._queue.splice(i, 1)[0];
+            m_this._processing += 1;
+            discard.__fetchQueue.reject();
+            delete discard.__fetchQueue;
+          }
+        }
+      }
+      while (m_this._processing < m_this._size && m_this._queue.length) {
+        var defer = m_this._queue.shift();
+        if (defer.__fetchQueue) {
+          m_this._processing += 1;
+          var needed = m_this._needed ? m_this._needed(defer) : true;
+          if (needed) {
+            defer.__fetchQueue.resolve();
+          } else {
+            defer.__fetchQueue.reject();
+          }
+          delete defer.__fetchQueue;
+        }
+      }
+      m_this._innextitem = false;
+    };
+
+    this.clear();
+    return this;
+  };
+})();

--- a/src/core/osmLayer.js
+++ b/src/core/osmLayer.js
@@ -45,6 +45,7 @@
       return geo.imageTile({
         index: index,
         size: {x: this._options.tileWidth, y: this._options.tileHeight},
+        queue: this._queue,
         url: this._options.url(urlParams.x, urlParams.y, urlParams.level || 0,
                                this._options.subdomains)
       });

--- a/src/core/tile.js
+++ b/src/core/tile.js
@@ -40,6 +40,7 @@
     this._wrap = spec.wrap || {x: 1, y: 1};
     this._url = spec.url;
     this._fetched = false;
+    this._queue = spec.queue || null;
 
     /**
      * Return the index coordinates.
@@ -98,8 +99,13 @@
      *
      */
     this.then = function (onSuccess, onFailure) {
-      this.fetch(); // This will replace the current then method
-
+      // both fetch and _queueAdd can replace the current then method
+      if (!this.fetched() && this._queue && this._queue.add && (!this.state ||
+          this.state() === 'pending')) {
+        this._queue.add(this, this.fetch);
+      } else {
+        this.fetch();
+      }
       // Call then on the new promise
       this.then(onSuccess, onFailure);
       return this;

--- a/src/core/tileLayer.js
+++ b/src/core/tileLayer.js
@@ -487,7 +487,7 @@
             }
 
             if (this.isValid(source)) {
-              tiles.push({index: $.extend({}, index), soure: source});
+              tiles.push({index: $.extend({}, index), source: source});
             }
           }
         }

--- a/testing/test-cases/phantomjs-tests/fetchQueue.js
+++ b/testing/test-cases/phantomjs-tests/fetchQueue.js
@@ -1,0 +1,202 @@
+// Test geo.core.fetchQueue
+
+/*global describe, it, beforeEach, expect, geo*/
+describe('geo.core.fetchQueue', function () {
+  'use strict';
+  var report = [],
+      reference = 1;
+
+  function make_deferred() {
+    var item = {ref: reference};
+    reference += 1;
+    item.process = function () {
+      item.defer = $.Deferred();
+      item.defer.then(function () {
+        report.push({ref: item.ref, success: true});
+      }, function () {
+        report.push({ref: item.ref, success: false});
+      }).promise(item);
+      return item;
+    };
+    return item;
+  }
+
+  // test cache size settings
+  describe('queue size', function () {
+    beforeEach(function () {
+      report = [];
+      reference = 1;
+    });
+
+    it('queue is the exepected size', function () {
+      var q = geo.fetchQueue({size: 2}), dlist = [];
+
+      expect(q.length).toBe(0);
+
+      dlist.push(make_deferred());
+      q.add(dlist[0], dlist[0].process);
+      expect(q.length).toBe(0);
+      expect(q.processing).toBe(1);
+
+      dlist.push(make_deferred());
+      q.add(dlist[1], dlist[1].process);
+      dlist.push(make_deferred());
+      q.add(dlist[2], dlist[2].process);
+      expect(q.length).toBe(1);
+      expect(q.processing).toBe(2);
+
+      dlist.push(make_deferred());
+      q.add(dlist[3], dlist[3].process);
+      expect(q.length).toBe(2);
+      expect(q.processing).toBe(2);
+      expect(q._queue[0]).toBe(dlist[3]);
+
+      // adding an existing item should move it to the front
+      q.add(dlist[2], dlist[2].process);
+      expect(q.length).toBe(2);
+      expect(q.processing).toBe(2);
+      expect(q._queue[0]).toBe(dlist[2]);
+
+      expect(q.remove(dlist[2])).toBe(true);
+      expect(q.length).toBe(1);
+      expect(q.processing).toBe(2);
+
+      expect(q.remove(dlist[2])).toBe(false);
+      expect(q.length).toBe(1);
+      expect(q.processing).toBe(2);
+
+      dlist[0].defer.resolve();
+      expect(q.length).toBe(0);
+      expect(q.processing).toBe(2);
+
+      dlist[3].defer.resolve();
+      expect(q.length).toBe(0);
+      expect(q.processing).toBe(1);
+    });
+
+    it('queue size can be changed', function () {
+      var q = geo.fetchQueue({size: 2}), dlist = [];
+
+      expect(q.size).toBe(2);
+
+      for (var i = 0; i < 5; i += 1) {
+        dlist.push(make_deferred());
+        // add items at end of queue
+        q.add(dlist[i], dlist[i].process, true);
+      }
+      expect(q.length).toBe(3);
+      expect(q.processing).toBe(2);
+
+      // increasing the size should start another item processing
+      q.size = 3;
+      expect(q.size).toBe(3);
+      expect(q.length).toBe(2);
+      expect(q.processing).toBe(3);
+
+      // but decresing it won't stop one
+      q.size = 1;
+      expect(q.size).toBe(1);
+      expect(q.length).toBe(2);
+      expect(q.processing).toBe(3);
+
+      dlist[0].defer.resolve();
+      expect(q.length).toBe(2);
+      expect(q.processing).toBe(2);
+
+      dlist[1].defer.resolve();
+      expect(q.length).toBe(2);
+      expect(q.processing).toBe(1);
+
+      dlist[2].defer.resolve();
+      expect(q.length).toBe(1);
+      expect(q.processing).toBe(1);
+    });
+
+    it('queue removes and skips unneeded items', function () {
+      var q = geo.fetchQueue({
+        size: 2,
+        track: 4,
+        needed: function (item) {
+          return (item.ref % 2) === 1;
+        }
+      });
+      var qrefs = [
+        [], // 1 being processed
+        [], // 1 being processed, 2 rejected
+        [], // 1 and 3 being processed
+        [4],
+        [5, 4],
+        [6, 5, 4],
+        [7, 6, 5, 4],
+        [7, 5],
+        [9, 7, 5],
+        [10, 9, 7, 5],
+        [11, 9, 7, 5],
+        [11, 9, 7, 5],
+        [13, 11, 9, 7, 5],
+        [13, 11, 9, 7, 5]
+      ];
+      var dlist = [], i, reportOrder = [1, 3, 11, 13, 7, 9, 5];
+
+      for (i = 0; i < 14; i += 1) {
+        dlist.push(make_deferred());
+        q.add(dlist[i], dlist[i].process);
+        expect(q.length).toBe(qrefs[i].length);
+        for (var j = 0; j < q.length; j += 1) {
+          expect(q._queue[j].ref).toBe(qrefs[i][j]);
+        }
+      }
+
+      while (q.processing) {
+        for (i = 0; i < dlist.length; i += 1) {
+          if (dlist[i].defer) {
+            dlist[i].defer.resolve();
+          }
+        }
+      }
+
+      expect(report.length).toBe(reportOrder.length);
+      for (i = 0; i < report.length; i += 1) {
+        expect(report[i].ref).toBe(reportOrder[i]);
+      }
+    });
+
+    it('batch ordering', function () {
+      var q = geo.fetchQueue({size: 1}), dlist = [], i;
+      var reportOrder = [
+        1, 22, 23, 20, 19, 17, 13, 14, 16, 11, 10, 5,
+        7, 8, 4, 2, 3, 6, 9, 12, 15, 18, 21, 24
+      ];
+
+      /* We add items to the queue stack-like, so the last added gets processed
+       * first, unless they are batched or added at the end.  For this test,
+       * the first item (1) will be processed immediately.  Items 2-4, 9-12,
+       * 17-20 are added without batching, while items 5-8, 13-16, 21-24 are
+       * batched.  Every third item is added at the end. */
+      for (i = 0; i < 24; i += 1) {
+        if ((i % 8) === 0) {
+          q.batch(false);
+          expect(q.batch()).toBe(false);
+        } else if ((i % 4) === 0) {
+          q.batch(true);
+          expect(q.batch()).toBe(parseInt(i / 8) + 1);
+        }
+        dlist.push(make_deferred());
+        q.add(dlist[i], dlist[i].process, (i % 3) === 2);
+      }
+
+      while (q.processing) {
+        for (i = 0; i < dlist.length; i += 1) {
+          if (dlist[i].defer) {
+            dlist[i].defer.resolve();
+          }
+        }
+      }
+
+      expect(report.length).toBe(reportOrder.length);
+      for (i = 0; i < report.length; i += 1) {
+        expect(report[i].ref).toBe(reportOrder[i]);
+      }
+    });
+  });
+});

--- a/testing/test-cases/phantomjs-tests/tileLayer.js
+++ b/testing/test-cases/phantomjs-tests/tileLayer.js
@@ -822,9 +822,9 @@ describe('geo.tileLayer', function () {
         });
 
         m = l._loadMetric({x: 0, y: 0, level: 0});
-        expect(m({x: 1, y: 1, level: 2}, {x: 2, y: 2, level: 2})).toBeLessThan(0);
-        expect(m({x: 1, y: 1, level: 1}, {x: 2, y: 2, level: 2})).toBeGreaterThan(0);
-        expect(m({x: 1, y: 1, level: 2}, {x: 0.5, y: 1.01, level: 2})).toBeGreaterThan(0);
+        expect(m({x: 1, y: 1, level: 2}, {x: 3, y: 3, level: 2})).toBeLessThan(0);
+        expect(m({x: 1, y: 1, level: 1}, {x: 3, y: 3, level: 2})).toBeLessThan(0);
+        expect(m({x: 2, y: 2, level: 2}, {x: 1.5, y: 2.01, level: 2})).toBeGreaterThan(0);
       });
 
       it('center (1, 1, 1)', function () {
@@ -833,9 +833,21 @@ describe('geo.tileLayer', function () {
         });
 
         m = l._loadMetric({x: 1, y: 1, level: 1});
-        expect(m({x: 1, y: 1, level: 2}, {x: 2, y: 2, level: 2})).toBeGreaterThan(0);
-        expect(m({x: 1, y: 1, level: 1}, {x: 2, y: 2, level: 2})).toBeGreaterThan(0);
-        expect(m({x: 1, y: 1, level: 2}, {x: 0.5, y: 1.01, level: 2})).toBeLessThan(0);
+        expect(m({x: 1, y: 1, level: 2}, {x: 3, y: 3, level: 2})).toBeGreaterThan(0);
+        expect(m({x: 1, y: 1, level: 1}, {x: 3, y: 3, level: 2})).toBeLessThan(0);
+        expect(m({x: 2, y: 2, level: 2}, {x: 1.5, y: 2.01, level: 2})).toBeLessThan(0);
+      });
+
+      it('center (1.5, 1.5, 2, 1)', function () {
+        var m, l = geo.tileLayer({
+          map: map()
+        });
+
+        m = l._loadMetric({x: 1.5, y: 1.5, level: 2, bottomLevel: 1});
+        expect(m({x: 1, y: 1, level: 2}, {x: 3, y: 3, level: 2})).toBeLessThan(0);
+        expect(m({x: 1, y: 1, level: 1}, {x: 3, y: 3, level: 2})).toBeLessThan(0);
+        expect(m({x: 1, y: 1, level: 0}, {x: 3, y: 3, level: 2})).toBeGreaterThan(0);
+        expect(m({x: 2, y: 2, level: 2}, {x: 1.5, y: 2.01, level: 2})).toBeGreaterThan(0);
       });
     });
 


### PR DESCRIPTION
This is actually a general deferred object fetch queue.  It expects that no more than some number of Deferred objects should be processed at once.  For images in modern browsers, there is standard limit of six images per domain at a time.  This is the default for the fetch queue.  If more items are requested, they are further deferred and are loaded in a priority order of last-requested-first.  Items can be cancelled as well if they are no longer needed.

Also fixed the metrics that determine the load order of tiles.  There was an issue that tiles were passed and the function didn't know how to access tile.index.  This metric has been extended to have a concept of a 'bottomLevel', where anything lower than that level is lower priority.  This allows highly zoomed areas to show useful tiles first, rather than showing the absolute lowest tiles first.

This resolves issue #472.