### PR TITLE
The performance value reported from Travis to cdash via notes wasn't calculating time properly.

### DIFF
--- a/src/polyfills.js
+++ b/src/polyfills.js
@@ -1,7 +1,7 @@
 // Add a polyfill for window.requestAnimationFrame.
 if (!window.requestAnimationFrame) {
   var _animationFrameFunc = [];
-  if (!window.performance) {
+  if (!window.performance || !window.performance.now) {
     window.performance = {now: function () { return new Date().getTime(); }};
   }
   window.requestAnimationFrame = function (func) {

--- a/tests/cases/osmLayer.js
+++ b/tests/cases/osmLayer.js
@@ -299,6 +299,7 @@ describe('geo.core.osmLayer', function () {
     waitForIt('tiles to load', function () {
       return Object.keys(layer.activeTiles).length === 17;
     });
+    measure_performance(mapinfo, 'osmLayer-d3-performance');
     it('destroy', destroy_map);
   });
 
@@ -328,10 +329,7 @@ describe('geo.core.osmLayer', function () {
     waitForIt('tiles to load', function () {
       return Object.keys(layer.activeTiles).length === 17;
     });
-    /* It seems that the canvas is too slow in phantomjs for this test to make
-     * sense, so disable it until we can figure a better way.
     measure_performance(mapinfo, 'osmLayer-canvas-performance');
-     */
     it('destroy', destroy_map);
   });
 

--- a/tests/notes.js
+++ b/tests/notes.js
@@ -44,7 +44,7 @@ function combine() {
 if (command === 'report') {
   console.log(JSON.stringify(combine(), null, 2));
 } else if (command === 'combine') {
-  fs.writeFileSync(output_file, JSON.stringify(combine()));
+  fs.writeFileSync(output_file, JSON.stringify(combine(), null, 2));
 } else if (command === 'reset') {
   reset();
 } else if (command === 'help') {


### PR DESCRIPTION
Our test environment does something peculiar to the time values, such that the time stamp of animation frames is not directly comparable to either the javascript date obtained by `new Date()` (it is off by a few seconds), nor with `window.performance.now()` (which reports values that are probably time-from-start in milliseconds rather than epoch milliseconds).

Also, we only reported timings for mocked vgl osm tiles.  This is now reporting timings for canvas and svg tiles, too.