### PR TITLE
Added zoom animation as an option.

### DIFF
--- a/examples/tiles/index.jade
+++ b/examples/tiles/index.jade
@@ -30,6 +30,9 @@ block append mainContent
     .form-group(title="Only allow integer zoom levels.")
       label(for="map-discrete") Discrete Zoom
       input#map-discrete.mapparam(param-name="discrete", type="checkbox", placeholder="false")
+    .form-group(title="Animate zoom transitions.")
+      label(for="mapinteractor-clampZoom") Animate Zoom
+      input#map-animateZoom.mapparam(param-name="animateZoom", type="checkbox", placeholder="true", checked="checked")
     .form-group(title="The lowest zoom level allowed.")
       label(for="map-min") Minimum Zoom
       input#map-min.mapparam(param-name="min", placeholder="0")

--- a/examples/tiles/main.js
+++ b/examples/tiles/main.js
@@ -256,6 +256,13 @@ $(function () {
   if (query.spring) {
     map.interactor().options(springEnabled);
   }
+  // Compute default values for zoom animation, then set the map interactor
+  var zoomAnimationDefault = map.interactor().options().zoomAnimation,
+      zoomAnimationEnabled = {zoomAnimation: $.extend(
+        {}, zoomAnimationDefault, {enabled: true})},
+      zoomAnimationDisabled = {zoomAnimation: {enabled: false}};
+  map.interactor().options(query.animateZoom !== 'false' ?
+    zoomAnimationEnabled : zoomAnimationDisabled);
   // Enable debug classes, if requested.
   $('#map').toggleClass('debug-label', (
       query.debug === 'true' || query.debug === 'all'))
@@ -293,6 +300,10 @@ $(function () {
       case 'allowRotation':
         mapParams.allowRotation = get_allow_rotation(value);
         map.allowRotation(mapParams.allowRotation);
+        break;
+      case 'animateZoom':
+        map.interactor().options(
+            value === 'true' ? zoomAnimationEnabled : zoomAnimationDisabled);
         break;
       case 'debug':
         $('#map').toggleClass('debug-label', (

--- a/src/core/map.js
+++ b/src/core/map.js
@@ -1226,7 +1226,10 @@ geo.map = function (arg) {
    * Cancel any existing transition.  The transition will send a cancel event
    * at the next animation frame, but no further activity occurs.
    *
-   * @param {string} source option cause of the cancel.
+   * @param {string} [source] optional cause of the cancel.  This can be any
+   *                 value, but something like <method name>.<action> is
+   *                 recommended to allow other functions to determine the
+   *                 source and cause of the transition being canceled.
    * @returns {bool} true if a transition was in progress.
    */
   this.transitionCancel = function (source) {

--- a/src/core/mapInteractor.js
+++ b/src/core/mapInteractor.js
@@ -1064,7 +1064,7 @@ geo.mapInteractor = function (args) {
       return geo.util.debounce(delay, false, apply, accum);
     } else {
       return function (dz, dir) {
-        if (!dz) {
+        if (!dz && targetZoom === undefined) {
           return;
         }
         accum(dz, dir);

--- a/src/core/mapInteractor.js
+++ b/src/core/mapInteractor.js
@@ -1029,7 +1029,7 @@ geo.mapInteractor = function (args) {
             done: function (status) {
               status = status || {};
               if (!status.next && (!status.cancel ||
-                  status.source !== 'debounced_zoom.zoom')) {
+                  ('' + status.source).search(/\.zoom$/) < 0)) {
                 targetZoom = undefined;
               }
               /* If we were animating the zoom, if the zoom is continuous, just

--- a/src/core/tileLayer.js
+++ b/src/core/tileLayer.js
@@ -893,8 +893,8 @@
      * @returns {object} Local coordinates
      */
     this.fromLocal = function (pt, zoom) {
-      //DWM:: these need to alawys use the *layer* unitsPerPixel, or possibly
-      //DWM:: convert tile space using a transform
+      // these need to always use the *layer* unitsPerPixel, or possibly
+      // convert tile space using a transform
       var map = this.map(),
           unit = map.unitsPerPixel(zoom === undefined ? map.zoom() : zoom);
       return {

--- a/src/gl/vglRenderer.js
+++ b/src/gl/vglRenderer.js
@@ -23,6 +23,7 @@ geo.gl.vglRenderer = function (arg) {
       m_width = 0,
       m_height = 0,
       m_renderAnimFrameRef = null,
+      m_lastZoom,
       s_init = this._init,
       s_exit = this._exit;
 
@@ -169,15 +170,17 @@ geo.gl.vglRenderer = function (arg) {
     renderWindow.renderers().forEach(function (renderer) {
       var cam = renderer.camera();
       if (geo.util.compareArrays(view, cam.viewMatrix()) &&
-          geo.util.compareArrays(proj, cam.projectionMatrix())) {
+          geo.util.compareArrays(proj, cam.projectionMatrix()) &&
+          m_lastZoom === map.zoom()) {
         return;
       }
+      m_lastZoom = map.zoom();
       cam.setViewMatrix(view, true);
       cam.setProjectionMatrix(proj);
       if (proj[1] || proj[2] || proj[3] || proj[4] || proj[6] || proj[7] ||
           proj[8] || proj[9] || proj[11] || proj[15] !== 1 || !ortho ||
-          (parseFloat(map.zoom().toFixed(6)) !==
-           parseFloat(map.zoom().toFixed(0)))) {
+          (parseFloat(m_lastZoom.toFixed(6)) !==
+           parseFloat(m_lastZoom.toFixed(0)))) {
         /* Don't align texels */
         cam.viewAlignment = function () {
           return null;

--- a/testing/test-cases/phantomjs-tests/map.js
+++ b/testing/test-cases/phantomjs-tests/map.js
@@ -488,6 +488,34 @@ describe('geo.core.map', function () {
       stepAnimationFrame(start + 500);
       expect(m.transition()).toBe(null);
       expect(wasCalled).toBe(true);
+      // test cancel with another transition added before the next render
+      wasCalled = false;
+      m.transition({
+        center: {x: -10, y: 0},
+        duration: 1000,
+        done: function () {
+          wasCalled = true;
+        }
+      });
+      stepAnimationFrame(start);
+      expect(m.transitionCancel()).toBe(true);
+      /* This should never be started or finished */
+      m.transition({
+        center: {x: 0, y: 0},
+        duration: 1000,
+        done: function () {
+          wasCalled = 'never';
+        }
+      });
+      expect(m.transitionCancel()).toBe(true);
+      m.transition({
+        center: {x: 10, y: 0},
+        duration: 1000
+      });
+      expect(wasCalled).toBe(false);
+      stepAnimationFrame(start + 500);
+      expect(m.transition()).not.toBe(null);
+      expect(wasCalled).toBe(true);
       unmockAnimationFrame();
     });
   });

--- a/testing/test-cases/phantomjs-tests/map.js
+++ b/testing/test-cases/phantomjs-tests/map.js
@@ -396,19 +396,15 @@ describe('geo.core.map', function () {
       stepAnimationFrame(start);
       // the first transition gets cancelled, as the second transition will
       // perform the entire action.
-      expect(m.transition().start.time).toBe(undefined);
-      expect(m.center().x).toBeCloseTo(10);
-      expect(m.center().y).toBeCloseTo(0);
-      stepAnimationFrame(start + 1);
-      expect(m.transition().start.time).toBe(start + 1);
+      expect(m.transition().start.time).toBe(start);
       expect(m.transition().time).toBe(0);
       expect(m.center().x).toBeCloseTo(10);
       expect(m.center().y).toBeCloseTo(0);
-      stepAnimationFrame(start + 501);
+      stepAnimationFrame(start + 500);
       expect(m.transition().time).toBeCloseTo(500);
       expect(m.center().x).toBeCloseTo(15);
       expect(m.center().y).toBeCloseTo(5, 1);
-      stepAnimationFrame(start + 1001);
+      stepAnimationFrame(start + 1000);
       expect(m.transition()).toBe(null);
       expect(m.center().x).toBeCloseTo(20);
       expect(m.center().y).toBeCloseTo(10);

--- a/testing/test-cases/phantomjs-tests/mapInteractor.js
+++ b/testing/test-cases/phantomjs-tests/mapInteractor.js
@@ -233,6 +233,7 @@ describe('mapInteractor', function () {
     var interactor = geo.mapInteractor({
       map: map,
       momentum: {enabled: false},
+      zoomAnimation: {enabled: false},
       panMoveButton: null,
       panWheelEnabled: false,
       zoomMoveButton: null,
@@ -273,6 +274,7 @@ describe('mapInteractor', function () {
 
     var interactor = geo.mapInteractor({
       map: map,
+      zoomAnimation: {enabled: false},
       panMoveButton: null,
       panWheelEnabled: false,
       zoomMoveButton: 'right',
@@ -867,6 +869,7 @@ describe('mapInteractor', function () {
       var map = mockedMap('#mapNode1'),
           interactor = geo.mapInteractor({
             map: map,
+            zoomAnimation: {enabled: false},
             throttle: 100,
             momentum: {
               enabled: false


### PR DESCRIPTION
Added zoom animation as an option. The speed and easing can be adjusted.

When a second transition is queued, we have a one animation frame delay when neither the current nor the new animation was being applied.  This delay has been removed.

Added some code to ensure pixel-perfect alignment in certain instances where it seemed like it didn't happen.

This resolves issue #542.