### PR TITLE
Fix a few issues with transitions.

### DIFF
--- a/examples/tiles/index.jade
+++ b/examples/tiles/index.jade
@@ -15,6 +15,9 @@ block append mainContent
     .form-group(title="Clamp vertical panning to the extent of the tiles.")
       label(for="map-clampBoundsY") Clamp Y Bounds
       input#map-clampBoundsY.mapparam(param-name="clampBoundsY", type="checkbox", placeholder="true", checked="checked")
+    .form-group(title="If clamping is turned off, spring back when the tiles are panned too far.")
+      label(for="mapinteractor-spring") Spring to Bounds
+      input#map-spring.mapparam(param-name="spring", type="checkbox", placeholder="false")
     .form-group(title="The starting x coordinate.  Changing this will also pan the current view.")
       label(for="map-x") Starting X
       input#map-x.mapparam(param-name="x", placeholder="-98")

--- a/examples/tiles/main.js
+++ b/examples/tiles/main.js
@@ -91,8 +91,6 @@ $(function () {
     }, 1000);
   });
 
-  var range = geo.transform.transformCoordinates(
-      'EPSG:4326', 'EPSG:3857', [{x: -180, y: 0}, {x: 180, y: 0}]);
   // Set map defaults to use our named node and have a reasonable center and
   // zoom level
   var mapParams = {
@@ -102,7 +100,7 @@ $(function () {
       y: 39.5
     },
     maxBounds: {},
-    zoom: query.zoom !== undefined ? parseFloat(query.zoom) : 3,
+    zoom: query.zoom !== undefined ? parseFloat(query.zoom) : 3
   };
   // Set the tile layer defaults to use the specified renderer and opacity
   var layerParams = {
@@ -117,6 +115,9 @@ $(function () {
   if (layerParams.renderer === 'null' || layerParams.renderer === 'html') {
     layerParams.renderer = null;
   }
+  // Default values for spring-back
+  var springEnabled = {spring: {enabled: true, springConstant: 0.00005}},
+      springDisabled = {spring: {enabled: false}};
   // Allow a custom tile url, including subdomains.
   if (query.url) {
     layerParams.url = query.url;
@@ -251,6 +252,10 @@ $(function () {
   if (query.projection) {
     map.camera().projection = query.projection;
   }
+  // Set the spring back.  This is set on the map interactor.
+  if (query.spring) {
+    map.interactor().options(springEnabled);
+  }
   // Enable debug classes, if requested.
   $('#map').toggleClass('debug-label', (
       query.debug === 'true' || query.debug === 'all'))
@@ -323,6 +328,10 @@ $(function () {
         break;
       case 'round':
         layerParams.tileRounding = Math[value];
+        break;
+      case 'spring':
+        map.interactor().options(
+            value === 'true' ? springEnabled : springDisabled);
         break;
       case 'url':
         var url = processedValue;

--- a/src/core/event.js
+++ b/src/core/event.js
@@ -228,6 +228,18 @@ geo.event.transitionend = 'geo_transitionend';
 
 //////////////////////////////////////////////////////////////////////////////
 /**
+ * Triggered if a map navigation animation is cancelled.
+ *
+ * @property {geo.geoPosition} center The target center
+ * @property {number} zoom The target zoom level
+ * @property {number} duration The duration of the transition in milliseconds
+ * @property {function} ease The easing function
+ */
+//////////////////////////////////////////////////////////////////////////////
+geo.event.transitioncancel = 'geo_transitioncancel';
+
+//////////////////////////////////////////////////////////////////////////////
+/**
  * Triggered when the parallel projection mode is changes.
  *
  * @property paralellProjection {boolean} True if parallel projection is turned

--- a/src/core/map.js
+++ b/src/core/map.js
@@ -1004,7 +1004,11 @@ geo.map = function (arg) {
     }
 
     if (m_transition) {
-      m_queuedTransition = opts;
+      /* The queued transition needs to combine the current transition's
+       * endpoint, any other queued transition, and the new transition to be
+       * complete. */
+      m_queuedTransition = $.extend(
+        {}, m_transition.end || {}, m_queuedTransition || {}, opts);
       return m_this;
     }
 
@@ -1106,6 +1110,16 @@ geo.map = function (arg) {
 
     function anim(time) {
       var done = m_transition.done, next;
+      if (m_transition.cancel === true) {
+        /* Finish cancelling a transition. */
+        m_transition = null;
+        m_queuedTransition = null;
+        m_this.geoTrigger(geo.event.transitioncancel, opts);
+        if (done) {
+          done();
+        }
+        return;
+      }
       next = m_queuedTransition;
 
       if (!m_transition.start.time) {
@@ -1172,6 +1186,20 @@ geo.map = function (arg) {
       window.requestAnimationFrame(anim);
     }
     return m_this;
+  };
+
+  /**
+   * Cancel any existing transition.  The transition will send a cancel event
+   * at the next animation frame, but no further activity occurs.
+   *
+   * @returns {bool} true if a transition was in progress.
+   */
+  this.transitionCancel = function () {
+    if (m_transition && m_transition.cancel !== true) {
+      m_transition.cancel = true;
+      return true;
+    }
+    return false;
   };
 
   ////////////////////////////////////////////////////////////////////////////

--- a/testing/test-cases/phantomjs-tests/map.js
+++ b/testing/test-cases/phantomjs-tests/map.js
@@ -1,6 +1,8 @@
 // Test geo.core.map
 
-/*global describe, it, expect, geo, closeToEqual*/
+/* global describe, it, expect, geo, closeToEqual, mockAnimationFrame,
+   unmockAnimationFrame, stepAnimationFrame */
+
 describe('geo.core.map', function () {
   'use strict';
 
@@ -232,47 +234,6 @@ describe('geo.core.map', function () {
   });
 
   describe('Public utility methods', function () {
-    var animFrameCallbacks = [], animFrameIndex = 0;
-
-    /* Replace window.requestAnimationFrame with this function, then call
-     * stepAnimationFrame with a delta from when this was supposed to start to
-     * test asynchronous animations.
-     *
-     * @param {function} callback the function to call on an animation frame
-     *                            interval.
-     */
-    function mockRequestAnimationFrame(callback) {
-      animFrameIndex += 1;
-      var id = animFrameIndex;
-      animFrameCallbacks.push({id: id, callback: callback});
-    }
-
-    /* Replace window.cancelAnimationFrame with this function.
-     *
-     * @param {number} id id of the callback to cancel.
-     */
-    function mockCancelAnimationFrame(id) {
-      for (var i = 0; i < animFrameCallbacks.length; i += 1) {
-        if (animFrameCallbacks[i].id === id) {
-          animFrameCallbacks.splice(i, 1);
-          return;
-        }
-      }
-    }
-
-    /* Call all animation frame functions that have been captured.
-     *
-     * @param {float} time float milliseconds.
-     */
-    function stepAnimationFrame(time) {
-      var callbacks = animFrameCallbacks, action;
-      animFrameCallbacks = [];
-      while (callbacks.length > 0) {
-        action = callbacks.shift();
-        action.callback.call(window, time);
-      }
-    }
-
     /* Count the number of jquery events bounds to an element using a
      * particular namespace.
      *
@@ -371,9 +332,10 @@ describe('geo.core.map', function () {
         left: -250, top: -250, right: 250, bottom: 250});
       expect(zc.zoom).toBeCloseTo(4);
       expect(closeToEqual(zc.center, {x: 0, y: 0})).toBe(true);
-      expect(function () { m.zoomAndCenterFromBounds({
-        left: -250, top: 250, right: 250, bottom: -250}); }).toThrow(
-        new Error('Invalid bounds provided'));
+      expect(function () {
+        m.zoomAndCenterFromBounds({
+          left: -250, top: 250, right: 250, bottom: -250});
+      }).toThrow(new Error('Invalid bounds provided'));
       zc = m.zoomAndCenterFromBounds({
         left: 0, top: -500, right: 10, bottom: 500});
       expect(zc.zoom).toBeCloseTo(3);
@@ -393,10 +355,7 @@ describe('geo.core.map', function () {
     });
     it('transition', function () {
       var m = create_map(), start, wasCalled;
-      var origRequestAnimationFrame = window.requestAnimationFrame,
-          origCancelAnimationFrame = window.cancelAnimationFrame;
-      window.requestAnimationFrame = mockRequestAnimationFrame;
-      window.cancelAnimationFrame = mockCancelAnimationFrame;
+      mockAnimationFrame();
       expect(m.transition()).toBe(null);
       start = new Date().getTime();
       m.transition({
@@ -509,8 +468,29 @@ describe('geo.core.map', function () {
       stepAnimationFrame(start + 1000);
       expect(m.center().x).toBeCloseTo(0);
       expect(m.center().y).toBeCloseTo(0);
-      window.requestAnimationFrame = origRequestAnimationFrame;
-      window.cancelAnimationFrame = origCancelAnimationFrame;
+      // test cancel
+      start = new Date().getTime();
+      wasCalled = undefined;
+      m.transition({
+        center: {x: 10, y: 0},
+        duration: 1000,
+        done: function () {
+          wasCalled = true;
+        }
+      });
+      expect(m.transition().start.time).toBe(undefined);
+      stepAnimationFrame(start);
+      expect(m.transition().start.time).toBe(start);
+      expect(m.transition().time).toBe(0);
+      expect(m.transitionCancel()).toBe(true);
+      expect(m.transition()).not.toBe(null);
+      expect(m.transition().cancel).toBe(true);
+      expect(m.transitionCancel()).toBe(false);
+      expect(wasCalled).toBe(undefined);
+      stepAnimationFrame(start + 500);
+      expect(m.transition()).toBe(null);
+      expect(wasCalled).toBe(true);
+      unmockAnimationFrame();
     });
   });
 


### PR DESCRIPTION
There were several bugs with momentum, transitions, and spring-back.

If momentum was occurring, a mouse wheel event would take place in the wrong location.  For instance, pan a map such that it has momentum and use the mouse wheel to zoom.  The map zooms, but is pans back suddenly to the start of the momentum location.  Now, when a new mouse action occurs, momentum is canceled.

If a transition was occurring, it would "fight" with mouse interaction.  Now, when a mouse action occurs, a transition is canceled and the transitioncancel event is triggered.

Springback used hard-coded boundaries in a fixed coordinate system.  Now it uses maxBounds in the map coordinate system.

Added a spring to bounds option to the tiles example.

Moved the mockAnimationFrame functions to the testUtils.js file so it can be used in multiple tests.

Added a mockDate routine to facilitate testing momentum and springback.

This fixes issue #537.