### PR TITLE
Use relative urls to data files in examples for github.io

### DIFF
--- a/examples/quads/main.js
+++ b/examples/quads/main.js
@@ -21,7 +21,7 @@ $(function () {
       .data([{
         ll: {x: -108, y: 29},
         ur: {x: -88, y: 49},
-        image: '/data/tilefancy.png'
+        image: '../../data/tilefancy.png'
       }, {
         ll: {x: -88, y: 29},
         ur: {x: -58, y: 49},
@@ -46,25 +46,25 @@ $(function () {
         lr: {x: -33, y: 9},
         ur: {x: -68, y: 9},
         ul: {x: -58, y: 29},
-        image: '/data/tilefancy.png'
+        image: '../../data/tilefancy.png'
       }, {
         ll: {x: -128, y: 29},
         ur: {x: -108, y: 49},
-        image: '/data/nosuchimage.png'
+        image: '../../data/nosuchimage.png'
       }, {
         ul: {x: -128, y: 29},
         ur: {x: -108, y: 29},
         ll: {x: -123, y: 9},
         lr: {x: -98, y: 9},
         previewImage: null,
-        image: '/data/nosuchimage.png'
+        image: '../../data/nosuchimage.png'
       }, {
         ul: {x: -148, y: 29},
         ur: {x: -128, y: 29},
         ll: {x: -148, y: 9},
         lr: {x: -123, y: 9},
         previewImage: previewImage,
-        image: '/data/nosuchimage.png'
+        image: '../../data/nosuchimage.png'
       }, {
         ll: {x: -138, y: 29},
         ur: {x: -128, y: 39},
@@ -90,13 +90,13 @@ $(function () {
         lr: {x: -88, y: 49},
         ur: {x: -108, y: 59},
         ul: {x: -88, y: 59},
-        image: '/data/tilefancy.png'
+        image: '../../data/tilefancy.png'
       }, {
         ll: {x: -88, y: 49},
         ur: {x: -68, y: 49},
         ul: {x: -88, y: 59},
         lr: {x: -68, y: 59},
-        image: '/data/tilefancy.png'
+        image: '../../data/tilefancy.png'
       */
       }])
       .style({
@@ -140,5 +140,5 @@ $(function () {
     quadDebug.quads = quads;
   };
 
-  previewImage.src = '/data/grid.jpg';
+  previewImage.src = '../../data/grid.jpg';
 });

--- a/examples/reprojection/index.jade
+++ b/examples/reprojection/index.jade
@@ -7,7 +7,7 @@ block append mainContent
       select#layer-url.layerparam(param-name="url", list="url-list", placeholder="http://otile1.mqcdn.com/tiles/1.0.0/map/{z}/{x}/{y}.png")
         option(value="http://otile1.mqcdn.com/tiles/1.0.0/map/{z}/{x}/{y}.png", credit='Tiles Courtesy of <a href="http://www.mapquest.com/">MapQuest</a>') MapQuest
         option(value="http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png", credit="© OpenStreetMap contributors") OpenStreetMap
-        option(value="/data/tilefancy.png", credit="") Fancy Test Tile
+        option(value="../../data/tilefancy.png", credit="") Fancy Test Tile
         option(value="http://otile1.mqcdn.com/tiles/1.0.0/sat/{z}/{x}/{y}.png", credit='Tiles Courtesy of <a href="http://www.mapquest.com/">MapQuest</a>') MapQuest Satellite
         option(value="http://tile.stamen.com/toner-lite/{z}/{x}/{y}.png", credit='Map tiles by <a href="http://stamen.com">Stamen Design</a>, under <a href="http://creativecommons.org/licenses/by/3.0">CC BY 3.0</a>. Data by <a href="http://openstreetmap.org">OpenStreetMap</a>, under <a href="http://www.openstreetmap.org/copyright">ODbL</a>.') Toner Lite
     .form-group(title="Web maps are most often rendered using a Mercator geographic coordinate system, but other projections can be used.  See spatialreference.org for more information on projections.")

--- a/examples/tiles/index.jade
+++ b/examples/tiles/index.jade
@@ -52,7 +52,7 @@ block append mainContent
       datalist#url-list
         option(value="http://otile1.mqcdn.com/tiles/1.0.0/map/{z}/{x}/{y}.png", credit='Tiles Courtesy of <a href="http://www.mapquest.com/">MapQuest</a>') MapQuest
         option(value="http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png", credit="© OpenStreetMap contributors") OSM
-        option(value="/data/tilefancy.png", credit="") Fancy Test Tile
+        option(value="../../data/tilefancy.png", credit="") Fancy Test Tile
         option(value="http://otile1.mqcdn.com/tiles/1.0.0/sat/{z}/{x}/{y}.png", credit='Tiles Courtesy of <a href="http://www.mapquest.com/">MapQuest</a>') MapQuest Satellite
         option(value="http://tile.stamen.com/toner-lite/{z}/{x}/{y}.png", credit='Map tiles by <a href="http://stamen.com">Stamen Design</a>, under <a href="http://creativecommons.org/licenses/by/3.0">CC BY 3.0</a>. Data by <a href="http://openstreetmap.org">OpenStreetMap</a>, under <a href="http://www.openstreetmap.org/copyright">ODbL</a>.') Toner Lite
     .form-group(title="The subdomains used to fetch tiles.  This can be a comma-separated list or a string of single-letter subdomains.")


### PR DESCRIPTION
On github.io, our `/dist` directory isn't mounted at `/`, but rather at `/geojs/`.  To make the code interoperable between our development server and the deployment, we need to use relative paths.