### PR TITLE
Ignore geojson features with empty coordinates

### DIFF
--- a/src/jsonReader.js
+++ b/src/jsonReader.js
@@ -133,6 +133,13 @@ var jsonReader = function (arg) {
     features.forEach(function (feature) {
       Array.prototype.push.apply(normalized, m_this._feature(feature));
     });
+
+    // remove features with empty geometries
+    normalized = normalized.filter(function (feature) {
+      return feature.geometry &&
+        feature.geometry.coordinates &&
+        feature.geometry.coordinates.length;
+    });
     return normalized;
   };
 

--- a/tests/cases/geojsonReader.js
+++ b/tests/cases/geojsonReader.js
@@ -213,6 +213,31 @@ describe('geojsonReader', function () {
           coordinates: [1, 1]
         }
       }]);
+
+      it('empty geometry', function () {
+        expect(reader._featureArray({
+          type: 'FeatureCollection',
+          features: [{
+            type: 'Feature',
+            geometry: {
+              type: 'Point',
+              coordinates: []
+            }
+          }, {
+            type: 'Feature',
+            geometry: {
+              type: 'LineString',
+              coordinates: []
+            }
+          }, {
+            type: 'Feature',
+            geometry: {
+              type: 'Polygon',
+              coordinates: []
+            }
+          }]
+        })).toEqual([]);
+      });
     });
 
     describe('Errors', function () {


### PR DESCRIPTION
GeoJSON features with empty coordinate arrays validate correctly at geojsonlint, so we should handle them somehow.  In this PR, I just filter them out before returning from the reader otherwise the renders throw all sorts of ugly errors.