### PR TITLE
UI Layer is implicitly moved to top whenever a new layer is added.

### DIFF
--- a/src/core/map.js
+++ b/src/core/map.js
@@ -509,8 +509,12 @@ geo.map = function (arg) {
       layerName, m_this, arg);
 
     if (newLayer) {
-
       m_this.addChild(newLayer);
+      m_this.children().forEach(function (c) {
+        if (c instanceof geo.gui.uiLayer) {
+          c.moveToTop();
+        }
+      });
       newLayer._update();
       m_this.modified();
 

--- a/testing/test-cases/phantomjs-tests/layerReorder.js
+++ b/testing/test-cases/phantomjs-tests/layerReorder.js
@@ -85,10 +85,6 @@ describe('Test the zIndex property of layers', function () {
   });
 });
 
-describe('UI Layer Z Index', function () {
-  'use strict'
-});
-
 describe('Test reordering layers', function () {
   'use strict';
 

--- a/testing/test-cases/phantomjs-tests/layerReorder.js
+++ b/testing/test-cases/phantomjs-tests/layerReorder.js
@@ -72,6 +72,21 @@ describe('Test the zIndex property of layers', function () {
     expect(getZIndex(l2)).toBe(12);
     expect(getZIndex(l3)).toBe(10);
   });
+
+  it('implicitly moves UI layer to top', function () {
+    var map = createMap(),
+        ui = map.createLayer('ui'),
+        l2 = map.createLayer('feature'),
+        l3 = map.createLayer('feature', {zIndex: 10});
+
+      expect(l2.zIndex()).toBeLessThan(l3.zIndex());
+      expect(ui.zIndex()).toBeGreaterThan(l2.zIndex());
+      expect(ui.zIndex()).toBeGreaterThan(l3.zIndex());
+  });
+});
+
+describe('UI Layer Z Index', function () {
+  'use strict'
 });
 
 describe('Test reordering layers', function () {


### PR DESCRIPTION
However, the user can still override this behavior by explicitly calling move up/down on a single layer after it has been added to the map. If this is not the desired behavior I can add a few more checks for those methods, but right now, whenever a new layer is added, the map's createLayer method will check for a UI layer and move to top. Added a test inside the layerReordering suite. 