### PR TITLE
Fix an interactor bug with momentum.

### DIFF
--- a/src/mapInteractor.js
+++ b/src/mapInteractor.js
@@ -636,7 +636,7 @@ var mapInteractor = function (args) {
         (!m_mouse.buttons.left || m_options.click.buttons.left) &&
         (!m_mouse.buttons.right || m_options.click.buttons.right) &&
         (!m_mouse.buttons.middle || m_options.click.buttons.middle)) {
-      m_clickMaybe = true;
+      m_clickMaybe = {x: m_mouse.page.x, y: m_mouse.page.y};
       if (m_options.click.duration > 0) {
         window.setTimeout(function () {
           m_clickMaybe = false;
@@ -768,7 +768,10 @@ var mapInteractor = function (args) {
     m_this._getMouseButton(evt);
     m_this._getMouseModifiers(evt);
 
-    if (m_options.click.cancelOnMove) {
+    /* Only cancel possible clicks on move if we actually moved */
+    if (m_options.click.cancelOnMove && (m_clickMaybe.x === undefined ||
+        m_mouse.page.x !== m_clickMaybe.x ||
+        m_mouse.page.y !== m_clickMaybe.y)) {
       m_clickMaybe = false;
     }
     if (m_clickMaybe) {

--- a/src/mapInteractor.js
+++ b/src/mapInteractor.js
@@ -611,7 +611,7 @@ var mapInteractor = function (args) {
       if (!keepQueue) {
         m_queue = {};
       }
-      m_state = {};
+      clearState();
     }
     return out;
   };
@@ -710,6 +710,7 @@ var mapInteractor = function (args) {
         $(document).on('mousemove.geojs', m_this._handleMouseMoveDocument);
       }
       $(document).on('mouseup.geojs', m_this._handleMouseUpDocument);
+      m_state.boundDocumentHandlers = true;
     }
 
   };
@@ -725,7 +726,7 @@ var mapInteractor = function (args) {
       return;
     }
 
-    if (m_state.action) {
+    if (m_state.boundDocumentHandlers) {
       // If currently performing a navigation action, the mouse
       // coordinates will be captured by the document handler.
       return;
@@ -810,6 +811,14 @@ var mapInteractor = function (args) {
     // Prevent default to stop text selection in particular
     evt.preventDefault();
   };
+
+  /**
+   * Clear the action state, but remember if we have bound document handlers.
+   * @private
+   */
+  function clearState() {
+    m_state = {boundDocumentHandlers: m_state.boundDocumentHandlers};
+  }
 
   /**
    * Use interactor options to modify the mouse velocity by momentum
@@ -975,6 +984,7 @@ var mapInteractor = function (args) {
 
     // unbind temporary handlers on document
     $(document).off('.geojs');
+    m_state.boundDocumentHandlers = false;
 
     if (m_mouse.buttons.right) {
       evt.preventDefault();
@@ -997,7 +1007,7 @@ var mapInteractor = function (args) {
 
     // reset the interactor state
     oldAction = m_state.action;
-    m_state = {};
+    clearState();
 
     // if momentum is enabled, start the action here
     if (m_options.momentum.enabled &&
@@ -1050,6 +1060,7 @@ var mapInteractor = function (args) {
 
     // unbind temporary handlers on document
     $(document).off('.geojs');
+    m_state.boundDocumentHandlers = false;
 
     // reset click detector variable
     m_clickMaybe = false;
@@ -1322,7 +1333,7 @@ var mapInteractor = function (args) {
 
       // stop panning when the speed is below the threshold
       if (!v) {
-        m_state = {};
+        clearState();
         return;
       }
 

--- a/src/mapInteractor.js
+++ b/src/mapInteractor.js
@@ -1016,8 +1016,8 @@ var mapInteractor = function (args) {
       var t = (new Date()).valueOf();
       var dt = t - m_mouse.time + m_mouse.deltaTime;
       if (t - m_mouse.time < m_options.momentum.stopTime) {
-        m_mouse.velocity.x = m_mouse.velocity.x * m_mouse.deltaTime / dt;
-        m_mouse.velocity.y = m_mouse.velocity.y * m_mouse.deltaTime / dt;
+        m_mouse.velocity.x *= m_mouse.deltaTime / dt;
+        m_mouse.velocity.y *= m_mouse.deltaTime / dt;
         m_mouse.deltaTime = dt;
       } else {
         m_mouse.velocity.x = m_mouse.velocity.y = 0;
@@ -1311,25 +1311,26 @@ var mapInteractor = function (args) {
     m_state.origAction = origAction;
     m_state.action = 'momentum';
     m_state.origin = m_this.mouse();
+    m_state.momentum = m_this.mouse();
     m_state.start = new Date();
     m_state.handler = function () {
       var v, s, last, dt;
 
-      // Not sure the correct way to do this.  We need the delta t for the
-      // next time step...  Maybe use a better interpolator and the time
-      // parameter from requestAnimationFrame.
-      dt = Math.min(m_mouse.deltaTime, 30);
       if (m_state.action !== 'momentum' ||
           !m_this.map() ||
           m_this.map().transition()) {
         // cancel if a new action was performed
         return;
       }
+      // Not sure the correct way to do this.  We need the delta t for the
+      // next time step...  Maybe use a better interpolator and the time
+      // parameter from requestAnimationFrame.
+      dt = Math.min(m_state.momentum.deltaTime, 30);
 
       last = m_state.start.valueOf();
       m_state.start = new Date();
 
-      v = modifyVelocity(m_mouse.velocity, m_state.start - last);
+      v = modifyVelocity(m_state.momentum.velocity, m_state.start - last);
 
       // stop panning when the speed is below the threshold
       if (!v) {
@@ -1348,18 +1349,18 @@ var mapInteractor = function (args) {
         v.x = 0;
         v.y = 0;
       }
-      m_mouse.velocity.x = v.x;
-      m_mouse.velocity.y = v.y;
+      m_state.momentum.velocity.x = v.x;
+      m_state.momentum.velocity.y = v.y;
 
       switch (m_state.origAction) {
         case 'zoom':
-          var dy = m_mouse.velocity.y * dt;
+          var dy = m_state.momentum.velocity.y * dt;
           m_callZoom(-dy * m_options.zoomScale / 120, m_state);
           break;
         default:
           m_this.map().pan({
-            x: m_mouse.velocity.x * dt,
-            y: m_mouse.velocity.y * dt
+            x: m_state.momentum.velocity.x * dt,
+            y: m_state.momentum.velocity.y * dt
           });
           break;
       }

--- a/tests/cases/mapInteractor.js
+++ b/tests/cases/mapInteractor.js
@@ -1397,4 +1397,46 @@ describe('mapInteractor', function () {
       expect(map.zoom()).toBe(3);
     });
   });
+  describe('Momemtum and mouse move interaction', function () {
+    var map, interactor;
+    beforeEach(function () {
+      /* we use the actual map as we need it to be a sceneobject */
+      map = create_map({discreteZoom: false, zoom: 2});
+      interactor = geo.mapInteractor({map: map});
+      map.interactor(interactor);
+    });
+    afterEach(function () {
+      map.exit();
+    });
+    it('Test mousemove after momementum', function () {
+      var lastmap;
+
+      function lastmove(evt) {
+        lastmap = evt.map;
+      }
+
+      map.geoOn(geo.event.mousemove, lastmove);
+      interactor.simulateEvent(
+        'mousemove', {map: {x: 4, y: 5}});
+      expect(lastmap).toEqual({x:4, y: 5});
+      interactor.simulateEvent(
+        'mousedown', {map: {x: 10, y: 10}, button: 'left'});
+      expect(lastmap).toEqual({x:4, y: 5});
+      interactor.simulateEvent(
+        'mouseup.geojs', {map: {x: 10, y: 10}, button: 'left'});
+      expect(lastmap).toEqual({x:4, y: 5});
+      interactor.simulateEvent(
+        'mousemove', {map: {x: 17, y: 27}});
+      expect(lastmap).toEqual({x:17, y: 27});
+      interactor.simulateEvent(
+        'mousedown', {map: {x: 30, y: 30}, button: 'right'});
+      expect(lastmap).toEqual({x:17, y: 27});
+      interactor.simulateEvent(
+        'mouseup.geojs', {map: {x: 30, y: 30}, button: 'right'});
+      expect(lastmap).toEqual({x:17, y: 27});
+      interactor.simulateEvent(
+        'mousemove', {map: {x: 47, y: 57}});
+      expect(lastmap).toEqual({x:47, y: 57});
+    });
+  });
 });

--- a/tests/cases/mapInteractor.js
+++ b/tests/cases/mapInteractor.js
@@ -876,7 +876,7 @@ describe('mapInteractor', function () {
             click: {
               enabled: true,
               cancelOnMove: false,
-              duration: 500
+              duration: 0
             },
             throttle: false
           }), triggered = 0;
@@ -905,7 +905,7 @@ describe('mapInteractor', function () {
             click: {
               enabled: true,
               cancelOnMove: true,
-              duration: 500
+              duration: 0
             },
             throttle: false
           }), triggered = 0;
@@ -927,6 +927,35 @@ describe('mapInteractor', function () {
       });
       expect(triggered).toBe(0);
     });
+    it('triggered by zero distance move then click', function () {
+      var map = mockedMap('#mapNode1'),
+          interactor = geo.mapInteractor({
+            map: map,
+            click: {
+              enabled: true,
+              cancelOnMove: true,
+              duration: 0
+            },
+            throttle: false
+          }), triggered = 0;
+
+      map.geoOn(geo.event.mouseclick, function () {
+        triggered += 1;
+      });
+      interactor.simulateEvent('mousedown', {
+        map: {x: 20, y: 20},
+        button: 'left'
+      });
+      interactor.simulateEvent('mousemove', {
+        map: {x: 20, y: 20},
+        button: 'left'
+      });
+      interactor.simulateEvent('mouseup', {
+        map: {x: 20, y: 20},
+        button: 'left'
+      });
+      expect(triggered).toBe(1);
+    });
     it('not triggered by disabled button', function () {
       var map = mockedMap('#mapNode1'),
           interactor = geo.mapInteractor({
@@ -934,7 +963,7 @@ describe('mapInteractor', function () {
             click: {
               enabled: true,
               cancelOnMove: true,
-              duration: 500,
+              duration: 0,
               buttons: {left: false}
             },
             throttle: false

--- a/tests/cases/polygonFeature.js
+++ b/tests/cases/polygonFeature.js
@@ -191,7 +191,7 @@ describe('geo.polygonFeature', function () {
       glCounts = $.extend({}, vgl.mockCounts());
     });
     waitForIt('next render gl A', function () {
-      return vgl.mockCounts().createProgram === (glCounts.createProgram || 0) + 2;
+      return vgl.mockCounts().createProgram >= (glCounts.createProgram || 0) + 2;
     });
     it('update the style', function () {
       polygons.style('fillColor', function (d) {


### PR DESCRIPTION
Using the default map interactor options, if you right click or right drag on the map, mousemove event cease getting generated.  The action state was marked as zoom or momentum after the mouse up (since it was performing that action), and this is never cleared as clearing is done on mouse up.  This blocked generating mousemove events.

Also, tweak one of the polygon tests to try to eliminate occasional test failures.