### PR TITLE
Don't load all tiles when keepLower is false

### DIFF
--- a/src/core/tileLayer.js
+++ b/src/core/tileLayer.js
@@ -486,7 +486,7 @@
         if (!this._options.wrapX) {
           start.x = Math.min(Math.max(start.x, 0), nTilesLevel.x - 1);
           end.x = Math.min(Math.max(end.x, 0), nTilesLevel.x - 1);
-          if (level === minLevel) {
+          if (level === minLevel && this._options.keepLower) {
             start.x = 0;
             end.x = nTilesLevel.x - 1;
           }
@@ -494,7 +494,7 @@
         if (!this._options.wrapY) {
           start.y = Math.min(Math.max(start.y, 0), nTilesLevel.y - 1);
           end.y = Math.min(Math.max(end.y, 0), nTilesLevel.y - 1);
-          if (level === minLevel) {
+          if (level === minLevel && this._options.keepLower) {
             start.y = 0;
             end.y = nTilesLevel.y - 1;
           }


### PR DESCRIPTION
@manthey I'm not entirely sure why the `level === minLevel` block exists.  It causes problems when trying to use WMS tiles.  We set `keepLower=false` and as a result all tiles in a vertical strip are loaded.  In our [example](http://opengeoscience.github.io/geojs/examples/wms/), the browser slows to a crawl as you zoom in.  If you have any better solutions, let me know.