### PR TITLE
Improve the speed of the tile layer.

### DIFF
--- a/src/core/featureLayer.js
+++ b/src/core/featureLayer.js
@@ -97,12 +97,12 @@ geo.featureLayer = function (arg) {
     }
 
     /// Call super class init
-    s_init.call(m_this);
+    s_init.call(m_this, true);
 
     /// Bind events to handlers
     m_this.geoOn(geo.event.resize, function (event) {
       m_this.renderer()._resize(event.x, event.y, event.width, event.height);
-      m_this._update({});
+      m_this._update({event: event});
       m_this.renderer()._render();
     });
 

--- a/src/core/layer.js
+++ b/src/core/layer.js
@@ -338,9 +338,13 @@ geo.layer = function (arg) {
   ////////////////////////////////////////////////////////////////////////////
   /**
    * Init layer
+   *
+   * @param {boolean} noEvents if a subclass of this intends to bind the
+   *    resize, pan, and zoom events itself, set this flag to true to avoid
+   *    binding them here.
    */
   ////////////////////////////////////////////////////////////////////////////
-  this._init = function () {
+  this._init = function (noEvents) {
     if (m_initialized) {
       return m_this;
     }
@@ -371,18 +375,20 @@ geo.layer = function (arg) {
 
     m_initialized = true;
 
-    /// Bind events to handlers
-    m_this.geoOn(geo.event.resize, function (event) {
-      m_this._update({event: event});
-    });
+    if (!noEvents) {
+      /// Bind events to handlers
+      m_this.geoOn(geo.event.resize, function (event) {
+        m_this._update({event: event});
+      });
 
-    m_this.geoOn(geo.event.pan, function (event) {
-      m_this._update({event: event});
-    });
+      m_this.geoOn(geo.event.pan, function (event) {
+        m_this._update({event: event});
+      });
 
-    m_this.geoOn(geo.event.zoom, function (event) {
-      m_this._update({event: event});
-    });
+      m_this.geoOn(geo.event.zoom, function (event) {
+        m_this._update({event: event});
+      });
+    }
 
     return m_this;
   };

--- a/src/core/map.js
+++ b/src/core/map.js
@@ -1027,11 +1027,15 @@ geo.map = function (arg) {
       if (m_transition.zCoord) {
         p[2] = z2zoom(p[2]);
       }
-      m_this.center({
-        x: p[0],
-        y: p[1]
-      }, null);
-      m_this.zoom(p[2], undefined, true);
+      if (fix_zoom(p[2], true) === m_zoom) {
+        m_this.center({
+          x: p[0],
+          y: p[1]
+        }, null);
+      } else {
+        m_center = m_this.gcsToWorld({x: p[0], y: p[1]}, null);
+        m_this.zoom(p[2], undefined, true);
+      }
 
       window.requestAnimationFrame(anim);
     }

--- a/src/core/map.js
+++ b/src/core/map.js
@@ -314,8 +314,7 @@ geo.map = function (arg) {
     evt = {
       geo: {},
       zoomLevel: m_zoom,
-      screenPosition: origin ? origin.map : undefined,
-      eventType: geo.event.zoom
+      screenPosition: origin ? origin.map : undefined
     };
     m_this.geoTrigger(geo.event.zoom, evt);
 
@@ -340,8 +339,7 @@ geo.map = function (arg) {
     var evt, unit;
     evt = {
       geo: {},
-      screenDelta: delta,
-      eventType: geo.event.pan
+      screenDelta: delta
     };
 
     unit = m_this.unitsPerPixel(m_zoom);
@@ -402,8 +400,7 @@ geo.map = function (arg) {
       geo.event.pan,
       {
         geo: coordinates,
-        screenDelta: null,
-        eventType: geo.event.pan
+        screenDelta: null
       }
     );
     return m_this;

--- a/src/core/sceneObject.js
+++ b/src/core/sceneObject.js
@@ -152,8 +152,10 @@ geo.sceneObject = function (arg) {
 
     // trigger the event on the children
     m_children.forEach(function (child) {
-      geoArgs._triggeredBy = m_this;
-      child.geoTrigger(event, args);
+      if (child.geoTrigger) {
+        geoArgs._triggeredBy = m_this;
+        child.geoTrigger(event, args);
+      }
     });
 
     return m_this;

--- a/src/core/tileLayer.js
+++ b/src/core/tileLayer.js
@@ -882,7 +882,11 @@
      * Update the view according to the map/camera.
      * @returns {this} Chainable
      */
-    this._update = function () {
+    this._update = function (evt) {
+      /* Ignore zoom events, as they are ALWAYS followed by a pan event */
+      if (evt && evt.event && evt.event.event === geo.event.zoom) {
+        return;
+      }
       var map = this.map(),
           mapZoom = map.zoom(),
           zoom = this._options.tileRounding(mapZoom),
@@ -978,6 +982,9 @@
       $.when.apply($, tiles)
         .done(// called on success and failure
           function () {
+            var map = this.map(),
+                mapZoom = map.zoom(),
+                zoom = this._options.tileRounding(mapZoom);
             this._purge(zoom, true);
           }.bind(this)
         );

--- a/src/d3/tileLayer.js
+++ b/src/d3/tileLayer.js
@@ -20,6 +20,8 @@ geo.d3.tileLayer = function () {
         reference: tile.toString(),
         parentId: parentNode.attr('data-tile-layer-id')
       });
+    /* Don't respond to geo events */
+    tile.feature.geoTrigger = undefined;
     tile.feature._update();
     m_this.draw();
   };
@@ -61,7 +63,7 @@ geo.d3.tileLayer = function () {
         Math.abs(lasty - view.top) < 65536) {
       return {x: lastx, y: lasty};
     }
-    var to = this._options.tileOffset(level),
+    var to = this._tileOffset(level),
         x = parseInt(view.left) + to.x,
         y = parseInt(view.top) + to.y;
     var tileCache = m_this.cache._cache;

--- a/src/gl/tileLayer.js
+++ b/src/gl/tileLayer.js
@@ -5,7 +5,7 @@ geo.gl.tileLayer = function () {
   this._drawTile = function (tile) {
     var bounds = this._tileBounds(tile),
         level = tile.index.level || 0,
-        to = this._options.tileOffset(level);
+        to = this._tileOffset(level);
     var ul = this.fromLocal(this.fromLevel({
       x: bounds.left - to.x, y: bounds.top - to.y
     }, level), 0);
@@ -19,6 +19,8 @@ geo.gl.tileLayer = function () {
       .upperLeft([ul.x, ul.y, level * 1e-7])
       .lowerRight([lr.x, lr.y, level * 1e-7])
       .style({image: tile._image});
+    /* Don't respond to geo events */
+    tile.feature.geoTrigger = undefined;
     tile.feature.gcs(m_this.map().gcs());
     tile.feature._update();
     m_this.draw();
@@ -35,7 +37,7 @@ geo.gl.tileLayer = function () {
 
   /* These functions don't need to do anything. */
   this._getSubLayer = function () {};
-  this._updateSubLayer = function () {};
+  this._updateSubLayer = undefined;
 };
 
 geo.registerLayerAdjustment('vgl', 'tile', geo.gl.tileLayer);

--- a/src/gl/vglRenderer.js
+++ b/src/gl/vglRenderer.js
@@ -123,8 +123,8 @@ geo.gl.vglRenderer = function (arg) {
   this._render = function () {
     if (m_renderAnimFrameRef === null) {
       m_renderAnimFrameRef = window.requestAnimationFrame(function () {
-        m_viewer.render();
         m_renderAnimFrameRef = null;
+        m_viewer.render();
       });
     }
     return m_this;


### PR DESCRIPTION
When animating transitions where the center and zoom is changing, only generate one pan action per time step (we had been generating two).

Don't trigger geo events on each tile.

Remove some code that does nothing.  The `_deferredPurge` feature was never invoked, nor was an already cached tile ever purged immediately.

Cache the tileOffset calculations.

When using the vgl renderer, skip some of the code that is needed by the other renderers.

Reduce the number of times _update is called on the tile layer.  The layer and featureLayer inits were both binding geo.event.*, resulting in two calls to _update each time an event was triggered.  Add a flag to the layer init function to avoid binding events when we know we are going to bind them in the subclass.  We ALWAYS fire a pan event after a zoom event when we generate the events internally.  Therefore, on the tileLayer, ignore zoom events for _update.  It just wastes time.