### PR TITLE
Update midas urls to https

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,7 @@ function(add_geojs_test test_name)
   set_property(TEST "notes-report" APPEND PROPERTY DEPENDS "${test_name}")
 endfunction()
 
-set(MIDAS_BASE_URL "http://midas3.kitware.com/midas" CACHE STRING "MIDAS data store URL.")
+set(MIDAS_BASE_URL "https://midas3.kitware.com/midas" CACHE STRING "MIDAS data store URL.")
 mark_as_advanced(MIDAS_BASE_URL)
 set(MIDAS_COMMUNITY "GeoJS" CACHE STRING "MIDAS community hosting test images.")
 mark_as_advanced(MIDAS_COMMUNITY)

--- a/testing/test-runners/midas_handler.py
+++ b/testing/test-runners/midas_handler.py
@@ -20,7 +20,7 @@ class MidasHandler(object):
     '''
 
     def __init__(self,
-                 MIDAS_BASE_URL='http://midas3.kitware.com/midas',
+                 MIDAS_BASE_URL='https://midas3.kitware.com/midas',
                  MIDAS_COMMUNITY='geojs'):
         '''
         Initialize private variables.
@@ -343,7 +343,7 @@ if __name__ == '__main__':
         sys.exit(1)
 
     path = [p for p in sys.argv[1].split('/') if p]
-    handler = MidasHandler('http://midas3.kitware.com/midas', 'geojs')
+    handler = MidasHandler('https://midas3.kitware.com/midas', 'geojs')
     images = handler.getImages(path, int(sys.argv[2]))
 
     img_base, img_ext = os.path.splitext(path[-1])

--- a/testing/test-runners/selenium_test.py.in
+++ b/testing/test-runners/selenium_test.py.in
@@ -237,7 +237,7 @@ class BaseTest(TestCase):
     testPath = ('test', 'selenium')
 
     #: A tuple representing the relative path to test data relative to the
-    #: `geojs MIDAS community <http://midas3.kitware.com/midas/community/40>`_.
+    #: `geojs MIDAS community <https://midas3.kitware.com/midas/community/40>`_.
     midasPath = ('Testing', ) + testPath
 
     #: A tuple representing the path to the selenium test
@@ -259,7 +259,7 @@ class BaseTest(TestCase):
 
     #: A :py:class:`midas_handler.MidasHandler` object providing methods for downloading and
     #: uploading data to the
-    #: `geojs MIDAS community <http://midas3.kitware.com/midas/community/40>`_.
+    #: `geojs MIDAS community <https://midas3.kitware.com/midas/community/40>`_.
     midas = MidasHandler(MIDAS_BASE_URL, MIDAS_COMMUNITY)
 
     #: The revision number of the test.  This value should be set by


### PR DESCRIPTION
The upload script was failing because Midas sends a 302 redirect, which causes the requests package to switch from POST to GET on the redirected URL.