### PR TITLE
Bump vgl to 0.3.4

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -18,7 +18,7 @@
     "proj4": "=2.3.3",
     "bootstrap": "~3.3.0",
     "bootswatch": "~3.3",
-    "vgl": "0.3.0"
+    "vgl": "0.3.4"
   },
   "devDependencies": {
     "codemirror": "~4.7.0",

--- a/src/core/tileLayer.js
+++ b/src/core/tileLayer.js
@@ -156,7 +156,12 @@
       options.url = m_tileUrlFromTemplate(options.url);
     }
 
-    var lastZoom = null, lastX = null, lastY = null, s_init = this._init,
+    var lastZoom = null,
+        lastX = null,
+        lastY = null,
+        s_init = this._init,
+        s_exit = this._exit,
+        m_exited,
         _deferredPurge = null;
 
     // copy the options into a private variable
@@ -942,6 +947,11 @@
           this._setTileTree(tile);
         } else {
           tile.then(function () {
+            if (m_exited) {
+              /* If we have disconnected the renderer, do nothing.  This
+               * happens when the layer is being deleted. */
+              return;
+            }
             if (tile !== this.cache.get(tile.toString())) {
               /* If the tile has fallen out of the cache, don't draw it -- it
                * is untracked.  This may be an indication that a larger cache
@@ -1221,6 +1231,16 @@
           this._getSubLayer(sublayer);
         }
       }
+      return this;
+    };
+
+    /**
+     * Clean up the layer.
+     */
+    this._exit = function () {
+      // call super method
+      s_exit.apply(this, arguments);
+      m_exited = true;
       return this;
     };
 

--- a/testing/js/testUtils.js
+++ b/testing/js/testUtils.js
@@ -1,6 +1,6 @@
 /* These are functions we want available to jasmine tests. */
 /* global it */
-/* exported waitForIt */
+/* exported waitForIt, mockVGLRenderer */
 
 /**
  * Create a pair of it functions.  The first one waits for a function to return
@@ -25,4 +25,114 @@ function waitForIt(desc, testFunc) {
   });
   it('done waiting for ' + desc, function () {
   });
+}
+
+/**
+ * Replace vgl.renderer with a mocked version for phantom tests.
+ */
+function mockVGLRenderer() {
+  'use strict';
+
+  if (vgl._mocked) {
+    return;
+  }
+
+  var noop = function () { };
+  var _id = 0,
+      incID = function () {
+        _id += 1;
+        return _id;
+      };
+  /* The context largely does nothing. */
+  var m_context = {
+    activeTexture: noop,
+    attachShader: noop,
+    bindAttribLocation: noop,
+    bindBuffer: noop,
+    bindFramebuffer: noop,
+    bindTexture: noop,
+    blendFuncSeparate: noop,
+    bufferData: noop,
+    bufferSubData: noop,
+    checkFramebufferStatus: function (key) {
+      if (key === vgl.GL.FRAMEBUFFER) {
+        return vgl.GL.FRAMEBUFFER_COMPLETE;
+      }
+    },
+    clear: noop,
+    clearColor: noop,
+    clearDepth: noop,
+    compileShader: noop,
+    createBuffer: incID,
+    createFramebuffer: noop,
+    createProgram: incID,
+    createShader: incID,
+    createTexture: incID,
+    deleteBuffer: noop,
+    deleteProgram: noop,
+    deleteShader: noop,
+    deleteTexture: noop,
+    depthFunc: noop,
+    disable: noop,
+    disableVertexAttribArray: noop,
+    drawArrays: noop,
+    enable: noop,
+    enableVertexAttribArray: noop,
+    finish: noop,
+    getExtension: incID,
+    getParameter: function (key) {
+      if (key === vgl.GL.DEPTH_BITS) {
+        return 16;
+      }
+    },
+    getProgramParameter: function (id, key) {
+      if (key === vgl.GL.LINK_STATUS) {
+        return true;
+      }
+    },
+    getShaderInfoLog: function () {
+      return 'log';
+    },
+    getShaderParameter: function (id, key) {
+      if (key === vgl.GL.COMPILE_STATUS) {
+        return true;
+      }
+    },
+    getUniformLocation: incID,
+    isEnabled: function (key) {
+      if (key === vgl.GL.BLEND) {
+        return true;
+      }
+    },
+    linkProgram: noop,
+    pixelStorei: noop,
+    shaderSource: noop,
+    texImage2D: noop,
+    texParameteri: noop,
+    uniform1iv: noop,
+    uniform1fv: noop,
+    uniform2fv: noop,
+    uniform3fv: noop,
+    uniform4fv: noop,
+    uniformMatrix3fv: noop,
+    uniformMatrix4fv: noop,
+    useProgram: noop,
+    vertexAttribPointer: noop,
+    vertexAttrib3fv: noop,
+    viewport: noop
+  };
+
+  /* Our mock has only a single renderWindow */
+  var m_renderWindow = vgl.renderWindow();
+  m_renderWindow._setup = function () {
+    return true;
+  };
+  m_renderWindow.context = function () {
+    return m_context;
+  };
+  vgl.renderWindow = function () {
+    return m_renderWindow;
+  };
+
+  vgl._mocked = true;
 }

--- a/testing/test-cases/phantomjs-tests/osmLayer.js
+++ b/testing/test-cases/phantomjs-tests/osmLayer.js
@@ -1,5 +1,5 @@
 // Test geo.core.osmLayer
-/*global describe, it, expect, geo, waitForIt*/
+/*global describe, it, expect, geo, waitForIt, mockVGLRenderer*/
 
 describe('geo.core.osmLayer', function () {
   'use strict';
@@ -69,6 +69,7 @@ describe('geo.core.osmLayer', function () {
     });
     describe('vgl', function () {
       it('creation', function () {
+        mockVGLRenderer();
         var map = create_map();
         map.createLayer('osm', {renderer: 'vgl'});
         expect(map.node().find('.webgl-canvas').length).toBe(1);
@@ -77,6 +78,7 @@ describe('geo.core.osmLayer', function () {
     describe('switch renderer', function () {
       var map, layer;
       it('vgl to null', function () {
+        mockVGLRenderer();
         map = create_map();
         layer = map.createLayer('osm', {renderer: 'vgl'});
         expect(map.node().find('.webgl-canvas').length).toBe(1);


### PR DESCRIPTION
This can't be merged as is.  I've spent a while trying to debug it, but very little of what I'm seeing makes sense.  For one, I can't figure out why the changes in VGL could possibly cause this. The first thing I noticed is the failing test `phantomjs:osmLayer`.  Opening it in the browser, it appears to pass, but if you open up the console there are all kinds of error messages like this:

```
Uncaught TypeError: Cannot read property 'api' of null
geo.createFeature @ init.js:141
createFeature @ featureLayer.js:39
_drawTile @ tileLayer.js:16
drawTile @ tileLayer.js:588
(anonymous function) @ tileLayer.js:960
(anonymous function) @ geo.ext.min.js:2
fire @ geo.ext.min.js:2
self.fireWith @ geo.ext.min.js:2
(anonymous function) @ geo.ext.min.js:2
fire @ geo.ext.min.js:2
self.fireWith @ geo.ext.min.js:2
deferred.(anonymous function) @ geo.ext.min.js:2
_image.onload @ imageTile.js:73

Uncaught TypeError: Cannot read property 'select' of null
_getSubLayer @ tileLayer.js:35
_drawTile @ tileLayer.js:9
drawTile @ tileLayer.js:588
(anonymous function) @ tileLayer.js:960
(anonymous function) @ geo.ext.min.js:2
fire @ geo.ext.min.js:2
self.fireWith @ geo.ext.min.js:2
(anonymous function) @ geo.ext.min.js:2
fire @ geo.ext.min.js:2
self.fireWith @ geo.ext.min.js:2
deferred.(anonymous function) @ geo.ext.min.js:2
_image.onload @ imageTile.js:73
```

The errors from the phantomjs console are more varied:
```
  http://allison.kitware.com:50100/src/core/init.js:141
  http://allison.kitware.com:50100/src/core/featureLayer.js:40
  http://allison.kitware.com:50100/src/gl/tileLayer.js:17
  http://allison.kitware.com:50100/src/core/tileLayer.js:588
  http://allison.kitware.com:50100/src/core/tileLayer.js:960
  http://allison.kitware.com:50100/test/lib/bind-polyfill.js:10
  http://allison.kitware.com:50100/built/geo.ext.min.js:2
  http://allison.kitware.com:50100/built/geo.ext.min.js:2
  http://allison.kitware.com:50100/built/geo.ext.min.js:2
  http://allison.kitware.com:50100/built/geo.ext.min.js:2
  http://allison.kitware.com:50100/built/geo.ext.min.js:2
  http://allison.kitware.com:50100/built/geo.ext.min.js:2
  http://allison.kitware.com:50100/built/geo.ext.min.js:2
  http://allison.kitware.com:50100/src/core/imageTile.js:73
TypeError: 'null' is not an object (evaluating 'm_this.canvas().select')

  http://allison.kitware.com:50100/src/core/init.js:141
  http://allison.kitware.com:50100/src/core/featureLayer.js:40
  http://allison.kitware.com:50100/src/gl/tileLayer.js:17
  http://allison.kitware.com:50100/src/core/tileLayer.js:588
  http://allison.kitware.com:50100/src/core/tileLayer.js:960
  http://allison.kitware.com:50100/test/lib/bind-polyfill.js:10
  http://allison.kitware.com:50100/built/geo.ext.min.js:2
  http://allison.kitware.com:50100/built/geo.ext.min.js:2
  http://allison.kitware.com:50100/built/geo.ext.min.js:2
  http://allison.kitware.com:50100/built/geo.ext.min.js:2
  http://allison.kitware.com:50100/built/geo.ext.min.js:2
  http://allison.kitware.com:50100/built/geo.ext.min.js:2
  http://allison.kitware.com:50100/built/geo.ext.min.js:2
  http://allison.kitware.com:50100/src/core/imageTile.js:73
TypeError: 'null' is not an object (evaluating 'renSt.m_context.getParameter')
```

In all cases, it *looks* like variables in the scope of our promise handlers are garbage collected before they fire.  It does appear to be a race condition because the errors don't always occur, and it is unfortunately one of those quantum-like situations such that attempting to observe the problem causes it to not occur.