### PR TITLE
Fix the widgets example.

### DIFF
--- a/examples/common/css/examples.css
+++ b/examples/common/css/examples.css
@@ -7,6 +7,7 @@ html, body {
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  overflow: hidden;
 }
 
 #map {

--- a/examples/main.css
+++ b/examples/main.css
@@ -1,3 +1,7 @@
+html, body {
+  overflow: auto;
+}
+
 .thumbnail {
   position: relative;
   overflow: hidden;

--- a/examples/widgets/example.json
+++ b/examples/widgets/example.json
@@ -6,5 +6,5 @@
   "about": {
     "text": "This example shows how the widgets API can be used to place elements on top of the map."
   },
-  "disabled": true
+  "disabled": false
 }

--- a/examples/widgets/main.js
+++ b/examples/widgets/main.js
@@ -62,8 +62,8 @@ $(function () {
   // Create a time series plot widget
   var widget = ui.createWidget('dom', {
     position: {
-      x: 20,
-      y: map.node().height() - 410 - 20
+      left: 20,
+      bottom: 20
     }
   });
   var $widget = $(widget.canvas());


### PR DESCRIPTION
If the widget uses a position with x and y parameters, these are expected to be in the map interface gcs (latitude and longitude).  Rather, one should use top, left, right, and bottom for fixed screen locations.

Also, I noticed of Firefox that the examples had a needless vertical scrollbar, which I have hidden.

This fixes issue #519.