### PR TITLE
Clean up attribution on map exit.

### DIFF
--- a/src/core/map.js
+++ b/src/core/map.js
@@ -859,7 +859,6 @@ geo.map = function (arg) {
    */
   ////////////////////////////////////////////////////////////////////////////
   this.exit = function () {
-    m_this.node().find('.geo-attribution').remove();
     var i, layers = m_this.children();
     for (i = 0; i < layers.length; i += 1) {
       layers[i]._exit();
@@ -869,6 +868,8 @@ geo.map = function (arg) {
       m_this.interactor(null);
     }
     m_this.node().off('.geo');
+    /* make sure the map node has nothing left in it */
+    m_this.node().empty();
     $(window).off('resize', resizeSelf);
     s_exit();
   };

--- a/src/core/map.js
+++ b/src/core/map.js
@@ -859,6 +859,7 @@ geo.map = function (arg) {
    */
   ////////////////////////////////////////////////////////////////////////////
   this.exit = function () {
+    m_this.node().find('.geo-attribution').remove();
     var i, layers = m_this.children();
     for (i = 0; i < layers.length; i += 1) {
       layers[i]._exit();

--- a/testing/test-cases/phantomjs-tests/map.js
+++ b/testing/test-cases/phantomjs-tests/map.js
@@ -295,9 +295,11 @@ describe('geo.core.map', function () {
 
     it('exit', function () {
       var m = create_map();
+      m.updateAttribution('Sample');
       expect(count_events(m.node(), 'geo')).toBeGreaterThan(0);
       m.exit();
       expect(count_events(m.node(), 'geo')).toBe(0);
+      expect($('#map').children().length).toBe(0);
     });
     it('pan, clampBoundsX, and clampBoundsY', function () {
       var m = create_map({


### PR DESCRIPTION
When map.exit() is called, it didn't delete the attribution div.