### PR TITLE
Reduce point clustering flicker.

### DIFF
--- a/src/map.js
+++ b/src/map.js
@@ -1704,6 +1704,7 @@ var map = function (arg) {
    *    with other settings applied.
    */
   function fix_zoom(zoom, ignoreDiscreteZoom) {
+    zoom = Math.round(zoom * 1e6) / 1e6;
     zoom = Math.max(
       Math.min(
         m_validZoomRange.max,

--- a/src/pointFeature.js
+++ b/src/pointFeature.js
@@ -143,7 +143,6 @@ var pointFeature = function (arg) {
     // prevent recomputing the clustering and set the new data array
     m_ignoreData = true;
     m_this.data(data);
-    m_this.draw();
   };
 
   ////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
There are two different contributing factors:

(1) some times zoom rounding caused a flicker.  In floating point, 7.99999999 is essentially 8.0, but their floors are different.  In general, round zoom values to six places.

(2) gratuitous drawing during the zoom event.  After reclustering, a point feature draw() call was being made.  This is never necessary (at least on current master).