### PR TITLE
Momentum on zoom and fix a momentum bug.

### DIFF
--- a/testing/js/testUtils.js
+++ b/testing/js/testUtils.js
@@ -327,7 +327,8 @@ function mockAnimationFrame(mockDate) {
 
 /**
  * Allow mocking calls to Date so that each new object is slightly after the
- * previous one.
+ * previous one.  Use a delta of 0 and calls to advanceDate() for complete
+ * controls.
  *
  * @param {number} delta number of milliseconds added to each call.
  */
@@ -343,6 +344,16 @@ function mockDate(delta) {
   window.unmockDate = function () {
     window.Date = origDate;
     window.unmockDate = undefined;
+    window.advanceDate = undefined;
+  };
+
+  /**
+   * Change the date that will be reported by new Date().
+   *
+   * @param {number} delta milliseconds to advance the date.
+   */
+  window.advanceDate = function (delta) {
+    startDate += delta;
   };
 
   /**


### PR DESCRIPTION
Momentum on zoom only applies when zoom is changed via a continuous action (the right mouse button, for instance).

Fixed a weird momentum "bounce".  Before, if you panned quickly, then stopped moving the mouse without releasing the mouse button, then release the mouse button a long time later, momentum is still applied.