### PR TITLE
Check if a renderer is available.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ script:
     - npm install
     - npm run build
     - ./node_modules/.bin/grunt docs
+    - ./node_modules/.bin/grunt copy:jqueryui
     - ./node_modules/.bin/grunt serve-test &
     - sleep 1
     - mkdir _build

--- a/docs/users.rst
+++ b/docs/users.rst
@@ -27,17 +27,21 @@ list of libraries used by GeoJS.
     +---------------------------+------------+---------------------------+
     | `proj4`_                  | 2.2        | Core                      |
     +---------------------------+------------+---------------------------+
-    | `GL matrix`_              | 2.1        | GL renderer               |
+    | `GL matrix`_              | 2.1        | Core, GL renderer         |
     +---------------------------+------------+---------------------------+
-    | `pnltri`_                 | 2.1        | GL renderer               |
+    | `pnltri`_                 | 2.1        | GL polygon feature        |
     +---------------------------+------------+---------------------------+
     | `d3`_                     | 3.3        | D3 renderer, UI widgets   |
     +---------------------------+------------+---------------------------+
 
 .. note::
 
-    The versions listed are what is provided in the bundle,
-    but other versions may work as well.
+    The versions listed are what is provided in the bundle, but other versions
+    may work as well.
+
+.. note::
+    Components used in the core code are strictly required.  Other components
+    can be excluded, though some functions will not work without them.
 
 .. _jQuery: http://jquery.com/
 .. _proj4: http://proj4js.org/
@@ -142,15 +146,17 @@ documentation for each of the classes.
 
 `geo.renderer <http://opengeoscience.github.io/geojs/apidocs/geo.renderer.html>`_
     A renderer is responsible for drawing geometries and images on the map.  This is an
-    abstract class which serves to define the minimal interface for a renderer.  Renderers
-    can provide an extended interface so that they can be used as a *base renderer*.  The
-    base renderer provides support methods for conversion between world and screen coordinates
-    and must respond to the map's request for navigation commands. Every map must have exactly
-    one layer attached to a base renderer.  Currently,
+    abstract class which serves to define the minimal interface for a renderer.
+    Not all features are available in all renderers, and an appropriate
+    renderer must be selected for a layer based on the features that will be
+    used.
+    If a renderer is requested when creating a layer, and that renderer is not
+    supported by the current installation, a fallback renderer may be used
+    instead and a warning sent to the console.
     `geo.gl.vglRenderer <http://opengeoscience.github.io/geojs/apidocs/geo.gl.vglRenderer.html>`_
-    is the only available base renderer.
+    requires webGL support.
     `geo.d3.d3Renderer <http://opengeoscience.github.io/geojs/apidocs/geo.d3.d3Renderer.html>`_
-    is also availabe for renderering features as SVG elements.
+    requires the d3 library to be present.
 
 `geo.layer <http://opengeoscience.github.io/geojs/apidocs/geo.layer.html>`_
     Layer objects are created by the map's ``createLayer`` method.  This is an abstract
@@ -159,7 +165,7 @@ documentation for each of the classes.
 
     `geo.featureLayer <http://opengeoscience.github.io/geojs/apidocs/geo.featureLayer.html>`_
         This is the primary container for features such as lines, points, etc.
-    
+
     `geo.osmLayer <http://opengeoscience.github.io/geojs/apidocs/geo.osmLayer.html>`_
         This layer displays tiled imagery from an openstreetmaps compatible tile server.
 

--- a/src/core/init.js
+++ b/src/core/init.js
@@ -97,7 +97,7 @@ geo.registerRenderer = function (name, func) {
  * Create new instance of the renderer
  */
 //////////////////////////////////////////////////////////////////////////////
-geo.createRenderer  = function (name, layer, canvas, options) {
+geo.createRenderer = function (name, layer, canvas, options) {
   'use strict';
 
   if (geo.renderers.hasOwnProperty(name)) {
@@ -108,6 +108,42 @@ geo.createRenderer  = function (name, layer, canvas, options) {
     return ren;
   }
   return null;
+};
+
+//////////////////////////////////////////////////////////////////////////////
+/**
+ * Check if the named renderer is supported.  If not, display a warning and get
+ * the name of a fallback renderer.  Ideally, we would pass a list of desired
+ * features, and, if the renderer is unavailable, this would choose a fallback
+ * that would support those features.
+ *
+ * @params {string|null} name name of the desired renderer
+ * @params {boolean} noFallack if true, don't recommend a fallback
+ * @return {string|null|false} the name of the renderer that should be used
+ *      of false if no valid renderer can be determined.
+ */
+//////////////////////////////////////////////////////////////////////////////
+geo.checkRenderer = function (name, noFallback) {
+  'use strict';
+  if (name === null) {
+    return name;
+  }
+  if (geo.renderers.hasOwnProperty(name)) {
+    var ren = geo.renderers[name];
+    if (!ren.supported || ren.supported()) {
+      return name;
+    }
+    if (!ren.fallback || noFallback) {
+      return false;
+    }
+    var fallback = geo.checkRenderer(ren.fallback(), true);
+    if (fallback !== false) {
+      console.warn(name + ' renderer is unavailable, using ' + fallback +
+                   ' renderer instead');
+    }
+    return fallback;
+  }
+  return false;
 };
 
 //////////////////////////////////////////////////////////////////////////////

--- a/src/core/layer.js
+++ b/src/core/layer.js
@@ -41,6 +41,8 @@ geo.layer = function (arg) {
       m_attribution = arg.attribution || null,
       m_zIndex;
 
+  m_rendererName = geo.checkRenderer(m_rendererName);
+
   if (!m_map) {
     throw new Error('Layers must be initialized on a map.');
   }
@@ -522,7 +524,9 @@ geo.layer.create = function (map, spec) {
   }
 
   spec.renderer = spec.renderer || 'vgl';
-  if (spec.renderer !== 'd3' && spec.renderer !== 'vgl') {
+  spec.renderer = geo.checkRenderer(spec.renderer);
+
+  if (!spec.renderer) {
     console.warn('Invalid renderer');
     return null;
   }

--- a/src/d3/d3Renderer.js
+++ b/src/d3/d3Renderer.js
@@ -516,3 +516,27 @@ geo.d3.d3Renderer = function (arg) {
 inherit(geo.d3.d3Renderer, geo.renderer);
 
 geo.registerRenderer('d3', geo.d3.d3Renderer);
+
+(function () {
+  'use strict';
+
+  /**
+   * Report if the d3 renderer is supported.  This is just a check if d3 is
+   * available.
+   *
+   * @returns {boolean} true if available.
+   */
+  geo.d3.d3Renderer.supported = function () {
+    return (typeof d3 !== 'undefined');
+  };
+
+  /**
+   * If the d3 renderer is not supported, supply the name of a renderer that
+   * should be used instead.  This asks for the null renderer.
+   *
+   * @returns null for the null renderer.
+   */
+  geo.d3.d3Renderer.fallback = function () {
+    return null;
+  };
+})();

--- a/src/gl/vglRenderer.js
+++ b/src/gl/vglRenderer.js
@@ -220,3 +220,46 @@ geo.gl.vglRenderer = function (arg) {
 inherit(geo.gl.vglRenderer, geo.renderer);
 
 geo.registerRenderer('vgl', geo.gl.vglRenderer);
+
+(function () {
+  'use strict';
+
+  var checkedWebGL;
+
+  /**
+   * Report if the vgl renderer is supported.  This is just a check if webGL is
+   * supported and available.
+   *
+   * @returns {boolean} true if available.
+   */
+  geo.gl.vglRenderer.supported = function () {
+    if (checkedWebGL === undefined) {
+      /* This is extracted from what Modernizr uses. */
+      var canvas, ctx, exts;
+      try {
+        canvas = document.createElement('canvas');
+        ctx = (canvas.getContext('webgl') ||
+               canvas.getContext('experimental-webgl'));
+        exts = ctx.getSupportedExtensions();
+        checkedWebGL = true;
+      } catch (e) {
+        console.error('No webGL support');
+        checkedWebGL = false;
+      }
+      canvas = undefined;
+      ctx = undefined;
+      exts = undefined;
+    }
+    return checkedWebGL;
+  };
+
+  /**
+   * If the vgl renderer is not supported, supply the name of a renderer that
+   * should be used instead.  This asks for the null renderer.
+   *
+   * @returns null for the null renderer.
+   */
+  geo.gl.vglRenderer.fallback = function () {
+    return null;
+  };
+})();

--- a/src/plugin/jquery-plugin.js
+++ b/src/plugin/jquery-plugin.js
@@ -452,5 +452,11 @@
 
   };
 
+  /* Provide a method to reload the plugin in case jquery-ui is loaded after
+   * the plugin. */
+  geo.jqueryPlugin = {reload: load};
+
   $(load);
-})($ || window.$, geo || window.geo, d3 || window.d3);
+})(typeof $ !== 'undefined' ? $ : window.$,
+   typeof geo !== 'undefined' ? geo : window.geo,
+   typeof d3 !== 'undefined' ? d3 : window.d3);

--- a/src/util/scales.js
+++ b/src/util/scales.js
@@ -2,6 +2,6 @@
   'use strict';
 
   geo.util.scale = {
-    d3: d3.scale
+    d3: typeof d3 !== 'undefined' ? d3.scale : undefined
   };
 })();

--- a/testing/js/testUtils.js
+++ b/testing/js/testUtils.js
@@ -133,6 +133,9 @@ function mockVGLRenderer() {
   vgl.renderWindow = function () {
     return m_renderWindow;
   };
+  geo.gl.vglRenderer.supported = function () {
+    return true;
+  };
 
   vgl._mocked = true;
 }

--- a/testing/test-cases/phantomjs-tests/jqueryPlugin.js
+++ b/testing/test-cases/phantomjs-tests/jqueryPlugin.js
@@ -1,0 +1,87 @@
+// Test plugin.jquery-plugin
+/*global describe, it, expect, beforeEach, mockVGLRenderer*/
+
+describe('plugin.jquery-plugin', function () {
+  'use strict';
+  function create_map() {
+    var node = $('<div id="map"/>').css({width: '500px', height: '500px'});
+    $('#map').remove();
+    $('body').append(node);
+    $('#map').geojsMap({
+      center: {latitude: 10, longitude: -10},
+      zoom: 4.1,
+      url: '/data/grid.jpg',
+      attribution: null,
+      layers: [{
+        renderer: 'vgl',
+        features: [{
+          type: 'point',
+          data: [{x: 10, y: -10}],
+          radius: 50,
+          fill: true,
+          fillColor: 'brown',
+          fillOpacity: 0.5,
+          stroke: true,
+          strokeColor: '#ffebcd',
+          strokeWidth: 10
+        }, {
+          data: [[{x: 7, y: -7}, {x: -7, y: 14}]],
+          type: 'line',
+          strokeWidth: 5,
+          strokeColor: 'darkorange',
+          strokeOpacity: 0.75
+        }]
+      }, {
+        renderer: 'd3',
+        features: [{
+          type: 'line',
+          data: [[{x: -10, y: 10}, {x: -20, y: 15}, {x: -30, y: 20}, {x: -40, y: 25}]],
+          strokeColor: 'slategrey',
+          strokeWidth: 10
+        }, {
+          type: 'point',
+          data: [{x: -10, y: 10}, {x: -20, y: 15}, {x: -30, y: 20}, {x: -40, y: 25}],
+          size: function (d, i) { return [0.1, 0.11, 0.111, 0.1111][i]; },
+          radius: 100,
+          fillColor: function (d, i) { return 'a' + i.toString(); },
+          fillOpacity: 1,
+          strokeColor: 'midnightblue',
+          strokeWidth: 5,
+          strokeOpacity: 0.5
+        }, {
+          type: 'point',
+          data: [{x: 10, y: 15}],
+          size: 10000,
+          fillColor: 'black',
+          fillOpacity: 1,
+          strokeColor: 'lightgrey',
+          strokeWidth: 2
+        }]
+      }]
+    });
+  }
+
+  describe('without jquery-ui', function () {
+    it('geojsMap', function () {
+      mockVGLRenderer();
+      expect(function () { create_map(); }).toThrow(new Error(
+        'The geojs jquery plugin requires jquery ui to be available.'
+      ));
+    });
+  });
+  describe('initial usage', function () {
+    /* This affects future describe() functions, too */
+    beforeEach(function (done) {
+      $.getScript(['/examples/common/js/jquery-ui.min.js'], function () {
+        $(geo.jqueryPlugin.reload);
+        mockVGLRenderer();
+        done();
+      });
+    });
+    it('geojsMap', function () {
+      create_map();
+      expect($('#map .webgl-canvas').length).toBe(2);
+      expect($('#map g circle').length).toBeGreaterThan(0);
+    });
+  });
+});

--- a/testing/test-cases/phantomjs-tests/map.js
+++ b/testing/test-cases/phantomjs-tests/map.js
@@ -5,7 +5,7 @@ describe('geo.core.map', function () {
   'use strict';
 
   function create_map(opts) {
-    var node = $('<div class="#map"/>').css({width: '500px', height: '500px'});
+    var node = $('<div id="map"/>').css({width: '500px', height: '500px'});
     $('#map').remove();
     $('body').append(node);
     opts = $.extend({}, opts);

--- a/testing/test-cases/phantomjs-tests/osmLayer.js
+++ b/testing/test-cases/phantomjs-tests/osmLayer.js
@@ -4,7 +4,7 @@
 describe('geo.core.osmLayer', function () {
   'use strict';
   function create_map(opts) {
-    var node = $('<div class="#map"/>');
+    var node = $('<div id="map"/>');
     $('#map').remove();
     $('body').append(node);
     opts = $.extend({}, opts);

--- a/testing/test-cases/phantomjs-tests/renderers.js
+++ b/testing/test-cases/phantomjs-tests/renderers.js
@@ -1,0 +1,67 @@
+// Test renderer functions
+/*global describe, it, expect, geo, mockVGLRenderer*/
+
+describe('renderers', function () {
+  'use strict';
+
+  var supported = true;
+  var fallback = 'd3';
+
+  function create_simple_renderer() {
+    var simpleRenderer = function (arg) {
+      if (!(this instanceof simpleRenderer)) {
+        /* jshint newcap: false */
+        return new simpleRenderer(arg);
+        /* jshint newcap: true */
+      }
+      geo.renderer.call(this, arg);
+      this._init(arg);
+      return this;
+    };
+    inherit(simpleRenderer, geo.renderer);
+
+    geo.registerRenderer('simple', simpleRenderer);
+
+    simpleRenderer.supported = function () {
+      return supported;
+    };
+
+    simpleRenderer.fallback = function () {
+      return fallback;
+    };
+  }
+
+  describe('basic functions', function () {
+    it('geo.createRenderer', function () {
+      create_simple_renderer();
+      expect(geo.createRenderer('simple')).not.toBe(null);
+      expect(geo.createRenderer('unknown')).toBe(null);
+    });
+    it('geo.checkRenderer', function () {
+      expect(geo.checkRenderer('simple')).toBe('simple');
+      expect(geo.checkRenderer('simple', true)).toBe('simple');
+      supported = false;
+      expect(geo.checkRenderer('simple')).toBe('d3');
+      expect(geo.checkRenderer('simple', true)).toBe(false);
+      fallback = 'unknown';
+      expect(geo.checkRenderer('simple')).toBe(false);
+      supported = true;
+      expect(geo.checkRenderer('simple')).toBe('simple');
+
+      expect(geo.checkRenderer(null)).toBe(null);
+
+      expect(geo.checkRenderer('d3')).toBe('d3');
+      var oldd3 = window.d3;
+      window.d3 = undefined;
+      expect(geo.checkRenderer('d3')).toBe(null);
+      window.d3 = oldd3;
+      expect(geo.checkRenderer('d3')).toBe('d3');
+
+      expect(geo.checkRenderer('vgl')).toBe(null);
+      mockVGLRenderer();
+      expect(geo.checkRenderer('vgl')).toBe('vgl');
+
+      expect(geo.checkRenderer('unknown')).toBe(false);
+    });
+  });
+});

--- a/testing/test-cases/phantomjs-tests/tileLayer.js
+++ b/testing/test-cases/phantomjs-tests/tileLayer.js
@@ -1,6 +1,6 @@
 // Test geo.tileLayer
 
-/*global describe, it, expect, geo*/
+/*global describe, it, expect, geo, mockVGLRenderer*/
 describe('geo.tileLayer', function () {
   'use strict';
 
@@ -97,6 +97,7 @@ describe('geo.tileLayer', function () {
 
     describe('center: (0, 0)', function () {
       it('origin: (0, 0), zoom level: 0', function () {
+        mockVGLRenderer();
         var l = get_layer({x: 0, y: 0}),
             s = l.map().unitsPerPixel();
         expect(l.tileAtPoint({x: 128 * s, y: 128 * s}, 0)).toEqual({x: 0, y: 0});
@@ -282,7 +283,7 @@ describe('geo.tileLayer', function () {
   describe('toLocal/fromLocal', function () {
     var opts = {},
         m = map(opts),
-        l = geo.tileLayer({map: m});
+        l = geo.tileLayer({map: m, renderer: null});
 
     it('Should not depend on map origin', function () {
       function check(p) {


### PR DESCRIPTION
If not, optionally use a fallback.

This is largely intended to fallback when webGL is unavailable, but it also has the feature that d3 is no longer a hard requirement.

Add a simple phantom test for the jquery-plugin.

Also, added a reload function for the jquery-plugin, mainly to facilitate testing.  This could also help lazy-loading in some instances.

Addresses issue #312.