### PR TITLE
Allow showing partial tiles on the edges of an image or map.

### DIFF
--- a/examples/tiles/main.js
+++ b/examples/tiles/main.js
@@ -167,6 +167,10 @@ $(function () {
         y: Math.ceil(h / (layerParams.tileHeight || 256) / scale)
       };
     };
+    layerParams.tilesMaxBounds = function (level) {
+      var scale = Math.pow(2, layerParams.maxLevel - level);
+      return {x: Math.floor(w / scale), y: Math.floor(h / scale)};
+    };
   }
   // Parse additional query options
   if (query.x !== undefined) {

--- a/src/canvas/quadFeature.js
+++ b/src/canvas/quadFeature.js
@@ -90,7 +90,12 @@ var canvas_quadFeature = function (arg) {
         opacity = quad.opacity;
         context2d.globalAlpha = opacity;
       }
-      context2d.drawImage(quad.image, 0, 0);
+      if (!quad.crop) {
+        context2d.drawImage(quad.image, 0, 0);
+      } else {
+        context2d.drawImage(quad.image, 0, 0, quad.crop.x, quad.crop.y, 0, 0,
+                            quad.crop.x, quad.crop.y);
+      }
     });
     if (opacity !== oldAlpha) {
       context2d.globalAlpha = oldAlpha;
@@ -146,6 +151,7 @@ inherit(canvas_quadFeature, quadFeature);
 var capabilities = {};
 capabilities[quadFeature.capabilities.color] = false;
 capabilities[quadFeature.capabilities.image] = true;
+capabilities[quadFeature.capabilities.imageCrop] = true;
 capabilities[quadFeature.capabilities.imageFull] = false;
 
 registerFeature('canvas', 'quad', canvas_quadFeature, capabilities);

--- a/src/canvas/tileLayer.js
+++ b/src/canvas/tileLayer.js
@@ -17,7 +17,11 @@ var canvas_tileLayer = function () {
     var bounds = this._tileBounds(tile),
         level = tile.index.level || 0,
         to = this._tileOffset(level),
+        crop = this.tileCropFromBounds(tile),
         quad = {};
+    if (crop) {
+      quad.crop = crop;
+    }
     quad.ul = this.fromLocal(this.fromLevel({
       x: bounds.left - to.x, y: bounds.top - to.y
     }, level), 0);

--- a/src/d3/quadFeature.js
+++ b/src/d3/quadFeature.js
@@ -231,6 +231,7 @@ inherit(d3_quadFeature, quadFeature);
 var capabilities = {};
 capabilities[quadFeature.capabilities.color] = true;
 capabilities[quadFeature.capabilities.image] = true;
+capabilities[quadFeature.capabilities.imageCrop] = false;
 capabilities[quadFeature.capabilities.imageFull] = false;
 
 registerFeature('d3', 'quad', d3_quadFeature, capabilities);

--- a/src/d3/tileLayer.js
+++ b/src/d3/tileLayer.js
@@ -10,6 +10,9 @@ var d3_tileLayer = function () {
       m_tiles = [];
 
   this._drawTile = function (tile) {
+    if (!m_quadFeature) {
+      return;
+    }
     var bounds = m_this._tileBounds(tile),
         level = tile.index.level || 0,
         to = this._tileOffset(level),

--- a/src/gl/quadFeature.js
+++ b/src/gl/quadFeature.js
@@ -43,7 +43,7 @@ var gl_quadFeature = function (arg) {
     'void main(void) {',
     '  mediump vec4 color = texture2D(sampler2d, iTextureCoord);',
     '  if (iTextureCoord.s > crop.s || 1.0 - iTextureCoord.t > crop.t) {',
-    '    return;',
+    '    discard;',
     '  }',
     '  color.w *= opacity;',
     '  gl_FragColor = color;',

--- a/src/gl/tileLayer.js
+++ b/src/gl/tileLayer.js
@@ -17,7 +17,14 @@ var gl_tileLayer = function () {
     var bounds = this._tileBounds(tile),
         level = tile.index.level || 0,
         to = this._tileOffset(level),
+        crop = this.tileCropFromBounds(tile),
         quad = {};
+    if (crop) {
+      quad.crop = {
+        x: crop.x / m_this._options.tileWidth,
+        y: crop.y / m_this._options.tileHeight
+      };
+    }
     quad.ul = this.fromLocal(this.fromLevel({
       x: bounds.left - to.x, y: bounds.top - to.y
     }, level), 0);

--- a/src/quadFeature.js
+++ b/src/quadFeature.js
@@ -321,9 +321,11 @@ var quadFeature = function (arg) {
           idx: i,
           pos: pos,
           opacity: opacity,
-          color: util.convertColor(colorFunc.call(m_this, d, i)),
-          reference: d.reference
+          color: util.convertColor(colorFunc.call(m_this, d, i))
         };
+        if (d.reference) {
+          quad.reference = d.reference;
+        }
         clrQuads.push(quad);
         quadinfo.clrquad = quad;
       } else {
@@ -340,9 +342,14 @@ var quadFeature = function (arg) {
         quad = {
           idx: i,
           pos: pos,
-          opacity: opacity,
-          reference: d.reference
+          opacity: opacity
         };
+        if (d.reference) {
+          quad.reference = d.reference;
+        }
+        if (d.crop) {
+          quad.crop = d.crop;
+        }
         if (image.complete && image.naturalWidth && image.naturalHeight) {
           quad.image = image;
         } else {
@@ -470,6 +477,8 @@ quadFeature.capabilities = {
   color: 'quad.color',
   /* support for parallelogram images */
   image: 'quad.image',
+  /* support for cropping quad images */
+  imageCrop: 'quad.imageCrop',
   /* support for arbitrary quad images */
   imageFull: 'quad.imageFull'
 };

--- a/src/tileLayer.js
+++ b/src/tileLayer.js
@@ -279,13 +279,13 @@ module.exports = (function () {
       var level = tile.index.level,
           bounds = this._tileBounds(tile);
       if (m_maxBounds[level] === undefined) {
-        m_maxBounds[level] = this.tilesMaxBounds(level);
+        m_maxBounds[level] = this.tilesMaxBounds(level) || null;
       }
       if (m_maxBounds[level] && (bounds.right > m_maxBounds[level].x ||
           bounds.bottom > m_maxBounds[level].y)) {
         return {
-          x: Math.min(m_maxBounds[level].x, bounds.right) - bounds.left,
-          y: Math.min(m_maxBounds[level].y, bounds.bottom) - bounds.top
+          x: Math.max(0, Math.min(m_maxBounds[level].x, bounds.right) - bounds.left),
+          y: Math.max(0, Math.min(m_maxBounds[level].y, bounds.bottom) - bounds.top)
         };
       }
     };

--- a/src/tileLayer.js
+++ b/src/tileLayer.js
@@ -122,6 +122,14 @@ module.exports = (function () {
    *   This function takes a zoom level argument and returns, in units of
    *   pixels, the coordinates of the point (0, 0) at the given zoom level
    *   relative to the bottom left corner of the domain.
+   * @param {function} [options.tileMaxBounds=null]
+   *   This function takes a zoom level argument and returns, in units of
+   *   pixels, the top, left, right, and bottom maximum value for which tiles
+   *   should be drawn at the given zoom level relative to the bottom left
+   *   corner of the domain.  This can be used to crop tiles at the edges of
+   *   tile layer.  Note that if tiles wrap, only complete tiles in the
+   *   wrapping direction(s) are supported, and this max bounds will probably
+   *   not behave properly.
    * @param {bool}   [options.topDown=false]  True if the gcs is top-down,
    *   false if bottom-up (the ingcs does not matter, only the gcs coordinate
    *   system).  When false, this inverts the gcs y-coordinate when calculating
@@ -170,6 +178,7 @@ module.exports = (function () {
     var s_init = this._init,
         s_exit = this._exit,
         m_lastTileSet = [],
+        m_maxBounds = [],
         m_exited;
 
     // copy the options into a private variable
@@ -238,6 +247,47 @@ module.exports = (function () {
       }
       var s = Math.pow(2, level);
       return {x: s, y: s};
+    };
+
+    /**
+     * The maximum tile bounds at the given zoom level, or null if no special
+     * tile bounds.
+     *
+     * @param {number} level A zoom level
+     * @returns {x: width, y: height} The maximum tile bounds in pixels for the
+     *      specified level, or null if none specified.
+     */
+    this.tilesMaxBounds = function (level) {
+      if (this._options.tilesMaxBounds) {
+        return this._options.tilesMaxBounds.call(this, level);
+      }
+      return null;
+    };
+
+    /**
+     * Get the crop values for a tile based on the tilesMaxBounds function.
+     * Returns undefined if the tile should not be cropped.
+     *
+     * @param {object} tile: the tile to compute crop values for.
+     * @returns {object} either undefined or an object with x and y values
+     *      which is the size in pixels for the tile.
+     */
+    this.tileCropFromBounds = function (tile) {
+      if (!this._options.tilesMaxBounds) {
+        return;
+      }
+      var level = tile.index.level,
+          bounds = this._tileBounds(tile);
+      if (m_maxBounds[level] === undefined) {
+        m_maxBounds[level] = this.tilesMaxBounds(level);
+      }
+      if (m_maxBounds[level] && (bounds.right > m_maxBounds[level].x ||
+          bounds.bottom > m_maxBounds[level].y)) {
+        return {
+          x: Math.min(m_maxBounds[level].x, bounds.right) - bounds.left,
+          y: Math.min(m_maxBounds[level].y, bounds.bottom) - bounds.top
+        };
+      }
     };
 
     /**
@@ -718,11 +768,13 @@ module.exports = (function () {
       }
 
       // get the layer node
-      var div = $(this._getSubLayer(tile.index.level)),
+      var level = tile.index.level,
+          div = $(this._getSubLayer(level)),
           bounds = this._tileBounds(tile),
           duration = this._options.animationDuration,
           container = $('<div class="geo-tile-container"/>').attr(
-            'tile-reference', tile.toString());
+            'tile-reference', tile.toString()),
+          crop;
 
       // apply a transform to place the image correctly
       container.append(tile.image);
@@ -731,6 +783,15 @@ module.exports = (function () {
         left: (bounds.left - parseInt(div.attr('offsetx') || 0, 10)) + 'px',
         top: (bounds.top - parseInt(div.attr('offsety') || 0, 10)) + 'px'
       });
+
+      crop = this.tileCropFromBounds(tile);
+      if (crop) {
+        container.css({
+          width: crop.x + 'px',
+          height: crop.y + 'px',
+          overflow: 'hidden'
+        });
+      }
 
       // apply fade in animation
       if (duration > 0) {
@@ -1423,9 +1484,10 @@ module.exports = (function () {
     url: null,
     subdomains: 'abc',
     tileOffset: function (level) {
-      void (level);
+      void level;
       return {x: 0, y: 0};
     },
+    tilesMaxBounds: null,
     topDown: false,
     keepLower: true,
     // cacheSize: 400,  // set depending on keepLower

--- a/src/tileLayer.js
+++ b/src/tileLayer.js
@@ -254,8 +254,8 @@ module.exports = (function () {
      * tile bounds.
      *
      * @param {number} level A zoom level
-     * @returns {x: width, y: height} The maximum tile bounds in pixels for the
-     *      specified level, or null if none specified.
+     * @returns {object} {x: width, y: height} The maximum tile bounds in
+     *      pixels for the specified level, or null if none specified.
      */
     this.tilesMaxBounds = function (level) {
       if (this._options.tilesMaxBounds) {

--- a/tests/cases/tileLayer.js
+++ b/tests/cases/tileLayer.js
@@ -665,6 +665,68 @@ describe('geo.tileLayer', function () {
           left: 960000, top: 1280000, right: 1280000, bottom: 1600000});
       });
     });
+    describe('tileCropFromBounds and tilesMaxBounds', function () {
+      var w = 5602, h = 4148,
+          mapOpts = {
+            unitsPerPixel: Math.pow(2, 5),
+            ingcs: '+proj=longlat +axis=esu',
+            gcs: '+proj=longlat +axis=enu',
+            maxBounds: {left: 0, top: 0, right: w, bottom: h},
+            center: {x: w / 2, y: h / 2},
+            max: 5
+          },
+          layerOpts = {
+            url: 'ignored',
+            maxLevel: 5,
+            tileOffset: function () { return {x: 0, y: 0}; },
+            tilesAtZoom: function (level) {
+              var scale = Math.pow(2, 5 - level);
+              return {
+                x: Math.ceil(w / 256 / scale),
+                y: Math.ceil(h / 256 / scale)
+              };
+            }
+          };
+      it('default', function () {
+        var layer = geo.tileLayer($.extend({}, layerOpts, {
+          map: map(mapOpts)
+        }));
+        expect(layer.tilesMaxBounds(0)).toBe(null);
+
+        var tile = layer._getTileCached({x: 21, y: 16, level: 5});
+        expect(layer.tileCropFromBounds(tile)).toBe(undefined);
+      });
+      it('with bounds', function () {
+        var tile;
+        var layer = geo.tileLayer($.extend({}, layerOpts, {
+          map: map(mapOpts),
+          tilesMaxBounds: function (level) {
+            var scale = Math.pow(2, 5 - level);
+            return {
+              x: Math.floor(w / scale),
+              y: Math.floor(h / scale)
+            };
+          }
+        }));
+        expect(layer.tilesMaxBounds(0)).toEqual({x: 175, y: 129});
+        expect(layer.tilesMaxBounds(5)).toEqual({x: w, y: h});
+
+        tile = layer._getTileCached({x: 21, y: 16, level: 5});
+        expect(layer.tileCropFromBounds(tile)).toEqual({x: 226, y: 52});
+
+        tile = layer._getTileCached({x: 4, y: 16, level: 5});
+        expect(layer.tileCropFromBounds(tile)).toEqual({x: 256, y: 52});
+
+        tile = layer._getTileCached({x: 21, y: 6, level: 5});
+        expect(layer.tileCropFromBounds(tile)).toEqual({x: 226, y: 256});
+
+        tile = layer._getTileCached({x: 5, y: 4, level: 3});
+        expect(layer.tileCropFromBounds(tile)).toEqual({x: 120, y: 13});
+
+        tile = layer._getTileCached({x: 0, y: 0, level: 0});
+        expect(layer.tileCropFromBounds(tile)).toEqual({x: 175, y: 129});
+      });
+    });
   });
   describe('Protected utility methods', function () {
     describe('_origin', function () {
@@ -1354,6 +1416,24 @@ describe('geo.tileLayer', function () {
         expect(l.canvas().find('.geo-tile-container').length).toBe(0);
         server.restore();
         console.warn.restore();
+      });
+
+      it('cropped tile', function () {
+        var w = 5602, h = 4148;
+        var l = layer_html({
+          url: function () { return '/data/white.jpg'; },
+          tilesMaxBounds: function (level) {
+            var scale = Math.pow(2, 5 - level);
+            return {
+              x: Math.floor(w / scale),
+              y: Math.floor(h / scale)
+            };
+          }
+        });
+        l.drawTile(l._getTileCached({x: 21, y: 16, level: 5}));
+        var c = l.canvas().find('.geo-tile-container');
+        expect(c.css('width')).toBe('226px');
+        expect(c.css('height')).toBe('52px');
       });
     });
 

--- a/tests/cases/tileLayer.js
+++ b/tests/cases/tileLayer.js
@@ -351,7 +351,8 @@ describe('geo.tileLayer', function () {
       tilesAtZoom: function (level) {
         var s = Math.pow(2, level);
         return {x: s, y: Math.ceil(s * 3 / 4)};
-      }
+      },
+      tilesMaxBounds: function () {}
     };
     opts.originalUrl = opts.url;
     it('Check tileLayer options', function () {


### PR DESCRIPTION
If the tileLayer tilesMaxBounds function is defined, some tiles may be cropped.  Tile cropping is implemented in the gl, canvas, and null renderers (but not d3).

This fixes issue #544.