### PR TITLE
Update to VGL version 0.3.10.

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "sinon": "1.17.3",
     "style-loader": "^0.13.1",
     "url-loader": "^0.5.7",
-    "vgl": "0.3.9",
+    "vgl": "0.3.10",
     "webpack": "^1.12.14",
     "webpack-dev-server": "^1.14.1",
     "xmlbuilder": "^8.2.2"


### PR DESCRIPTION
This stops zero-length buffers from throwing GL warnings.