### PR TITLE
Change how zoom on a clamped map works.

### DIFF
--- a/src/gl/vglRenderer.js
+++ b/src/gl/vglRenderer.js
@@ -212,21 +212,9 @@ var vglRenderer = function (arg) {
     });
   };
 
-  // Connect to interactor events
-  // Connect to pan event
+  // Connect to pan event.  This is sufficient, as all zooms and rotations also
+  // produce a pan
   m_this.layer().geoOn(geo_event.pan, function (evt) {
-    void (evt);
-    m_this._updateRendererCamera();
-  });
-
-  // Connect to zoom event
-  m_this.layer().geoOn(geo_event.zoom, function (evt) {
-    void (evt);
-    m_this._updateRendererCamera();
-  });
-
-  // Connect to rotation event
-  m_this.layer().geoOn(geo_event.rotate, function (evt) {
     void (evt);
     m_this._updateRendererCamera();
   });


### PR DESCRIPTION
Before, if you have a clamped map or image and zoom in via the mouse wheel near an edge with adjacent empty space, the location of the map slides back and forth, rather than the point where you are zooming remaining under the mouse cursor.

Now, the coordinates under the mouse cursor remain the same, which means the map may not be clamped as fully as it could.  You can drag the map to reduce the empty space that clamp would have removed in the past, but not to increase it.  If you zoom in on an area off of the map, the clamping will still apply to prevent more than half of the viewport from having empty space.  This also affects how rotation clamping works.

There was an oddness where the reported map center was not the visible map center if clamping had occurred.  This has been fixed.

Also, noticed some needless code in the vgl renderer, so removed it.