### PR TITLE
Fix an alignment issue with the null renderer.

### DIFF
--- a/src/tileLayer.js
+++ b/src/tileLayer.js
@@ -1025,8 +1025,8 @@ module.exports = (function () {
               rotation = map.rotation(),
               rx = -to.x + -(view.left + view.right) / 2 + offset.x,
               ry = -to.y + -(view.bottom + view.top) / 2 + offset.y,
-              dx = (rx + map.size().width / 2) * scale,
-              dy = (ry + map.size().height / 2) * scale;
+              dx = (rx + map.size().width / 2),
+              dy = (ry + map.size().height / 2);
 
           this.canvas().css({
             'transform-origin': '' +


### PR DESCRIPTION
At non-integer zoom levels, a pan would result in the tiles being offset from where they should have been.

I'm not sure how to test this short of using image comparison.  We could make a test with tile layers using different renderers of different opacities, so that they should line up after panning or other actions.

Fixes issue #575.