### PR TITLE
Map rotation

### DIFF
--- a/examples/common/css/examples.css
+++ b/examples/common/css/examples.css
@@ -1,6 +1,12 @@
 html, body {
   height: 100%;
   width: 100%;
+  -webkit-touch-callout: none;
+  -webkit-user-select: none;
+  -khtml-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
 }
 
 #map {

--- a/examples/common/templates/index.jade
+++ b/examples/common/templates/index.jade
@@ -2,6 +2,7 @@ doctype html
 html(lang="en")
   head
     meta(charset="UTF-8")
+    link(rel="shortcut icon" href="data:image/x-icon;," type="image/x-icon")
     title= title
 
     // Include common files

--- a/examples/tiles/index.jade
+++ b/examples/tiles/index.jade
@@ -35,6 +35,16 @@ block append mainContent
     .form-group(title="The starting zoom level.  Changing this will also change the current zoom level.")
       label(for="map-zoom") Starting Zoom
       input#map-zoom.mapparam(param-name="zoom", placeholder="3")
+    .form-group(title="Allow the map to be rotated.")
+      label(for="map-allowRotation") Allow Rotation
+      select#map-allowRotation.mapparam(param-name="allowRotation", placeholder="true")
+        option(value="true") Yes
+        option(value="false") No
+        option(value="90") 90&deg; increments
+        option(value="30") 30&deg; increments
+        option(value="15") 15&deg; increments
+        option(value="5") 5&deg; increments
+        option(value="1") 1&deg; increments
 
     .form-group(title="The url used to fetch tiles.  Use {x}, {y}, {z}, and {s} for templating.")
       label(for="layer-url") Tile URL

--- a/examples/tiles/main.css
+++ b/examples/tiles/main.css
@@ -1,6 +1,13 @@
-#map.debug-border .geo-tile-container img {
+#map.debug-border .geo-tile-container:before {
+    content: "";
     box-sizing: inherit;
     border: 4px solid rgba(0,0,0,0.25);
+    position: absolute;
+    top: 0;
+    left: 0;
+    bottom: 0;
+    right: 0;
+    z-index: 1;
 }
 #map.debug-label .geo-tile-container:after {
     content: attr(tile-reference);
@@ -8,6 +15,7 @@
     top: 5px;
     left: 10px;
     font-size: 30px;
+    line-height: 1.3em;
     color: black;
 }
 @keyframes imgfadein {

--- a/examples/tiles/main.js
+++ b/examples/tiles/main.js
@@ -1,6 +1,8 @@
 // This example should be tried with different query strings.
 
 /* Many parameters can be adjusted via url query parameters:
+ *  allowRotation: 'true' to allow map rotation, 'false' to prevent it, or
+ *      allowable rotations in degrees.
  *  attribution: override the layer attribution text.
  *  clampBoundsX: 'true' to clamp movement in the horizontal direction.
  *  clampBoundsY: 'true' to clamp movement in the vertical direction.
@@ -19,6 +21,10 @@
  *  min: minimum zoom level (default is 0).
  *  max: maximum zoom level (default is 16 for maps, or the entire image for
  *      images).
+ *  maxBoundsBottom: maximum bounds bottom value.
+ *  maxBoundsLeft: maximum bounds left value.
+ *  maxBoundsRight: maximum bounds right value.
+ *  maxBoundsTop: maximum bounds top value.
  *  opacity: a css opacity value (typically a float from 0 to 1).
  *  projection: 'parallel' or 'projection' for the camera projection.
  *  renderer: 'vgl' (default), 'd3', 'null', or 'html'.  This picks the
@@ -27,6 +33,7 @@
  *  subdomains: a comma-separated string of subdomains to use in the {s} part
  *      of the url parameter.  If there are no commas in the string, each letter
  *      is used by itself (e.g., 'abc' is the same as 'a,b,c').
+ *  unitsPerPixel: set the units per pixel at zoom level 0.
  *  url: url to use for the map files.  Placeholders are allowed.  Default is
  *      http://otile1.mqcdn.com/tiles/1.0.0/map/{z}/{x}/{y}.png .  Other useful
  *      urls are are: /data/tilefancy.png
@@ -92,6 +99,7 @@ $(function () {
       x: -98.0,
       y: 39.5
     },
+    maxBounds: {},
     zoom: query.zoom !== undefined ? parseFloat(query.zoom) : 3
   };
   // Set the tile layer defaults to use the specified renderer and opacity
@@ -157,6 +165,21 @@ $(function () {
   if (query.min !== undefined) {
     mapParams.min = parseFloat(query.min);
   }
+  if (query.maxBoundsLeft !== undefined) {
+    mapParams.maxBounds.left = parseFloat(query.maxBoundsLeft);
+  }
+  if (query.maxBoundsRight !== undefined) {
+    mapParams.maxBounds.right = parseFloat(query.maxBoundsRight);
+  }
+  if (query.maxBoundsTop !== undefined) {
+    mapParams.maxBounds.top = parseFloat(query.maxBoundsTop);
+  }
+  if (query.maxBoundsBottom !== undefined) {
+    mapParams.maxBounds.bottom = parseFloat(query.maxBoundsBottom);
+  }
+  if (query.allowRotation) {
+    mapParams.allowRotation = get_allow_rotation(query.allowRotation);
+  }
   if (query.attribution !== undefined) {
     layerParams.attribution = query.attribution;
   }
@@ -186,6 +209,9 @@ $(function () {
     // unitsPerPixel is at zoom level 0.  We want each pixel to be 1 at the
     // maximum zoom
     mapParams.unitsPerPixel = Math.pow(2, mapParams.max);
+  }
+  if (query.unitsPerPixel !== undefined) {
+    mapParams.unitsPerPixel = parseFloat(query.unitsPerPixel);
   }
   // Populate boolean flags for the map
   $.each({
@@ -249,6 +275,10 @@ $(function () {
     var processedValue = (ctl.is('[type="checkbox"]') ?
         (value === 'true') : value);
     switch (param) {
+      case 'allowRotation':
+        mapParams.allowRotation = get_allow_rotation(value);
+        map.allowRotation(mapParams.allowRotation);
+        break;
       case 'debug':
         $('#map').toggleClass('debug-label', (
             value === 'true' || value === 'all'))
@@ -325,5 +355,19 @@ $(function () {
     var newurl = window.location.protocol + '//' + window.location.host +
         window.location.pathname + '?' + $.param(query);
     window.history.replaceState(query, '', newurl);
+  }
+
+  /* Return the value to set for the allowRotation parameter.
+   * @param value the value in the query string.
+   * @returns true, false, or a function.
+   */
+  function get_allow_rotation(value) {
+    if (!parseFloat(value)) {
+      return value !== 'false';
+    }
+    return function (rotation) {
+      var factor = 180 / Math.PI / parseFloat(value);
+      return Math.round(rotation * factor) / factor;
+    };
   }
 });

--- a/examples/transitions/index.jade
+++ b/examples/transitions/index.jade
@@ -6,4 +6,4 @@ block append mainContent
     button#elastic-to-moscow Elastic to Moscow
     button#bounce-to-istanbul Bounce to Istanbul
     button#fly-to-bern Fly to Bern
-
+    button#spin-to-budapest Spin to Budapest

--- a/examples/transitions/main.js
+++ b/examples/transitions/main.js
@@ -10,7 +10,7 @@ $(function () {
   });
 
   // Add an OSM layer
-  var osm = map.createLayer('osm',{
+  var osm = map.createLayer('osm', {
     baseUrl: 'http://otile1.mqcdn.com/tiles/1.0.0/map'
   });
 
@@ -61,6 +61,14 @@ $(function () {
       center: {x: 7.4500, y: 46.9500},
       duration: 2000,
       interp: d3.interpolateZoom
+    });
+  });
+
+  $('#spin-to-budapest').click(function () {
+    map.transition({
+      center: {x: 19.0514, y: 47.4925},
+      rotation: Math.PI * 2,
+      duration: 2000
     });
   });
 });

--- a/src/core/event.js
+++ b/src/core/event.js
@@ -71,8 +71,8 @@ geo.event.zoom = 'geo_zoom';
 
 //////////////////////////////////////////////////////////////////////////////
 /**
- * Triggered when the map is rotated around the map center (pointing downward
- * so that positive angles are clockwise rotations).
+ * Triggered when the map is rotated around the current map center (pointing
+ * downward so that positive angles are clockwise rotations).
  *
  * @property {number} angle The angle of the rotation in radians
  */

--- a/src/core/event.js
+++ b/src/core/event.js
@@ -32,7 +32,6 @@ geo.event = {};
 //
 // geo.event.update = 'geo_update';
 // geo.event.opacityUpdate = 'geo_opacityUpdate';
-// geo.event.layerToggle = 'geo_layerToggle';
 // geo.event.layerSelect = 'geo_layerSelect';
 // geo.event.layerUnselect = 'geo_layerUnselect';
 // geo.event.query = 'geo_query';

--- a/src/core/featureLayer.js
+++ b/src/core/featureLayer.js
@@ -101,12 +101,23 @@ geo.featureLayer = function (arg) {
 
     /// Bind events to handlers
     m_this.geoOn(geo.event.resize, function (event) {
-      m_this.renderer()._resize(event.x, event.y, event.width, event.height);
-      m_this._update({event: event});
-      m_this.renderer()._render();
+      if (m_this.renderer()) {
+        m_this.renderer()._resize(event.x, event.y, event.width, event.height);
+        m_this._update({event: event});
+        m_this.renderer()._render();
+      } else {
+        m_this._update({event: event});
+      }
     });
 
     m_this.geoOn(geo.event.pan, function (event) {
+      m_this._update({event: event});
+      if (m_this.renderer()) {
+        m_this.renderer()._render();
+      }
+    });
+
+    m_this.geoOn(geo.event.rotate, function (event) {
       m_this._update({event: event});
       if (m_this.renderer()) {
         m_this.renderer()._render();

--- a/src/core/layer.js
+++ b/src/core/layer.js
@@ -387,6 +387,10 @@ geo.layer = function (arg) {
         m_this._update({event: event});
       });
 
+      m_this.geoOn(geo.event.rotate, function (event) {
+        m_this._update({event: event});
+      });
+
       m_this.geoOn(geo.event.zoom, function (event) {
         m_this._update({event: event});
       });

--- a/src/core/map.js
+++ b/src/core/map.js
@@ -531,7 +531,6 @@ geo.map = function (arg) {
 
     if (layer !== null && layer !== undefined) {
       layer._exit();
-
       m_this.removeChild(layer);
 
       m_this.modified();

--- a/src/core/map.js
+++ b/src/core/map.js
@@ -33,6 +33,7 @@
  * @param {object?} center Map center
  * @param {number} [center.x=0]
  * @param {number} [center.y=0]
+ * @param {number} [rotation=0] Clockwise rotation in radians
  * @param {number?} width The map width (default node width)
  * @param {number?} height The map height (default node height)
  *
@@ -42,6 +43,10 @@
  * @param {number} [max=16]  Maximum zoom level
  * @param {boolean} [discreteZoom=false]  True to only allow integer zoom
  *   levels.  False for any zoom level.
+ * @param {boolean} [allowRotation=true]  False prevents rotation, true allows
+ *   any rotation.  If a function, the function is called with a rotation
+ *   (angle in radians) and returns a valid rotation (this can be used to
+ *   constrain the rotation to a range or specific values).
  *
  * *** Advanced parameters ***
  * @param {geo.camera?} camera The camera to control the view
@@ -85,6 +90,7 @@ geo.map = function (arg) {
       m_ingcs = arg.ingcs === undefined ? 'EPSG:4326' : arg.ingcs,
       m_center = {x: 0, y: 0},
       m_zoom = arg.zoom === undefined ? 4 : arg.zoom,
+      m_rotation = 0,
       m_fileReader = null,
       m_interactor = null,
       m_validZoomRange = {min: 0, max: 16, origMin: 0},
@@ -92,6 +98,9 @@ geo.map = function (arg) {
       m_queuedTransition = null,
       m_clock = null,
       m_discreteZoom = arg.discreteZoom ? true : false,
+      m_allowRotation = (typeof arg.allowRotation === 'function' ?
+                         arg.allowRotation : (arg.allowRotation === undefined ?
+                         true : !!arg.allowRotation)),
       m_maxBounds = arg.maxBounds || {},
       m_camera = arg.camera || geo.camera(),
       m_unitsPerPixel,
@@ -99,7 +108,7 @@ geo.map = function (arg) {
       m_clampBoundsY,
       m_clampZoom,
       m_origin,
-      m_scale = {x: 1, y: 1, z: 1}; // constant for the moment
+      m_scale = {x: 1, y: 1, z: 1}; // constant and ignored for the moment
 
   /* Compute the maximum bounds on our map projection.  By default, x ranges
    * from [-180, 180] in the interface projection, and y matches the x range in
@@ -212,6 +221,28 @@ geo.map = function (arg) {
 
   ////////////////////////////////////////////////////////////////////////////
   /**
+   * Get/set the allowRotation setting.  If changed, adjust the map as needed.
+   *
+   * @param {boolean|function} allowRotation the new allowRotation value.
+   * @returns {boolean|function|this}
+   */
+  ////////////////////////////////////////////////////////////////////////////
+  this.allowRotation = function (allowRotation) {
+    if (allowRotation === undefined) {
+      return m_allowRotation;
+    }
+    if (typeof allowRotation !== 'function') {
+      allowRotation = !!allowRotation;
+    }
+    if (allowRotation !== m_allowRotation) {
+      m_allowRotation = allowRotation;
+      m_this.rotation(m_rotation);
+    }
+    return m_this;
+  };
+
+  ////////////////////////////////////////////////////////////////////////////
+  /**
    * Get the map's world coordinate origin in gcs coordinates
    *
    * @returns {object}
@@ -307,10 +338,10 @@ geo.map = function (arg) {
 
     m_zoom = val;
 
-    bounds = m_this.boundsFromZoomAndCenter(val, m_center, null);
+    bounds = m_this.boundsFromZoomAndCenter(val, m_center, m_rotation, null);
     m_this.modified();
 
-    camera_bounds(bounds);
+    camera_bounds(bounds, m_rotation);
     evt = {
       geo: {},
       zoomLevel: m_zoom,
@@ -344,16 +375,21 @@ geo.map = function (arg) {
 
     unit = m_this.unitsPerPixel(m_zoom);
 
+    var sinr = Math.sin(m_rotation), cosr = Math.cos(m_rotation);
     m_camera.pan({
-      x: delta.x * unit,
-      y: -delta.y * unit
+      x: (delta.x * cosr - (-delta.y) * sinr) * unit,
+      y: (delta.x * sinr + (-delta.y) * cosr) * unit
     });
     /* If m_clampBounds* is true, clamp the pan */
-    var bounds = fix_bounds(m_camera.bounds);
+    var bounds = fix_bounds(m_camera.bounds, m_rotation);
     if (bounds !== m_camera.bounds) {
       var panPos = m_this.gcsToDisplay({
             x: m_camera.bounds.left, y: m_camera.bounds.top}, null);
-      camera_bounds(bounds);
+      bounds = m_this.boundsFromZoomAndCenter(m_zoom, {
+        x: (bounds.left + bounds.right) / 2,
+        y: (bounds.top + bounds.bottom) / 2
+      }, m_rotation, null);
+      camera_bounds(bounds, m_rotation);
       var clampPos = m_this.gcsToDisplay({
             x: m_camera.bounds.left, y: m_camera.bounds.top}, null);
       evt.screenDelta.x += clampPos.x - panPos.x;
@@ -368,6 +404,53 @@ geo.map = function (arg) {
     m_this.geoTrigger(geo.event.pan, evt);
 
     m_this.modified();
+    return m_this;
+  };
+
+  ////////////////////////////////////////////////////////////////////////////
+  /**
+   * Get/set the map rotation.  The rotation is performed around the current
+   * view center.
+   *
+   * @param {Object} rotation angle in radians (positive is clockwise)
+   * @param {Object} origin is specified, rotate about this origin
+   * @param {boolean} ignoreRotationFunc if true, don't constrain the rotation.
+   * @returns {geo.map}
+   */
+  ////////////////////////////////////////////////////////////////////////////
+  this.rotation = function (rotation, origin, ignoreRotationFunc) {
+    if (rotation === undefined) {
+      return m_rotation;
+    }
+    rotation = fix_rotation(rotation, ignoreRotationFunc);
+    if (rotation === m_rotation) {
+      return m_this;
+    }
+    m_rotation = rotation;
+
+    var bounds = m_this.boundsFromZoomAndCenter(
+        m_zoom, m_center, m_rotation, null);
+    m_this.modified();
+
+    camera_bounds(bounds, m_rotation);
+
+    var evt = {
+      geo: {},
+      rotation: m_rotation,
+      screenPosition: origin ? origin.map : undefined
+    };
+
+    m_this.geoTrigger(geo.event.rotate, evt);
+
+    if (origin && origin.geo && origin.map) {
+      var shifted = m_this.gcsToDisplay(origin.geo);
+      m_this.pan({x: origin.map.x - shifted.x, y: origin.map.y - shifted.y});
+    } else {
+      m_this.pan({x: 0, y: 0});
+    }
+    /* Changing the rotation can change our minimum zoom */
+    reset_minimum_zoom();
+    m_this.zoom(m_zoom);
     return m_this;
   };
 
@@ -394,7 +477,8 @@ geo.map = function (arg) {
     // get the screen coordinates of the new center
     m_center = $.extend({}, m_this.gcsToWorld(coordinates, gcs));
 
-    camera_bounds(m_this.boundsFromZoomAndCenter(m_zoom, m_center, null));
+    camera_bounds(m_this.boundsFromZoomAndCenter(
+        m_zoom, m_center, m_rotation, null), m_rotation);
     // trigger a pan event
     m_this.geoTrigger(
       geo.event.pan,
@@ -506,6 +590,29 @@ geo.map = function (arg) {
     }
     m_this.resize(0, 0, arg.width, arg.height);
     return m_this;
+  };
+
+  ////////////////////////////////////////////////////////////////////////////
+  /**
+   * Get the rotated size of the map.  This is the width and height of the
+   * non-rotated area necessary to enclose the rotated area in pixels.
+   *
+   * @returns {Object} An object containing width and height as keys
+   */
+  ////////////////////////////////////////////////////////////////////////////
+  this.rotatedSize = function () {
+    if (!this.rotation()) {
+      return {
+        width: m_width,
+        height: m_height
+      };
+    }
+    var bds = rotate_bounds_center(
+        {x: 0, y: 0}, {width: m_width, height: m_height}, this.rotation());
+    return {
+      width: Math.abs(bds.right - bds.left),
+      height: Math.abs(bds.top - bds.bottom)
+    };
   };
 
   ////////////////////////////////////////////////////////////////////////////
@@ -864,13 +971,14 @@ geo.map = function (arg) {
 
   ////////////////////////////////////////////////////////////////////////////
   /**
-   * Start an animated zoom/pan.
+   * Start an animated zoom/pan/rotate.
    *
    * Options:
    * <pre>
    *   opts = {
    *     center: { x: ... , y: ... } // the new center
    *     zoom: ... // the new zoom level
+   *     rotation: ... // the new rotation angle
    *     duration: ... // the duration (in ms) of the transition
    *     ease: ... // an easing function [0, 1] -> [0, 1]
    *   }
@@ -902,11 +1010,11 @@ geo.map = function (arg) {
     }
     function defaultInterp(p0, p1) {
       return function (t) {
-        return [
-          interp1(p0[0], p1[0], t),
-          interp1(p0[1], p1[1], t),
-          interp1(p0[2], p1[2], t)
-        ];
+        var result = [];
+        $.each(p0, function (idx) {
+          result.push(interp1(p0[idx], p1[idx], t));
+        });
+        return result;
       };
     }
 
@@ -923,6 +1031,7 @@ geo.map = function (arg) {
     var defaultOpts = {
       center: m_this.center(undefined, null),
       zoom: m_this.zoom(),
+      rotation: m_this.rotation(),
       duration: 1000,
       ease: function (t) {
         return t;
@@ -945,11 +1054,13 @@ geo.map = function (arg) {
     m_transition = {
       start: {
         center: m_this.center(undefined, null),
-        zoom: m_this.zoom()
+        zoom: m_this.zoom(),
+        rotation: m_this.rotation()
       },
       end: {
         center: defaultOpts.center,
-        zoom: fix_zoom(defaultOpts.zoom)
+        zoom: fix_zoom(defaultOpts.zoom),
+        rotation: fix_rotation(defaultOpts.rotation, undefined, true)
       },
       ease: defaultOpts.ease,
       zCoord: defaultOpts.zCoord,
@@ -962,12 +1073,14 @@ geo.map = function (arg) {
         [
           m_transition.start.center.x,
           m_transition.start.center.y,
-          zoom2z(m_transition.start.zoom)
+          zoom2z(m_transition.start.zoom),
+          m_transition.start.rotation
         ],
         [
           m_transition.end.center.x,
           m_transition.end.center.y,
-          zoom2z(m_transition.end.zoom)
+          zoom2z(m_transition.end.zoom),
+          m_transition.end.rotation
         ]
       );
     } else {
@@ -975,12 +1088,14 @@ geo.map = function (arg) {
         [
           m_transition.start.center.x,
           m_transition.start.center.y,
-          m_transition.start.zoom
+          m_transition.start.zoom,
+          m_transition.start.rotation
         ],
         [
           m_transition.end.center.x,
           m_transition.end.center.y,
-          m_transition.end.zoom
+          m_transition.end.zoom,
+          m_transition.end.rotation
         ]
       );
     }
@@ -998,6 +1113,7 @@ geo.map = function (arg) {
         if (!next) {
           m_this.center(m_transition.end.center, null);
           m_this.zoom(m_transition.end.zoom);
+          m_this.rotation(fix_rotation(m_transition.end.rotation));
         }
 
         m_transition = null;
@@ -1033,6 +1149,7 @@ geo.map = function (arg) {
         m_center = m_this.gcsToWorld({x: p[0], y: p[1]}, null);
         m_this.zoom(p[2], undefined, true);
       }
+      m_this.rotation(p[3], undefined, true);
 
       window.requestAnimationFrame(anim);
     }
@@ -1055,10 +1172,11 @@ geo.map = function (arg) {
   ////////////////////////////////////////////////////////////////////////////
   /**
    * Get/set the locations of the current map corners as latitudes/longitudes.
-   * When provided the argument should be an object containing the keys
-   * lowerLeft and upperRight declaring the desired new map bounds.  The
-   * new bounds will contain at least the min/max lat/lngs provided.  In any
-   * case, the actual new bounds will be returned by this function.
+   * When provided the argument should be an object containing the keys left,
+   * top, right, bottom declaring the desired new map bounds.  The new bounds
+   * will contain at least the min/max lat/lngs provided modified by clamp
+   * settings.  In any case, the actual new bounds will be returned by this
+   * function.
    *
    * @param {geo.geoBounds} [bds] The requested map bounds
    * @param {string|geo.transform} [gcs] undefined to use the interface gcs,
@@ -1083,16 +1201,16 @@ geo.map = function (arg) {
           bottom: trans[1].y
         };
       }
-      bds = fix_bounds(bds);
-      nav = m_this.zoomAndCenterFromBounds(bds, null);
+      bds = fix_bounds(bds, m_rotation);
+      nav = m_this.zoomAndCenterFromBounds(bds, m_rotation, null);
 
-      // This might have concequences in terms of bounds/zoom clamping.
+      // This might have consequences in terms of bounds/zoom clamping.
       // What behavior do we expect from this method in that case?
       m_this.zoom(nav.zoom);
       m_this.center(nav.center, null);
     }
 
-    return m_this.boundsFromZoomAndCenter(m_zoom, m_center, gcs);
+    return m_this.boundsFromZoomAndCenter(m_zoom, m_center, m_rotation, gcs);
   };
 
   ////////////////////////////////////////////////////////////////////////////
@@ -1100,12 +1218,13 @@ geo.map = function (arg) {
    * Get the center zoom level necessary to display the given lat/lon bounds.
    *
    * @param {geo.geoBounds} [bds] The requested map bounds
+   * @param {number} rotation Rotation in clockwise radians.
    * @param {string|geo.transform} [gcs] undefined to use the interface gcs,
    *    null to use the map gcs, or any other transform.
    * @return {object} Object containing keys 'center' and 'zoom'
    */
   ////////////////////////////////////////////////////////////////////////////
-  this.zoomAndCenterFromBounds = function (bounds, gcs) {
+  this.zoomAndCenterFromBounds = function (bounds, rotation, gcs) {
     var center, zoom;
 
     gcs = (gcs === null ? m_gcs : (gcs === undefined ? m_ingcs : gcs));
@@ -1127,7 +1246,7 @@ geo.map = function (arg) {
     zoom = fix_zoom(calculate_zoom(bounds));
 
     // clamp bounds if necessary
-    bounds = fix_bounds(bounds);
+    bounds = fix_bounds(bounds, m_rotation);
 
     /* This relies on having the map projection coordinates be uniform
      * regardless of location.  If not, the center will not be correct. */
@@ -1136,7 +1255,9 @@ geo.map = function (arg) {
       x: (bounds.left + bounds.right) / 2 - m_origin.x,
       y: (bounds.top + bounds.bottom) / 2 - m_origin.y
     };
-
+    if (gcs !== m_gcs) {
+      center = geo.transform.transformCoordinates(m_gcs, gcs, [center])[0];
+    }
     return {
       zoom: zoom,
       center: center
@@ -1152,13 +1273,14 @@ geo.map = function (arg) {
    *
    * @param {number} zoom The requested zoom level
    * @param {geo.geoPosition} center The requested center
+   * @param {number} rotation The requested rotation
    * @param {string|geo.transform} [gcs] undefined to use the interface gcs,
    *    null to use the map gcs, or any other transform.
    * @return {geo.geoBounds}
    */
   ////////////////////////////////////////////////////////////////////////////
-  this.boundsFromZoomAndCenter = function (zoom, center, gcs) {
-    var width, height, bounds, units;
+  this.boundsFromZoomAndCenter = function (zoom, center, rotation, gcs) {
+    var width, height, halfw, halfh, bounds, units;
 
     gcs = (gcs === null ? m_gcs : (gcs === undefined ? m_ingcs : gcs));
     // preprocess the arguments
@@ -1167,21 +1289,46 @@ geo.map = function (arg) {
     center = m_this.gcsToWorld(center, gcs);
 
     // get half the width and height in world coordinates
-    width = m_width * units / 2;
-    height = m_height * units / 2;
+    width = m_width * units;
+    height = m_height * units;
+    halfw = width / 2;
+    halfh = height / 2;
 
     // calculate the bounds.  This is only valid if the map projection has
     // uniform units in each direction.  If not, then worldToGcs should be
     // used.
-    bounds = {
-      left: center.x - width + m_origin.x,
-      right: center.x + width + m_origin.x,
-      bottom: center.y - height + m_origin.y,
-      top: center.y + height + m_origin.y
-    };
 
-    // correct the bounds when clamping is enabled
-    return fix_bounds(bounds);
+    if (rotation) {
+      center.x += m_origin.x;
+      center.y += m_origin.y;
+      bounds = rotate_bounds_center(
+        center, {width: width, height: height}, rotation);
+      // correct the bounds when clamping is enabled
+      bounds.width = width;
+      bounds.height = height;
+      bounds = fix_bounds(bounds, rotation);
+    } else {
+      bounds = {
+        left: center.x - halfw + m_origin.x,
+        right: center.x + halfw + m_origin.x,
+        bottom: center.y - halfh + m_origin.y,
+        top: center.y + halfh + m_origin.y
+      };
+      // correct the bounds when clamping is enabled
+      bounds = fix_bounds(bounds, 0);
+    }
+    if (gcs !== m_gcs) {
+      var bds = geo.transform.transformCoordinates(
+        m_gcs, gcs,
+        [[bounds.left, bounds.top], [bounds.right, bounds.bottom]]);
+      bounds = {
+        left: bds[0][0], top: bds[0][1], right: bds[1][0], bottom: bds[1][1]
+      };
+    }
+    /* Add the original width and height of the viewport before rotation. */
+    bounds.width = width;
+    bounds.height = height;
+    return bounds;
   };
 
   ////////////////////////////////////////////////////////////////////////////
@@ -1315,6 +1462,51 @@ geo.map = function (arg) {
   }
 
   /**
+   * Adjust a set of bounds based on a rotation.
+   * @private.
+   */
+  function rotate_bounds(bounds, rotation) {
+    if (rotation) {
+      var center = {
+        x: (bounds.left + bounds.right) / 2,
+        y: (bounds.top + bounds.bottom) / 2
+      };
+      var size = {
+        width: Math.abs(bounds.left - bounds.right),
+        height: Math.abs(bounds.top - bounds.bottom)
+      };
+      bounds = rotate_bounds_center(center, size, rotation);
+    }
+    return bounds;
+  }
+
+  /**
+   * Generate a set of bounds based on a center point, a width and height, and
+   * a rotation.
+   * @private.
+   */
+  function rotate_bounds_center(center, size, rotation) {
+    // calculate the half width and height
+    var width = size.width / 2, height = size.height / 2;
+    var sinr = Math.sin(rotation), cosr = Math.cos(rotation);
+    var ul = {}, ur = {}, ll = {}, lr = {};
+    ul.x = center.x + (-width) * cosr - (-height) * sinr;
+    ul.y = center.y + (-width) * sinr + (-height) * cosr;
+    ur.x = center.x +   width  * cosr - (-height) * sinr;
+    ur.y = center.y +   width  * sinr + (-height) * cosr;
+    ll.x = center.x + (-width) * cosr -   height  * sinr;
+    ll.y = center.y + (-width) * sinr +   height  * cosr;
+    lr.x = center.x +   width  * cosr -   height  * sinr;
+    lr.y = center.y +   width  * sinr +   height  * cosr;
+    return {
+      left: Math.min(ul.x, ur.x, ll.x, lr.x),
+      right: Math.max(ul.x, ur.x, ll.x, lr.x),
+      bottom: Math.min(ul.y, ur.y, ll.y, lr.y),
+      top: Math.max(ul.y, ur.y, ll.y, lr.y)
+    };
+  }
+
+  /**
    * Calculate the minimum zoom level to fit the given
    * bounds inside the view port using the view port size,
    * the given bounds, and the number of units per
@@ -1323,6 +1515,7 @@ geo.map = function (arg) {
    * @private
    */
   function calculate_zoom(bounds) {
+    bounds = rotate_bounds(bounds, m_rotation);
     // compare the aspect ratios of the viewport and bounds
     var scl = camera_scaling(bounds), z;
 
@@ -1380,21 +1573,94 @@ geo.map = function (arg) {
   }
 
   /**
+   * Return a valid rotation angle.
+   * @private
+   */
+  function fix_rotation(rotation, ignoreRotationFunc, noRangeLimit) {
+    if (!m_allowRotation) {
+      return 0;
+    }
+    if (!ignoreRotationFunc && typeof m_allowRotation === 'function') {
+      rotation = m_allowRotation(rotation);
+    }
+    /* Ensure that the rotation is in the range [0, 2pi) */
+    if (!noRangeLimit) {
+      var range = Math.PI * 2;
+      rotation = (rotation % range) + (rotation >= 0 ? 0 : range);
+      if (Math.min(Math.abs(rotation), Math.abs(rotation - range)) < 0.00001) {
+        rotation = 0;
+      }
+    }
+    return rotation;
+  }
+
+  /**
    * Return the nearest valid bounds maintaining the
    * width and height. Does nothing if m_clampBounds* is
    * false.
    * @private
    */
-  function fix_bounds(bounds) {
-    var dx, dy;
+  function fix_bounds(bounds, rotation) {
+    if (!m_clampBoundsX && !m_clampBoundsY) {
+      return bounds;
+    }
+    var dx, dy, maxBounds = m_maxBounds;
+    if (rotation) {
+      maxBounds = $.extend({}, m_maxBounds);
+      /* When rotated, expand the maximum bounds so that they will allow the
+       * corners to be visible.  We know the rotated bounding box, plus the
+       * original maximum bounds.  To fit the corners of the maximum bounds, we
+       * can expand the total bounds by the same factor that the rotated
+       * bounding box is expanded from the non-rotated bounding box (for a
+       * small rotation, this is sin(rotation) * (original bounding box height)
+       * in the width).  This feels like appropriate behaviour with one of the
+       * two bounds clamped.  With both, it seems mildly peculiar. */
+      var bw = Math.abs(bounds.right - bounds.left),
+          bh = Math.abs(bounds.top - bounds.bottom),
+          absinr = Math.abs(Math.sin(rotation)),
+          abcosr = Math.abs(Math.cos(rotation)),
+          ow, oh;
+      if (bounds.width && bounds.height) {
+        ow = bounds.width;
+        oh = bounds.height;
+      } else if (Math.abs(absinr - abcosr) < 0.0005) {
+        /* If we are close to a 45 degree rotation, it is ill-determined to
+         * compute the original (pre-rotation) bounds width and height.  In
+         * this case, assume that we are using the map's aspect ratio. */
+        if (m_width && m_height) {
+          var aspect = Math.abs(m_width / m_height);
+          var fac = Math.pow(1 + Math.pow(aspect, 2), 0.5);
+          ow = Math.max(bw, bh) / fac;
+          oh = ow * aspect;
+        } else {
+          /* Fallback if we don't have width or height */
+          ow = bw * abcosr;
+          oh = bh * absinr;
+        }
+      } else {
+        /* Compute the pre-rotation (original) bounds width and height */
+        ow = (abcosr * bw - absinr * bh) / (abcosr * abcosr - absinr * absinr);
+        oh = (abcosr * bh - absinr * bw) / (abcosr * abcosr - absinr * absinr);
+      }
+      /* Our maximum bounds are expanded based on the projected length of a
+       * tilted side of the original bounding box in the rotated bounding box.
+       * To handle all rotations, take the minimum difference in width or
+       * height. */
+      var bdx = bw - Math.max(abcosr * ow, absinr * oh),
+          bdy = bh - Math.max(abcosr * oh, absinr * ow);
+      maxBounds.left -= bdx;
+      maxBounds.right += bdx;
+      maxBounds.top += bdy;
+      maxBounds.bottom -= bdy;
+    }
     if (m_clampBoundsX) {
-      if (bounds.right - bounds.left > m_maxBounds.right - m_maxBounds.left) {
-        dx = m_maxBounds.left - ((bounds.right - bounds.left - (
-          m_maxBounds.right - m_maxBounds.left)) / 2) - bounds.left;
-      } else if (bounds.left < m_maxBounds.left) {
-        dx = m_maxBounds.left - bounds.left;
-      } else if (bounds.right > m_maxBounds.right) {
-        dx = m_maxBounds.right - bounds.right;
+      if (bounds.right - bounds.left > maxBounds.right - maxBounds.left) {
+        dx = maxBounds.left - ((bounds.right - bounds.left - (
+          maxBounds.right - maxBounds.left)) / 2) - bounds.left;
+      } else if (bounds.left < maxBounds.left) {
+        dx = maxBounds.left - bounds.left;
+      } else if (bounds.right > maxBounds.right) {
+        dx = maxBounds.right - bounds.right;
       }
       if (dx) {
         bounds = {
@@ -1406,13 +1672,13 @@ geo.map = function (arg) {
       }
     }
     if (m_clampBoundsY) {
-      if (bounds.top - bounds.bottom > m_maxBounds.top - m_maxBounds.bottom) {
-        dy = m_maxBounds.bottom - ((bounds.top - bounds.bottom - (
-          m_maxBounds.top - m_maxBounds.bottom)) / 2) - bounds.bottom;
-      } else if (bounds.top > m_maxBounds.top) {
-        dy = m_maxBounds.top - bounds.top;
-      } else if (bounds.bottom < m_maxBounds.bottom) {
-        dy = m_maxBounds.bottom - bounds.bottom;
+      if (bounds.top - bounds.bottom > maxBounds.top - maxBounds.bottom) {
+        dy = maxBounds.bottom - ((bounds.top - bounds.bottom - (
+          maxBounds.top - maxBounds.bottom)) / 2) - bounds.bottom;
+      } else if (bounds.top > maxBounds.top) {
+        dy = maxBounds.top - bounds.top;
+      } else if (bounds.bottom < maxBounds.bottom) {
+        dy = maxBounds.bottom - bounds.bottom;
       }
       if (dy) {
         bounds = {
@@ -1431,8 +1697,17 @@ geo.map = function (arg) {
    * correct for the viewport aspect ratio.
    * @private
    */
-  function camera_bounds(bounds) {
-    m_camera.bounds = bounds;
+  function camera_bounds(bounds, rotation) {
+    m_camera.rotation = rotation || 0;
+    /* When dealing with rotation, use the original width and height of the
+     * bounds, as the rotation will have expanded them. */
+    if (bounds.width && bounds.height && rotation) {
+      var cx = (bounds.left + bounds.right) / 2,
+          cy = (bounds.top + bounds.bottom) / 2;
+      m_camera.viewFromCenterSizeRotation({x: cx, y: cy}, bounds, rotation);
+    } else {
+      m_camera.bounds = bounds;
+    }
   }
 
   ////////////////////////////////////////////////////////////////////////////
@@ -1448,6 +1723,7 @@ geo.map = function (arg) {
   // Fix the zoom level (minimum and initial)
   this.zoomRange(arg, true);
   m_zoom = fix_zoom(m_zoom);
+  m_rotation = fix_rotation(m_rotation);
   // Now update to the correct center and zoom level
   this.center($.extend({}, arg.center || m_center), undefined);
 

--- a/src/core/mapInteractor.js
+++ b/src/core/mapInteractor.js
@@ -53,6 +53,7 @@ geo.mapInteractor = function (args) {
   // copy the options object with defaults
   m_options = $.extend(
     true,
+    {},
     {
       throttle: 30,
       discreteZoom: false,

--- a/src/core/mapInteractor.js
+++ b/src/core/mapInteractor.js
@@ -60,13 +60,18 @@ geo.mapInteractor = function (args) {
       panMoveModifiers: {},
       zoomMoveButton: 'right',
       zoomMoveModifiers: {},
+      rotateMoveButton: 'left',
+      rotateMoveModifiers: {'ctrl': true},
       panWheelEnabled: false,
       panWheelModifiers: {},
       zoomWheelEnabled: true,
       zoomWheelModifiers: {},
+      rotateWheelEnabled: true,
+      rotateWheelModifiers: {'ctrl': true},
       wheelScaleX: 1,
       wheelScaleY: 1,
       zoomScale: 1,
+      rotateWheelScale: 6 * Math.PI / 180,
       selectionButton: 'left',
       selectionModifiers: {'shift': true},
       momentum: {
@@ -111,6 +116,12 @@ geo.mapInteractor = function (args) {
   //   // modifier keys that must be pressed to initiate a zoom on mousemove
   //   zoomMoveModifiers: { 'ctrl' | 'alt' | 'meta' | 'shift' }
   //
+  //   // button that must be pressed to initiate a rotate on mousedown
+  //   rotateMoveButton: 'right' | 'left' | 'middle'
+  //
+  //   // modifier keys that must be pressed to initiate a rotate on mousemove
+  //   rotateMoveModifiers: { 'ctrl' | 'alt' | 'meta' | 'shift' }
+  //
   //   // enable or disable panning with the mouse wheel
   //   panWheelEnabled: true | false
   //
@@ -123,12 +134,21 @@ geo.mapInteractor = function (args) {
   //   // modifier keys that must be pressed to trigger a zoom on wheel
   //   zoomWheelModifiers: {...}
   //
+  //   // enable or disable rotation with the mouse wheel
+  //   rotateWheelEnabled: true | false
+  //
+  //   // modifier keys that must be pressed to trigger a rotate on wheel
+  //   rotateWheelModifiers: {...}
+  //
   //   // wheel scale factor to change the magnitude of wheel interactions
   //   wheelScaleX: 1
   //   wheelScaleY: 1
   //
   //   // zoom scale factor to change the magnitude of zoom move interactions
   //   zoomScale: 1
+  //
+  //   // scale factor to change the magnitude of wheel rotation interactions
+  //   rotateWheelScale: 1
   //
   //   // button that must be pressed to enable drag selection
   //    selectionButton: 'right' | 'left' | 'middle'
@@ -289,7 +309,7 @@ geo.mapInteractor = function (args) {
   // core browser events.
   //
   // i.e.
-  // {
+  //  {
   //    'action': 'pan',      // an ongoing pan event
   //    'origin': {...},      // mouse object at the start of the action
   //    'delta': {x: *, y: *} // mouse movement since action start
@@ -299,6 +319,13 @@ geo.mapInteractor = function (args) {
   //  {
   //    'action': 'zoom',  // an ongoing zoom event
   //    ...
+  //  }
+  //
+  //  {
+  //    'action': 'rotate',   // an ongoing rotate event
+  //    'origin': {...},      // mouse object at the start of the action
+  //    'delta': {x: *, y: *} // mouse movement since action start
+  //                          // not including the current event
   //  }
   //
   //  {
@@ -354,7 +381,9 @@ geo.mapInteractor = function (args) {
     // Disable dragging images and such
     $node.on('dragstart', function () { return false; });
     if (m_options.panMoveButton === 'right' ||
-        m_options.zoomMoveButton === 'right') {
+        m_options.zoomMoveButton === 'right' ||
+        m_options.rotateMoveButton === 'right' ||
+        m_options.selectionButton === 'right') {
       $node.on('contextmenu.geojs', function () { return false; });
     }
     return m_this;
@@ -596,6 +625,8 @@ geo.mapInteractor = function (args) {
       action = 'pan';
     } else if (eventMatch(m_options.zoomMoveButton, m_options.zoomMoveModifiers)) {
       action = 'zoom';
+    } else if (eventMatch(m_options.rotateMoveButton, m_options.rotateMoveModifiers)) {
+      action = 'rotate';
     } else if (eventMatch(m_options.selectionButton, m_options.selectionModifiers)) {
       action = 'select';
     }
@@ -725,6 +756,16 @@ geo.mapInteractor = function (args) {
       m_this.map().pan({x: dx, y: dy});
     } else if (m_state.action === 'zoom') {
       m_callZoom(-dy * m_options.zoomScale / 120, m_state);
+    } else if (m_state.action === 'rotate') {
+      var cx, cy;
+      if (m_state.origin.rotation === undefined) {
+        cx = m_state.origin.map.x - m_this.map().size().width / 2;
+        cy = m_state.origin.map.y - m_this.map().size().height / 2;
+        m_state.origin.rotation = m_this.map().rotation() - Math.atan2(cy, cx);
+      }
+      cx = m_mouse.map.x - m_this.map().size().width / 2;
+      cy = m_mouse.map.y - m_this.map().size().height / 2;
+      m_this.map().rotation(m_state.origin.rotation + Math.atan2(cy, cx));
     } else if (m_state.action === 'select') {
       // Get the bounds of the current selection
       selectionObj = m_this._getSelection();
@@ -1037,6 +1078,12 @@ geo.mapInteractor = function (args) {
         zoomFactor = -m_queue.scroll.y;
 
         m_callZoom(zoomFactor, m_mouse);
+      } else if (m_options.rotateWheelEnabled &&
+                 eventMatch('wheel', m_options.rotateWheelModifiers)) {
+        m_this.map().rotation(
+            m_this.map().rotation() +
+            m_queue.scroll.y * m_options.rotateWheelScale,
+            m_mouse);
       }
 
       // reset the queue

--- a/src/core/osmLayer.js
+++ b/src/core/osmLayer.js
@@ -52,17 +52,10 @@
     }.bind(this);
   };
 
-  // Compute the circumference of the earth / 2 in meters for osm layer image bounds
-  var cEarth = Math.PI * geo.util.radiusEarth;
-
   /**
    * This object contains the default options used to initialize the osmLayer.
    */
   geo.osmLayer.defaults = $.extend({}, geo.tileLayer.defaults, {
-    minX: -cEarth,
-    maxX: cEarth,
-    minY: -cEarth,
-    maxY: cEarth,
     minLevel: 0,
     maxLevel: 18,
     tileOverlap: 0,

--- a/src/core/tileLayer.js
+++ b/src/core/tileLayer.js
@@ -876,7 +876,11 @@
       if (!node) {
         node = $(
           '<div class=geo-tile-layer data-tile-layer="' + level.toFixed() + '"/>'
-        ).css('transform-origin', '0px').get(0);
+        ).css({
+          'transform-origin': '0px 0px',
+          'line-height': 0,
+          'font-size': 0
+        }).get(0);
         this.canvas().append(node);
       }
       return node;

--- a/src/d3/d3Renderer.js
+++ b/src/d3/d3Renderer.js
@@ -429,6 +429,10 @@ geo.d3.d3Renderer = function (arg) {
   this._exit = function () {
     m_features = {};
     m_this.canvas().remove();
+    m_svg.remove();
+    m_svg = undefined;
+    m_defs.remove();
+    m_defs = undefined;
     s_exit();
   };
 

--- a/src/util/init.js
+++ b/src/util/init.js
@@ -217,6 +217,18 @@
     },
 
     /**
+     * Compare two arrays and return if their contents are equal.
+     * @param {array} a1 first array to compare
+     * @param {array} a2 second array to compare
+     * @returns {boolean} true if the contents of the arrays are equal.
+     */
+    compareArrays: function (a1, a2) {
+      return (a1.length === a2.length && a1.every(function (el, idx) {
+        return el === a2[idx];
+      }));
+    },
+
+    /**
      * Create a vec3 that is always an array.  This should only be used if it
      * will not be used in a WebGL context.  Plain arrays usually use 64-bit
      * float values, whereas vec3 defaults to 32-bit floats.

--- a/testing/js/testUtils.js
+++ b/testing/js/testUtils.js
@@ -1,6 +1,6 @@
 /* These are functions we want available to jasmine tests. */
 /* global it */
-/* exported waitForIt, mockVGLRenderer */
+/* exported waitForIt, mockVGLRenderer, closeToArray, closeToEqual */
 
 /**
  * Create a pair of it functions.  The first one waits for a function to return
@@ -25,6 +25,58 @@ function waitForIt(desc, testFunc) {
   });
   it('done waiting for ' + desc, function () {
   });
+}
+
+/**
+ * Compare two arrays with a precision tolerance.
+ * @param {array} a1 first array to compare
+ * @param {array} a2 second array to compare
+ * @param {number} precision precision used in jasmine's toBeCloseTo function
+ * @return {boolean} true if the arrays are close.
+ */
+function closeToArray(a1, a2, precision) {
+  'use strict';
+  var i;
+  if (a1.length !== a2.length) {
+    return false;
+  }
+  precision = (precision !== 0) ? (precision || 2) : precision;
+  precision = Math.pow(10, -precision) / 2;
+  for (i = 0; i < a1.length; i += 1) {
+    if (Math.abs(a1[i] - a2[i]) >= precision) {
+      return false;
+    }
+  }
+  return true;
+}
+
+/**
+ * Compare two objects containing numbers with a precision tolerance.
+ * @param {array} a1 first object to compare
+ * @param {array} a2 second object to compare
+ * @param {number} precision precision used in jasmine's toBeCloseTo function
+ * @return {boolean} true if the objects are close.
+ */
+function closeToEqual(o1, o2, precision) {
+  'use strict';
+  var key;
+
+  precision = (precision !== 0) ? (precision || 2) : precision;
+  precision = Math.pow(10, -precision) / 2;
+  for (key in o1) {
+    if (o1.hasOwnProperty(key)) {
+      if (o2[key] === undefined ||
+          Math.abs(o1[key] - o2[key]) >= precision) {
+        return false;
+      }
+    }
+  }
+  for (key in o2) {
+    if (o2.hasOwnProperty(key) && o1[key] === undefined) {
+      return false;
+    }
+  }
+  return true;
 }
 
 /**

--- a/testing/js/testUtils.js
+++ b/testing/js/testUtils.js
@@ -67,6 +67,8 @@ function closeToEqual(o1, o2, precision) {
     if (o1.hasOwnProperty(key)) {
       if (o2[key] === undefined ||
           Math.abs(o1[key] - o2[key]) >= precision) {
+        console.log('not closeToEqual: ' + key + ' ' + o1[key] + ' !~= ' +
+                    o2[key]);
         return false;
       }
     }

--- a/testing/test-cases/phantomjs-tests/map.js
+++ b/testing/test-cases/phantomjs-tests/map.js
@@ -1,6 +1,6 @@
 // Test geo.core.map
 
-/*global describe, it, expect, geo*/
+/*global describe, it, expect, geo, closeToEqual*/
 describe('geo.core.map', function () {
   'use strict';
 
@@ -52,11 +52,210 @@ describe('geo.core.map', function () {
       expect(zr.origMin).toBe(0);
       expect(zr.max).toBe(2);
     });
-
-    // add additional tests here
+    it('allowRotation', function () {
+      var m = create_map();
+      expect(m.allowRotation()).toBe(true);
+      m.rotation(0);
+      expect(m.rotation()).toBe(0);
+      m.rotation(1);
+      expect(m.rotation()).toBe(1);
+      m.allowRotation(false);
+      expect(m.allowRotation()).toBe(false);
+      expect(m.rotation()).toBe(0);
+      m.rotation(0);
+      expect(m.rotation()).toBe(0);
+      m.rotation(1);
+      expect(m.rotation()).toBe(0);
+      m.allowRotation(true);
+      m.rotation(1);
+      expect(m.rotation()).toBe(1);
+      m.allowRotation(function (rotation) {
+        var factor = 180 / Math.PI / 15;
+        return Math.round(rotation * factor) / factor;
+      });
+      expect(typeof m.allowRotation()).toBe('function');
+      expect(m.rotation()).toBeCloseTo(60 * Math.PI / 180);
+      m.rotation(0);
+      expect(m.rotation()).toBe(0);
+      m.rotation(17 * Math.PI / 180);
+      expect(m.rotation()).toBeCloseTo(15 * Math.PI / 180);
+      m.allowRotation(true);
+      expect(m.rotation()).toBeCloseTo(15 * Math.PI / 180);
+      m.rotation(17 * Math.PI / 180);
+      expect(m.rotation()).toBeCloseTo(17 * Math.PI / 180);
+    });
+    it('size and rotatedSize', function () {
+      var m = create_map();
+      expect(m.size()).toEqual({width: 500, height: 500});
+      expect(m.rotatedSize()).toEqual({width: 500, height: 500});
+      m.size({width: 400, height: 300});
+      expect(m.size()).toEqual({width: 400, height: 300});
+      expect(m.rotatedSize()).toEqual({width: 400, height: 300});
+      m.rotation(Math.PI);
+      expect(m.size()).toEqual({width: 400, height: 300});
+      expect(closeToEqual(m.rotatedSize(), {width: 400, height: 300})).toBe(true);
+      m.rotation(Math.PI / 2);
+      expect(m.size()).toEqual({width: 400, height: 300});
+      expect(closeToEqual(m.rotatedSize(), {width: 300, height: 400})).toBe(true);
+      m.rotation(Math.PI / 4);
+      expect(m.size()).toEqual({width: 400, height: 300});
+      expect(closeToEqual(m.rotatedSize(), {
+        width: 700 / Math.sqrt(2), height: 700 / Math.sqrt(2)})).toBe(true);
+      m.rotation(Math.PI / 12);
+      expect(m.size()).toEqual({width: 400, height: 300});
+      expect(closeToEqual(m.rotatedSize(), {
+        width: 400 * Math.cos(Math.PI / 12) + 300 * Math.sin(Math.PI / 12),
+        height: 400 * Math.sin(Math.PI / 12) + 300 * Math.cos(Math.PI / 12)
+      })).toBe(true);
+      m.size({width: 300, height: 400});
+      expect(m.size()).toEqual({width: 300, height: 400});
+      expect(closeToEqual(m.rotatedSize(), {
+        width: 300 * Math.cos(Math.PI / 12) + 400 * Math.sin(Math.PI / 12),
+        height: 300 * Math.sin(Math.PI / 12) + 400 * Math.cos(Math.PI / 12)
+      })).toBe(true);
+    });
+    it('unitsPerPixel', function () {
+      var m = create_map(), circEarth = 6378137 * Math.PI * 2;
+      m.createLayer('feature', {renderer: 'd3'});
+      expect(m.unitsPerPixel()).toBeCloseTo(circEarth / 256);
+      expect(m.unitsPerPixel(0)).toBeCloseTo(circEarth / 256);
+      expect(m.unitsPerPixel(1)).toBeCloseTo(circEarth / 256 / 2);
+      expect(m.unitsPerPixel(4)).toBeCloseTo(circEarth / 256 / 16);
+      m.unitsPerPixel(undefined, 200000);
+      expect(m.unitsPerPixel()).toBe(200000);
+      expect(m.unitsPerPixel(4)).toBeCloseTo(200000 / 16);
+      m.unitsPerPixel(4, 200000);
+      expect(m.unitsPerPixel()).toBeCloseTo(200000 * 16);
+      expect(m.unitsPerPixel(4)).toBeCloseTo(200000);
+    });
+    it('scale', function () {
+      var m = create_map();
+      expect(m.scale()).toEqual({x: 1, y: 1, z: 1});
+    });
+    it('gcs and ingcs', function () {
+      var m = create_map(), units = m.unitsPerPixel();
+      expect(m.gcs()).toBe('EPSG:3857');
+      expect(m.ingcs()).toBe('EPSG:4326');
+      m.bounds({left: -180, top: 5, right: 180, bottom: -5});
+      expect(closeToEqual(m.bounds(), {
+        left: -180, top: 85.05, right: 180, bottom: -85.05,
+        width: 256 * units, height: 256 * units})).toBe(true);
+      expect(closeToEqual(m.bounds(undefined, null), {
+        left: -128 * units, top: 128 * units,
+        right: 128 * units, bottom: -128 * units,
+        width: 256 * units, height: 256 * units})).toBe(true);
+      m.ingcs('EPSG:3857');
+      expect(m.ingcs()).toBe('EPSG:3857');
+      expect(closeToEqual(m.bounds(), {
+        left: -128 * units, top: 128 * units,
+        right: 128 * units, bottom: -128 * units,
+        width: 256 * units, height: 256 * units})).toBe(true);
+      m.unitsPerPixel(0, 1);
+      m.gcs('+proj=longlat +axis=enu');
+      expect(m.gcs()).toBe('+proj=longlat +axis=enu');
+      m.ingcs('+proj=longlat +axis=esu');
+      expect(m.ingcs()).toBe('+proj=longlat +axis=esu');
+      expect(closeToEqual(m.bounds(), {
+        left: -128, top: -128, right: 128, bottom: 128,
+        width: 256, height: 256})).toBe(true);
+      expect(closeToEqual(m.bounds(undefined, null), {
+        left: -128, top: 128, right: 128, bottom: -128,
+        width: 256, height: 256})).toBe(true);
+    });
+    it('zoom and discreteZoom', function () {
+      var m = create_map();
+      expect(m.zoom()).toBe(4);
+      expect(m.discreteZoom()).toBe(false);
+      m.zoom(3.5);
+      expect(m.zoom()).toBe(3.5);
+      expect(closeToEqual(m.center(), {x: 0, y: 0, z: 0})).toBe(true);
+      m.zoom(3, {geo: m.displayToGcs({x: 122, y: 186}),
+                 map: {x: 122, y: 186}});
+      expect(m.zoom()).toBe(3);
+      expect(closeToEqual(m.center(), {x: 6.59, y: -3.293, z: 0})).toBe(true);
+      m.discreteZoom(true);
+      expect(m.discreteZoom()).toBe(true);
+      expect(m.zoom()).toBe(3);
+      m.zoom(4.1);
+      expect(m.zoom()).toBe(4);
+      m.zoom(4.1, undefined, true);
+      expect(m.zoom()).toBe(4.1);
+      m.discreteZoom(false);
+      expect(m.discreteZoom()).toBe(false);
+      m.clampZoom(true);
+      m.zoom(0);
+      expect(m.zoom()).toBeGreaterThan(0.6);
+      expect(m.zoom()).toBeLessThan(1);
+      m.discreteZoom(true);
+      m.zoom(0);
+      expect(m.zoom()).toBe(1);
+      m.resize(0, 0, 600, 600);
+      expect(m.zoom()).toBe(2);
+      m.zoom(3);
+      expect(m.zoom()).toBe(3);
+      m.zoom(0);
+      expect(m.zoom()).toBe(2);
+    });
+    it('rotation', function () {
+      var m = create_map();
+      expect(m.rotation()).toBe(0);
+      m.rotation(1);
+      expect(m.rotation()).toBe(1);
+      expect(closeToEqual(m.center(), {x: 0, y: 0, z: 0})).toBe(true);
+      m.rotation(0, {geo: m.displayToGcs({x: 122, y: 186}),
+                     map: {x: 122, y: 186}});
+      expect(m.rotation()).toBe(0);
+      expect(m.center().x).toBeGreaterThan(0.4);
+      expect(m.center().y).toBeLessThan(-11);
+      m.rotation(-1);
+      expect(m.rotation()).toBeCloseTo(Math.PI * 2 - 1);
+      m.rotation(17);
+      expect(m.rotation()).toBeCloseTo(17 - Math.PI * 4);
+    });
   });
 
   describe('Public utility methods', function () {
+    var animFrameCallbacks = [], animFrameIndex = 0;
+
+    /* Replace window.requestAnimationFrame with this function, then call
+     * stepAnimationFrame with a delta from when this was supposed to start to
+     * test asynchronous animations.
+     *
+     * @param {function} callback the function to call on an animation frame
+     *                            interval.
+     */
+    function mockRequestAnimationFrame(callback) {
+      animFrameIndex += 1;
+      var id = animFrameIndex;
+      animFrameCallbacks.push({id: id, callback: callback});
+    }
+
+    /* Replace window.cancelAnimationFrame with this function.
+     *
+     * @param {number} id id of the callback to cancel.
+     */
+    function mockCancelAnimationFrame(id) {
+      for (var i = 0; i < animFrameCallbacks.length; i += 1) {
+        if (animFrameCallbacks[i].id === id) {
+          animFrameCallbacks.splice(i, 1);
+          return;
+        }
+      }
+    }
+
+    /* Call all animation frame functions that have been captured.
+     *
+     * @param {float} time float milliseconds.
+     */
+    function stepAnimationFrame(time) {
+      var callbacks = animFrameCallbacks, action;
+      animFrameCallbacks = [];
+      while (callbacks.length > 0) {
+        action = callbacks.shift();
+        action.callback.call(window, time);
+      }
+    }
+
     /* Count the number of jquery events bounds to an element using a
      * particular namespace.
      *
@@ -83,7 +282,241 @@ describe('geo.core.map', function () {
       m.exit();
       expect(count_events(m.node(), 'geo')).toBe(0);
     });
+    it('pan, clampBoundsX, and clampBoundsY', function () {
+      var m = create_map({
+        unitsPerPixel: 16,
+        gcs: '+proj=longlat +axis=enu',
+        ingcs: '+proj=longlat +axis=esu',
+        maxBounds: {left: -2048, right: 2048, top: -2048, bottom: 2048},
+        max: 4
+      });
+      expect(closeToEqual(m.center(), {x: 0, y: 0, z: 0})).toBe(true);
+      m.pan({x: -128, y: 0});
+      expect(closeToEqual(m.center(), {x: 128, y: 0, z: 0})).toBe(true);
+      m.clampZoom(false);
+      expect(m.clampBoundsX()).toBe(false);
+      expect(m.clampBoundsY()).toBe(true);
+      m.clampBoundsX(false);
+      expect(m.clampBoundsX()).toBe(false);
+      m.clampBoundsY(false);
+      expect(m.clampBoundsY()).toBe(false);
+      m.zoom(0);
+      m.center({x: 0, y: 0});
+      expect(closeToEqual(m.center(), {x: 0, y: 0, z: 0})).toBe(true);
+      m.pan({x: -128, y: 0});
+      expect(closeToEqual(m.center(), {x: 2048, y: 0, z: 0})).toBe(true);
+      m.pan({x: -128, y: 0});
+      expect(closeToEqual(m.center(), {x: 4096, y: 0, z: 0})).toBe(true);
+      m.center({x: 0, y: 0});
+      m.clampBoundsX(true);
+      expect(m.clampBoundsX()).toBe(true);
+      expect(closeToEqual(m.center(), {x: 0, y: 0, z: 0})).toBe(true);
+      m.pan({x: -128, y: 0});
+      expect(closeToEqual(m.center(), {x: 0, y: 0, z: 0})).toBe(true);
+      m.pan({x: 0, y: 100});
+      expect(closeToEqual(m.center(), {x: 0, y: -1600, z: 0})).toBe(true);
+      m.center({x: 0, y: 0});
+      m.clampBoundsY(true);
+      expect(m.clampBoundsY()).toBe(true);
+      expect(closeToEqual(m.center(), {x: 0, y: 0, z: 0})).toBe(true);
+      m.pan({x: -128, y: 0});
+      expect(closeToEqual(m.center(), {x: 0, y: 0, z: 0})).toBe(true);
+      m.pan({x: 0, y: 100});
+      expect(closeToEqual(m.center(), {x: 0, y: 0, z: 0})).toBe(true);
+      m.center({x: 0, y: 0});
+      m.clampBoundsX(false);
+      expect(closeToEqual(m.center(), {x: 0, y: 0, z: 0})).toBe(true);
+      m.pan({x: -128, y: 0});
+      expect(closeToEqual(m.center(), {x: 2048, y: 0, z: 0})).toBe(true);
+      m.pan({x: 0, y: 100});
+      expect(closeToEqual(m.center(), {x: 2048, y: 0, z: 0})).toBe(true);
+      m.zoom(2);
+      m.clampBoundsX(true);
+      m.pan({x: 1000, y: 0});
+      expect(closeToEqual(m.center(), {x: -1048, y: 0, z: 0})).toBe(true);
+      m.pan({x: -1000, y: 0});
+      expect(closeToEqual(m.center(), {x: 1048, y: 0, z: 0})).toBe(true);
+      m.pan({x: 262, y: 1000});
+      expect(closeToEqual(m.center(), {x: 0, y: -1048, z: 0})).toBe(true);
+      m.pan({x: 0, y: -1000});
+      expect(closeToEqual(m.center(), {x: 0, y: 1048, z: 0})).toBe(true);
+    });
+    it('zoomAndCenterFromBounds', function () {
+      var zc;
+      var m = create_map({
+        unitsPerPixel: 16,
+        gcs: '+proj=longlat +axis=enu',
+        ingcs: '+proj=longlat +axis=esu',
+        maxBounds: {left: -2048, right: 2048, top: -2048, bottom: 2048},
+        max: 4
+      });
+      zc = m.zoomAndCenterFromBounds({
+        left: -250, top: -250, right: 250, bottom: 250});
+      expect(zc.zoom).toBeCloseTo(4);
+      expect(closeToEqual(zc.center, {x: 0, y: 0})).toBe(true);
+      expect(function () { m.zoomAndCenterFromBounds({
+        left: -250, top: 250, right: 250, bottom: -250}); }).toThrow(
+        new Error('Invalid bounds provided'));
+      zc = m.zoomAndCenterFromBounds({
+        left: 0, top: -500, right: 10, bottom: 500});
+      expect(zc.zoom).toBeCloseTo(3);
+      expect(closeToEqual(zc.center, {x: 5, y: 0})).toBe(true);
+      // check using gcs rather than ingcs
+      zc = m.zoomAndCenterFromBounds({
+        left: -250, top: 250, right: 250, bottom: -250}, undefined, null);
+      expect(zc.zoom).toBeCloseTo(4);
+      expect(closeToEqual(zc.center, {x: 0, y: 0})).toBe(true);
+      // check rotation
+      zc = m.zoomAndCenterFromBounds({
+        left: -500, top: -500, right: 500, bottom: 500}, Math.PI / 6);
+      expect(zc.zoom).toBeCloseTo(
+        3 - Math.log(Math.cos(Math.PI / 6) + Math.sin(Math.PI / 6)) /
+        Math.log(2));
+      expect(closeToEqual(zc.center, {x: 0, y: 0})).toBe(true);
+    });
+    it('transition', function () {
+      var m = create_map(), start, wasCalled;
+      var origRequestAnimationFrame = window.requestAnimationFrame,
+          origCancelAnimationFrame = window.cancelAnimationFrame;
+      window.requestAnimationFrame = mockRequestAnimationFrame;
+      window.cancelAnimationFrame = mockCancelAnimationFrame;
+      expect(m.transition()).toBe(null);
+      start = new Date().getTime();
+      m.transition({
+        center: {x: 10, y: 0},
+        zoom: 2,
+        rotation: Math.PI,
+        duration: 1000
+      });
+      expect(m.transition().ease).not.toBe(null);
+      expect(m.transition().start.time).toBe(undefined);
+      stepAnimationFrame(start);
+      expect(m.transition().start.time).toBe(start);
+      expect(m.transition().time).toBe(0);
+      stepAnimationFrame(start + 500);
+      expect(m.transition().time).toBeCloseTo(500);
+      expect(m.center().x).toBeCloseTo(5);
+      expect(m.zoom()).toBeLessThan(2.9);
+      expect(m.rotation()).toBeCloseTo(Math.PI / 2);
+      stepAnimationFrame(start + 1000);
+      expect(m.transition()).toBe(null);
+      expect(m.center().x).toBeCloseTo(10);
+      expect(m.zoom()).toBe(2);
+      expect(m.rotation()).toBeCloseTo(Math.PI);
+      // queue two transitions.  The first transition will end as it starts.
+      m.transition({
+        center: {x: 20, y: 0},
+        rotation: 0,
+        duration: 1000
+      });
+      m.transition({
+        center: {x: 20, y: 10},
+        rotation: 0,
+        duration: 1000
+      });
+      expect(m.transition().start.time).toBe(undefined);
+      stepAnimationFrame(start);
+      // the first transition gets cancelled, as the second transition will
+      // perform the entire action.
+      expect(m.transition().start.time).toBe(undefined);
+      expect(m.center().x).toBeCloseTo(10);
+      expect(m.center().y).toBeCloseTo(0);
+      stepAnimationFrame(start + 1);
+      expect(m.transition().start.time).toBe(start + 1);
+      expect(m.transition().time).toBe(0);
+      expect(m.center().x).toBeCloseTo(10);
+      expect(m.center().y).toBeCloseTo(0);
+      stepAnimationFrame(start + 501);
+      expect(m.transition().time).toBeCloseTo(500);
+      expect(m.center().x).toBeCloseTo(15);
+      expect(m.center().y).toBeCloseTo(5, 1);
+      stepAnimationFrame(start + 1001);
+      expect(m.transition()).toBe(null);
+      expect(m.center().x).toBeCloseTo(20);
+      expect(m.center().y).toBeCloseTo(10);
+      // test without zCoord effect
+      m.transition({
+        zoom: 4,
+        zCoord: false
+      });
+      stepAnimationFrame(start);
+      stepAnimationFrame(start + 500);
+      expect(m.zoom()).toBeCloseTo(3);
+      stepAnimationFrame(start + 1000);
+      expect(m.transition()).toBe(null);
+      expect(m.zoom()).toBe(4);
+      // test with callback
+      m.transition({
+        center: {x: 0, y: 0},
+        duration: 1000,
+        done: function () {
+          wasCalled = true;
+        }
+      });
+      stepAnimationFrame(start);
+      expect(wasCalled).toBe(undefined);
+      stepAnimationFrame(start + 1000);
+      expect(wasCalled).toBe(true);
+      // test cancelNavigation
+      geo.event.cancelNavigation = true;
+      m.transition({
+        center: {x: -10, y: 0},
+        duration: 1000
+      });
+      expect(m.transition()).toBe(null);
+      expect(m.center().x).toBeCloseTo(0);
+      expect(m.center().y).toBeCloseTo(0);
+      geo.event.cancelNavigation = false;
+      // test cancelAnimation
+      geo.event.cancelAnimation = true;
+      m.transition({
+        center: {x: -10, y: 0},
+        duration: 1000
+      });
+      expect(m.transition()).toBe(null);
+      expect(m.center().x).toBeCloseTo(-10);
+      expect(m.center().y).toBeCloseTo(0);
+      geo.event.cancelAnimation = false;
+      // test with custom easing
+      m.transition({
+        center: {x: 0, y: 0},
+        ease: function (t) {
+          return t * t;
+        },
+        duration: 1000
+      });
+      stepAnimationFrame(start);
+      stepAnimationFrame(start + 500);
+      expect(m.center().x).toBeCloseTo(-7.5);
+      expect(m.center().y).toBeCloseTo(0);
+      stepAnimationFrame(start + 1000);
+      expect(m.center().x).toBeCloseTo(0);
+      expect(m.center().y).toBeCloseTo(0);
+      window.requestAnimationFrame = origRequestAnimationFrame;
+      window.cancelAnimationFrame = origCancelAnimationFrame;
+    });
+  });
 
-    // add additional public method tests here
+  describe('Public non-class methods', function () {
+    it('geo.map.create', function () {
+      var layerSpec = {type: 'feature', renderer: 'd3', features: []};
+      var node = $('<div id="map"/>').css({width: '500px', height: '500px'});
+      $('#map').remove();
+      $('body').append(node);
+      var m = geo.map.create({node: node, layers: [layerSpec]});
+      expect(m.layers().length).toBe(1);
+      expect(geo.map.create({})).toBe(null);
+    });
+  });
+
+  describe('Internal methods', function () {
+    it('resizeSelf', function () {
+      var m = create_map();
+      expect(m.size()).toEqual({width: 500, height: 500});
+      $('#map').css({width: '400px', height: '400px'});
+      expect(m.size()).toEqual({width: 500, height: 500});
+      $(window).trigger('resize');
+      expect(m.size()).toEqual({width: 400, height: 400});
+    });
   });
 });

--- a/testing/test-cases/phantomjs-tests/osmLayer.js
+++ b/testing/test-cases/phantomjs-tests/osmLayer.js
@@ -41,7 +41,7 @@ describe('geo.core.osmLayer', function () {
         var transform = layer.canvas().css('transform');
         layer._update();
         expect(layer.canvas().css('transform')).toBe(transform);
-        map.zoom(1);
+        map.zoom(1.5);
         expect(layer.canvas().css('transform')).not.toBe(transform);
       });
     });

--- a/testing/test-cases/phantomjs-tests/osmLayer.js
+++ b/testing/test-cases/phantomjs-tests/osmLayer.js
@@ -1,16 +1,19 @@
 // Test geo.core.osmLayer
-/*global describe, it, expect, geo, waitForIt, mockVGLRenderer*/
+/*global describe, it, expect, geo, waitForIt, mockVGLRenderer, closeToEqual*/
 
 describe('geo.core.osmLayer', function () {
   'use strict';
   function create_map(opts) {
-    var node = $('<div id="map"/>');
-    $('#map').remove();
-    $('body').append(node);
+    var node = $('<div id="map"/>').css({width: '640px', height: '360px'});
+    $('#map,#map-container').remove();
+    /* Prepend because we want the map to be the first item so that its
+     * position doesn't change when data is added to the html reporter div. */
+    $('body').prepend(node);
     opts = $.extend({}, opts);
     opts.node = node;
     return geo.map(opts);
   }
+
 
   describe('default osmLayer', function () {
     describe('html', function () {
@@ -106,6 +109,54 @@ describe('geo.core.osmLayer', function () {
         layer = map.createLayer('osm', {renderer: 'vgl'});
         expect(map.node().find('[data-tile-layer="0"]').is('g')).toBe(false);
         expect(map.node().find('.webgl-canvas').length).toBe(1);
+      });
+    });
+
+    describe('html and d3 alignment', function () {
+      var positions = {};
+      var map, layer;
+      /* A set of angles to test with the number of tiles we expect at each
+       * angle.  This could be extended to test many more angles, but phantom
+       * does odd things with the offsets, so the test looks like it fails.
+      var angles = {0: 21, 1: 21, 30: 29, '-30': 29, 90: 21, 120: 29, 180: 21,
+                    210: 29, '-17.05': 29};
+       */
+      var angles = {0: 21, 180: 21};
+      $.each(angles, function (angle, numTiles) {
+        it('null default', function () {
+          map = create_map();
+          if (angle) {
+            map.rotation(parseFloat(angle) * Math.PI / 180);
+          }
+          layer = map.createLayer('osm', {renderer: null});
+          expect(map.node().find('[data-tile-layer="0"]').length).toBe(1);
+        });
+        waitForIt('null tiles to load', function () {
+          return $('[tile-reference]').length === numTiles;
+        });
+        it('check null tiles and switch to d3', function () {
+          positions = {};
+          $.each($('[tile-reference]'), function () {
+            var ref = $(this).attr('tile-reference');
+            positions[ref] = $(this)[0].getBoundingClientRect();
+          });
+          map.deleteLayer(layer);
+          layer = map.createLayer('osm', {renderer: 'd3'});
+          expect(map.node().find('[data-tile-layer="0"]').is('div')).toBe(false);
+          expect(map.node().find('[data-tile-layer="0"]').length).toBe(1);
+        });
+        waitForIt('d3 tiles to load', function () {
+          return $('image[reference]').length === numTiles;
+        });
+        it('compare tile offsets at angle ' + angle, function () {
+          $.each($('image[reference]'), function () {
+            var ref = $(this).attr('reference');
+            var offset = $(this)[0].getBoundingClientRect();
+            /* Allow around 1 pixel of difference */
+            expect(closeToEqual(offset, positions[ref], -0.4)).toBe(true);
+          });
+          map.exit();
+        });
       });
     });
   });

--- a/testing/test-cases/phantomjs-tests/tileLayer.js
+++ b/testing/test-cases/phantomjs-tests/tileLayer.js
@@ -322,10 +322,6 @@ describe('geo.tileLayer', function () {
       animationDuration: 10,
       tileRounding: function () {},
       attribution: 'My awesome layer',
-      minX: -10,
-      maxX: 5,
-      minY: 100,
-      maxY: 1000,
       tileOffset: function () {},
       topDown: true
     };

--- a/testing/test-cases/phantomjs-tests/tileLayer.js
+++ b/testing/test-cases/phantomjs-tests/tileLayer.js
@@ -1,6 +1,6 @@
 // Test geo.tileLayer
 
-/*global describe, it, expect, geo, mockVGLRenderer*/
+/*global describe, it, expect, geo, mockVGLRenderer, closeToEqual*/
 describe('geo.tileLayer', function () {
   'use strict';
 
@@ -67,6 +67,12 @@ describe('geo.tileLayer', function () {
           x: p.x,
           y: p.y
         };
+      },
+      gcs: function () {
+        return '+proj=longlat +axis=esu';
+      },
+      ingcs: function () {
+        return '+proj=longlat +axis=enu';
       },
       updateAttribution: function () {
       },
@@ -591,6 +597,31 @@ describe('geo.tileLayer', function () {
       };
 
       l.prefetch(1, {left: 0, right: 1, bottom: 0, top: 1}).then(done);
+    });
+    describe('gcsTileBounds', function () {
+      it('level 0 tile is the world', function () {
+        var m = map(), l;
+        l = geo.tileLayer({map: m});
+        expect(l.gcsTileBounds({level: 0, x: 0, y: 0})).toEqual({
+            left: 0, top: 0, right: 2560000, bottom: 2560000});
+        expect(closeToEqual(l.gcsTileBounds({level: 0, x: 0, y: 0}, null), {
+            left: 0, top: 0, right: 2560000, bottom: -2560000})).toBe(true);
+        expect(closeToEqual(l.gcsTileBounds(
+            {level: 0, x: 0, y: 0}, '+proj=longlat +axis=wnu'), {
+            left: 0, top: 0, right: -2560000, bottom: 2560000})).toBe(true);
+      });
+      it('level 3 tiles', function () {
+        var m = map(), l;
+        l = geo.tileLayer({map: m});
+        expect(l.gcsTileBounds({level: 3, x: 0, y: 0})).toEqual({
+            left: 0, top: 0, right: 320000, bottom: 320000});
+        expect(l.gcsTileBounds({level: 3, x: 7, y: 0})).toEqual({
+            left: 2240000, top: 0, right: 2560000, bottom: 320000});
+        expect(l.gcsTileBounds({level: 3, x: 7, y: 7})).toEqual({
+            left: 2240000, top: 2240000, right: 2560000, bottom: 2560000});
+        expect(l.gcsTileBounds({level: 3, x: 3, y: 4})).toEqual({
+            left: 960000, top: 1280000, right: 1280000, bottom: 1600000});
+      });
     });
   });
   describe('Protected utility methods', function () {

--- a/testing/test-cases/selenium-tests/osmLayer/testDrawOsm.py
+++ b/testing/test-cases/selenium-tests/osmLayer/testDrawOsm.py
@@ -32,6 +32,13 @@ class osmBase(object):
         self.waitForIdle()
         self.screenshotTest(testName)
 
+    def test_osm_rotate(self):
+        testName = 'osmRotate'
+        self.loadPage()
+        self.drag('#map', (50, 100), (100, 200), True)
+        self.waitForIdle()
+        self.screenshotTest(testName)
+
 
 class FirefoxOSM(osmBase, FirefoxTest):
     testCase = osmBase.testCase + ('firefox',)

--- a/testing/test-cases/selenium-tests/osmLayer/testDrawOsm.py
+++ b/testing/test-cases/selenium-tests/osmLayer/testDrawOsm.py
@@ -37,7 +37,7 @@ class osmBase(object):
         self.loadPage()
         self.drag('#map', (50, 100), (100, 200), True)
         self.waitForIdle()
-        self.screenshotTest(testName)
+        self.screenshotTest(testName, revision=1)
 
 
 class FirefoxOSM(osmBase, FirefoxTest):

--- a/testing/test-runners/selenium_test.py.in
+++ b/testing/test-runners/selenium_test.py.in
@@ -27,7 +27,7 @@ else:
 
 from selenium import webdriver
 from selenium.webdriver.support.wait import WebDriverWait
-from selenium.webdriver.common.action_chains import ActionChains
+from selenium.webdriver.common.action_chains import ActionChains, Keys
 from PIL import Image, ImageStat, ImageChops
 
 from midas_handler import MidasHandler
@@ -443,7 +443,7 @@ class BaseTest(TestCase):
             url = self.testBaseURL + url
         return self.driver.get(url)
 
-    def drag(self, element, delta, offset=(0, 0)):
+    def drag(self, element, delta, offset=(0, 0), ctrlDown=False):
         '''
         Drag the element given (by a CSS selector) starting
         at ``offset`` relative to the center of the element by
@@ -454,6 +454,7 @@ class BaseTest(TestCase):
         :type delta: [x, y]
         :param offset:  The offset from the element center to start the drag.
         :type offset: [x, y]
+        :param ctrlDown: if True, hold down control key during the drag.
 
         For example,
 
@@ -464,11 +465,15 @@ class BaseTest(TestCase):
         '''
         el = self.getElement(element)
         action = ActionChains(self.driver)
+        if ctrlDown:
+            action.key_down(Keys.CONTROL)
 
         action.move_to_element_with_offset(el, offset[0], offset[1])
         action.click_and_hold()
         action.move_by_offset(delta[0], delta[1])
         action.release()
+        if ctrlDown:
+            action.key_up(Keys.CONTROL)
         action.perform()
 
     def hover(self, element, offset=(0, 0)):


### PR DESCRIPTION
Maps now have a rotation property (default=0).  The tiles that are fetched are the covering rectangle of tiles.  This could be optimized so that only tiles that have a portion on the display would be fetched (though calculating that would be more costly).  Rotations work on all renderers.

Added rotation interactions.  By default ctrl+left mouse button will rotation around the center of the map by the angle that the mouse cursor moves around the center of the map.  Ctrl+wheel will rotate in 5 degree increments (strictly, one zoom level wheel movement is the same amount of wheel movement that rotates 6 degrees).

Adjust bounding box to handle clamping when rotated.  This will always let you see the entire map or image, but isn't as intuitive as it could be from a UI standpoint.  Perhaps this should be refactored in a later PR.

Fixed issues with map.bounds and map.zoomAndCenterFromBounds not returning data in the specified gcs (but always in the map gcs).

Tiles in the gl renderer will be pixel-perfect at integer zoom levels for rotations that are multiples of 90 degrees.

Removed the minX, minY, maxX, maxY parameters from the tileLayer and osmLayer classes, as they were not used.

Stopped examples from trying to load a favicon (this can be changed if we ever have a favicon, I was just tired of the 404 errors on it).

Stop allowing text selections in the examples.  When dragging maps, selecting text looks bad.

Added a "Spin to Budapest" option to the transitions example.

Updated the tiles example to allow setting the maxBounds and unitsPerPixel in the query arguments.  Added allowRotation to both the controls and the query arguments.  Changed how debug borders are drawn in the null renderer on the tiles example.

One of the added tests compares the null renderer with the d3 renderer.  Due to some wackiness in the phantom svg renderer, this only works at 0 and 180 degree rotations.

Fixed some css issues if the browser has odd line-height and font-size behavior (this affected the null renderer's tile sizes in phantom).

Removed vestigial references to map.toggle(), as it couldn't have ever worked, and any caller with enough information to use it could have toggle a layer's visibility on their own.

For transitions, deeply copy the options so that we aren't altering a data structure the caller may still be using.

Renamed defaultOpts to opts in a lot of the transition code, as it references the specific options and not the defaults.

Actually attach the geo.event.cancelAnimation and geo.event.cancelNavigation functionality in transitions.

Added tests that cover most of map.js (besides also covering most of the new code).  Added a selenium test for rotation that needs a new base-line image.