### PR TITLE
Fix some tile related bugs.

### DIFF
--- a/src/core/fetchQueue.js
+++ b/src/core/fetchQueue.js
@@ -135,6 +135,15 @@
     };
 
     /**
+     * Get the position of a deferred object in the queue.
+     * @param {Deferred} defer Deferred object to get the position of.
+     * @returns {number} -1 if not in the queue, or the position in the queue.
+     */
+    this.get = function (defer) {
+      return $.inArray(defer, this._queue);
+    };
+
+    /**
      * Remove a Deferred object from the queue.
      * @param {Deferred} defer Deferred object to add to the queue.
      * @returns {bool} true if the object was removed

--- a/src/core/tileCache.js
+++ b/src/core/tileCache.js
@@ -102,8 +102,11 @@
     /**
      * Add a tile to the cache.
      * @param {geo.tile} tile
+     * @param {function} removeFunc if specified and tiles must be purged from
+     *      the cache, call this function on each tile before purging.
+     * @param {boolean} noPurge if true, don't purge tiles.
      */
-    this.add = function (tile) {
+    this.add = function (tile, removeFunc, noPurge) {
       // remove any existing tiles with the same hash
       this.remove(tile);
       var hash = tile.toString();
@@ -112,9 +115,24 @@
       this._cache[hash] = tile;
       this._atime.unshift(hash);
 
-      // purge a tile from the cache if necessary
+      if (!noPurge) {
+        this.purge(removeFunc);
+      }
+    };
+
+    /**
+     * Purge tiles from the cache if it is full.
+     * @param {function} removeFunc if specified and tiles must be purged from
+     *      the cache, call this function on each tile before purging.
+     */
+    this.purge = function (removeFunc) {
+      var hash;
       while (this._atime.length > this.size) {
         hash = this._atime.pop();
+        var tile = this._cache[hash];
+        if (removeFunc) {
+          removeFunc(tile);
+        }
         delete this._cache[hash];
       }
     };

--- a/testing/test-cases/phantomjs-tests/fetchQueue.js
+++ b/testing/test-cases/phantomjs-tests/fetchQueue.js
@@ -50,12 +50,14 @@ describe('geo.core.fetchQueue', function () {
       expect(q.length).toBe(2);
       expect(q.processing).toBe(2);
       expect(q._queue[0]).toBe(dlist[3]);
+      expect(q.get(dlist[3])).toBe(0);
 
       // adding an existing item should move it to the front
       q.add(dlist[2], dlist[2].process);
       expect(q.length).toBe(2);
       expect(q.processing).toBe(2);
       expect(q._queue[0]).toBe(dlist[2]);
+      expect(q.get(dlist[2])).toBe(0);
 
       expect(q.remove(dlist[2])).toBe(true);
       expect(q.length).toBe(1);
@@ -136,14 +138,18 @@ describe('geo.core.fetchQueue', function () {
         [13, 11, 9, 7, 5],
         [13, 11, 9, 7, 5]
       ];
-      var dlist = [], i, reportOrder = [1, 3, 11, 13, 7, 9, 5];
+      var dlist = [], i, j, reportOrder = [1, 3, 11, 13, 7, 9, 5];
 
       for (i = 0; i < 14; i += 1) {
         dlist.push(make_deferred());
         q.add(dlist[i], dlist[i].process);
         expect(q.length).toBe(qrefs[i].length);
-        for (var j = 0; j < q.length; j += 1) {
+        for (j = 0; j < q.length; j += 1) {
           expect(q._queue[j].ref).toBe(qrefs[i][j]);
+          expect(q.get(dlist[qrefs[i][j] - 1])).toBe(j);
+        }
+        for (j = 0; j < dlist.length; j += 1) {
+          expect(q.get(dlist[j])).toBe($.inArray(dlist[j].ref, qrefs[i]));
         }
       }
 

--- a/testing/test-cases/phantomjs-tests/tileCache.js
+++ b/testing/test-cases/phantomjs-tests/tileCache.js
@@ -132,4 +132,44 @@ describe('geo.tileCache', function () {
     expect(cache.get('1')).toBe(null);
     expect(cache.get('2')).toBe(null);
   });
+  it('cache.purge', function () {
+    var cache = geo.tileCache({size: 2});
+
+    cache.add(1, undefined, true);
+    cache.add(2, undefined, true);
+    expect(cache.length).toBe(2);
+    cache.add(3, undefined, true);
+    expect(cache.length).toBe(3);
+    cache.remove(3);
+    expect(cache.length).toBe(2);
+    cache.add(4, undefined, true);
+    expect(cache.length).toBe(3);
+    cache.purge();
+    expect(cache.length).toBe(2);
+    cache.add(5);
+    expect(cache.length).toBe(2);
+  });
+  it('cache.purge removeFunc', function () {
+    var cache = geo.tileCache({size: 2});
+    var removalInfo = [];
+    var removeFunc = function (item) {
+      removalInfo.push(item);
+    };
+    cache.add(1, removeFunc);
+    cache.add(2, removeFunc);
+    cache.add(3, removeFunc);
+    expect(removalInfo.length).toBe(1);
+    expect(removalInfo[0]).toBe(1);
+    cache.add(4, removeFunc, true);
+    expect(removalInfo.length).toBe(1);
+    cache.purge();
+    expect(removalInfo.length).toBe(1);
+    cache.add(5);
+    expect(removalInfo.length).toBe(1);
+    cache.add(6, removeFunc, true);
+    expect(removalInfo.length).toBe(1);
+    cache.purge(removeFunc);
+    expect(removalInfo.length).toBe(2);
+    expect(removalInfo[1]).toBe(4);
+  });
 });


### PR DESCRIPTION
There was the possibility of getting a tile 'stuck' on the map.  This was caused by removing tiles from the tileCache when we weren't truly done with some tiles and not calling the _remove function on those tiles.  This was fixed by calling the remove function when removing tiles from the cache.

There was a problem where we could discard a tile we wanted, only to re-add it almost immediately.  This occurred when there was a comparatively large amount of tile churn compared to the tileCache size.  As new tiles were added to the tile cache, old tiles were removed from the cache.  If a new tile was the same as an old tile but was of low priority, all of the high priority new tiles would be added, pushing the old reference to low priority out of the cache.  Now, tiles are all added to the cache *before* the cache is purged of excess tiles.

Fixed a tile load order issue that could occur under high tile churn.  If a tile was already in the fetch queue, it wasn't properly added to the front of the fetch queue.

Made the tileCache automatically grow if it is smaller than the minimum size we need to hold all rendered tiles.

Add more tests to the fetchQueue, tileCache, and tileLayer.