### PR TITLE
Fix an issue at high zooms with d3 and html renderers.

### DIFF
--- a/src/core/tileLayer.js
+++ b/src/core/tileLayer.js
@@ -843,7 +843,9 @@
           Math.abs(lasty - view.top) < 65536) {
         return {x: lastx, y: lasty};
       }
-      var x = parseInt(view.left), y = parseInt(view.top);
+      var to = this._options.tileOffset(level),
+          x = parseInt(view.left) + to.x,
+          y = parseInt(view.top) + to.y;
       canvas.find('.geo-tile-layer').each(function (idx, el) {
         var $el = $(el),
             layer = parseInt($el.data('tileLayer'));

--- a/src/d3/tileLayer.js
+++ b/src/d3/tileLayer.js
@@ -61,7 +61,9 @@ geo.d3.tileLayer = function () {
         Math.abs(lasty - view.top) < 65536) {
       return {x: lastx, y: lasty};
     }
-    var x = parseInt(view.left), y = parseInt(view.top);
+    var to = this._options.tileOffset(level),
+        x = parseInt(view.left) + to.x,
+        y = parseInt(view.top) + to.y;
     var tileCache = m_this.cache._cache;
     $.each(canvas.selectAll('.geo-tile-layer')[0], function (idx, el) {
       var layer = parseInt($(el).attr('data-tile-layer')),


### PR DESCRIPTION
At high zooms, the calculated offset failed to use the tile offset, which meant that the tile offset would still suffer from a loss of precision in CSS or SVG coordinates.  By taking into account the tile offset, this is better.