### PR TITLE
Fix delete polygon with stroke

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "geojs",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "JavaScript Geo visualization and Analysis Library",
   "homepage": "https://github.com/OpenGeoscience/geojs",
   "main": "geo.js",

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -73,7 +73,7 @@ copyright = u'2014, Kitware, Inc.'
 # built documents.
 #
 # The short X.Y version.
-version = '0.10.0'
+version = '0.10.1'
 # The full version, including alpha/beta/rc tags.
 release = version
 

--- a/geo.js
+++ b/geo.js
@@ -32103,6 +32103,14 @@ return /******/ (function(modules) { // webpackBootstrap
 	        m_features[i]._exit();
 	        m_this.dataTime().modified();
 	        m_this.modified();
+	      }
+	    }
+
+	    // Loop through a second to time actually remove
+	    // the given feature from the array because the
+	    // `_exit` call above may mutate it.
+	    for (i = 0; i < m_features.length; i += 1) {
+	      if (m_features[i] === feature) {
 	        m_features.splice(i, 1);
 	      }
 	    }
@@ -47064,7 +47072,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	  this._checkForStroke = function () {
 	    if (s_style('stroke') === false) {
 	      if (m_lineFeature && m_this.layer()) {
-	        m_this.layer().removeFeature(m_lineFeature);
+	        m_this.layer().deleteFeature(m_lineFeature);
 	        m_lineFeature = null;
 	      }
 	      return;
@@ -47144,7 +47152,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	  ////////////////////////////////////////////////////////////////////////////
 	  this._exit = function () {
 	    if (m_lineFeature && m_this.layer()) {
-	      m_this.layer().removeFeature(m_lineFeature);
+	      m_this.layer().deleteFeature(m_lineFeature);
 	      m_lineFeature = null;
 	    }
 	    s_exit();
@@ -47610,14 +47618,14 @@ return /******/ (function(modules) { // webpackBootstrap
 /* 229 */
 /***/ function(module, exports, __webpack_require__) {
 
-	module.exports = ("0.10.0");
+	module.exports = ("0.10.1");
 
 
 /***/ },
 /* 230 */
 /***/ function(module, exports, __webpack_require__) {
 
-	module.exports = ("49720649e1585e43d139e7de6cb40ad2aed89c05");
+	module.exports = ("f4a5a6af9b762c4261dd1e9cfeacd2df6e9b362d");
 
 
 /***/ },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geojs",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "JavaScript Geo visualization and Analysis Library",
   "homepage": "https://github.com/OpenGeoscience/geojs",
   "license": "Apache-2.0",

--- a/src/featureLayer.js
+++ b/src/featureLayer.js
@@ -65,6 +65,14 @@ var featureLayer = function (arg) {
         m_features[i]._exit();
         m_this.dataTime().modified();
         m_this.modified();
+      }
+    }
+
+    // Loop through a second to time actually remove
+    // the given feature from the array because the
+    // `_exit` call above may mutate it.
+    for (i = 0; i < m_features.length; i += 1) {
+      if (m_features[i] === feature) {
         m_features.splice(i, 1);
       }
     }

--- a/src/polygonFeature.js
+++ b/src/polygonFeature.js
@@ -277,7 +277,7 @@ var polygonFeature = function (arg) {
   this._checkForStroke = function () {
     if (s_style('stroke') === false) {
       if (m_lineFeature && m_this.layer()) {
-        m_this.layer().removeFeature(m_lineFeature);
+        m_this.layer().deleteFeature(m_lineFeature);
         m_lineFeature = null;
       }
       return;
@@ -357,7 +357,7 @@ var polygonFeature = function (arg) {
   ////////////////////////////////////////////////////////////////////////////
   this._exit = function () {
     if (m_lineFeature && m_this.layer()) {
-      m_this.layer().removeFeature(m_lineFeature);
+      m_this.layer().deleteFeature(m_lineFeature);
       m_lineFeature = null;
     }
     s_exit();

--- a/tests/cases/polygonFeature.js
+++ b/tests/cases/polygonFeature.js
@@ -43,6 +43,7 @@ describe('geo.polygonFeature', function () {
     fillColor: function (d, idx, poly, polyidx) {
       return poly.fillColor !== undefined ? poly.fillColor : 'blue';
     },
+    stroke: true,
     uniformPolygon: function (d) {
       return d.uniformPolygon !== undefined ? d.uniformPolygon : false;
     }


### PR DESCRIPTION
I noticed this while testing the examples for the release.  Trying to remove a stroked polygon was throwing an exception because of a typo and a bug in how the internal references were managed.

I also bumped to version 0.10.1 because I already published 0.10.0.  😞 