### PR TITLE
Upload performance artifacts to s3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,24 @@
 language: node_js
-sudo: False
+sudo: false
 node_js:
-    - "0.12"
-
+- '0.12'
 cache:
-    directories:
-        - node_modules
-        - $HOME/cache
-
+  directories:
+  - node_modules
+  - "$HOME/cache"
 before_install:
-    - CACHE="${HOME}/cache" CMAKE_VERSION=3.5.0 CMAKE_SHORT_VERSION=3.5 source ./scripts/install_cmake.sh
-    - npm prune
-
+- CACHE="${HOME}/cache" CMAKE_VERSION=3.5.0 CMAKE_SHORT_VERSION=3.5 source ./scripts/install_cmake.sh
+- npm prune
 script:
-    - npm run build
-    - npm run docs
-    - mkdir _build
-    - ctest -S cmake/travis_build.cmake -VV || true
-    - if [ -f _build/test_failed ] ; then false ; fi
-
+- npm run build
+- npm run docs
+- mkdir _build
+- ctest -S cmake/travis_build.cmake -VV || true
+- if [ -f _build/test_failed ] ; then false ; fi
 after_success:
-  - npm run codecov
+- npm run codecov
+env:
+  global:
+  - secure: L6J79xqMkGc0i6A469jd+2nyJdvJSWRkEuhfvjMbv7wFyTHF8GYjceeenGGGnCxc62LpKFLLOU35ulRqOWMAUqgHOzXUo8BEZtc+XljGq25Uqgm0/z84p1vSbuH1tZyY7/PwM2m06UadWe9Y6Vo6qZsVuiUCiEjImfmzeP9fb5g=
+  - secure: Rj4jqVvqPV4H/E2tpWbONhQY6zyESWmJRLvZiZC55gR3D9EIfq8L5AYwF+BJVlYAPZ2g9vzsXUnLy07GDxE/MVsiooLdiU0WofRNbLCnJjijP+v2ZWCR/77Vl6hTDZ/5PeFT2zwNdFDcIOLONzJNzgrX0jqrIyuehReFmZVwTs0=
+  - secure: fBktMf44ZPj7Y4gAXJSOG3u0Bvo1jv9HKCeM0zVLOW61bDdMCbCHBAxGa0QxHht1aISm8DNnhTrnnzpeZLHUEYyVdqU3zmDxJILKEhhnEavWAXf1ZBIY/VPysA2S1MfrLfwgLTj5tCP+/1Ytet2CSp6mmTDBDzL90URoFUYwweU=

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,9 @@ script:
 - if [ -f _build/test_failed ] ; then false ; fi
 after_success:
 - npm run codecov
+- pip install --user GitPython boto3
+- python $TRAVIS_BUILD_DIR/scripts/upload_notes.py --repo $TRAVIS_BUILD_DIR --upload $TRAVIS_BUILD_DIR/_build/build_notes.json
 env:
   global:
-  - secure: L6J79xqMkGc0i6A469jd+2nyJdvJSWRkEuhfvjMbv7wFyTHF8GYjceeenGGGnCxc62LpKFLLOU35ulRqOWMAUqgHOzXUo8BEZtc+XljGq25Uqgm0/z84p1vSbuH1tZyY7/PwM2m06UadWe9Y6Vo6qZsVuiUCiEjImfmzeP9fb5g=
-  - secure: Rj4jqVvqPV4H/E2tpWbONhQY6zyESWmJRLvZiZC55gR3D9EIfq8L5AYwF+BJVlYAPZ2g9vzsXUnLy07GDxE/MVsiooLdiU0WofRNbLCnJjijP+v2ZWCR/77Vl6hTDZ/5PeFT2zwNdFDcIOLONzJNzgrX0jqrIyuehReFmZVwTs0=
-  - secure: fBktMf44ZPj7Y4gAXJSOG3u0Bvo1jv9HKCeM0zVLOW61bDdMCbCHBAxGa0QxHht1aISm8DNnhTrnnzpeZLHUEYyVdqU3zmDxJILKEhhnEavWAXf1ZBIY/VPysA2S1MfrLfwgLTj5tCP+/1Ytet2CSp6mmTDBDzL90URoFUYwweU=
+  - secure: JYWs3zJV09uAb7CvX32pADRYTH2XqSGvImNEI6zVFxJxs9r0JsGgyOTz4PPBgs3dv1OjVBXqxu4GD2ZBKeo0Ax13ZnBNVR/BacupBtIwXbxp/FG2lr+WBzE0YnEBhAF/mW5DEkNBWJyLSiBlxYA5QFAAHYwb/GOADl+Z9Qi2FIU=
+  - secure: on13Ka+3jkLDCXxqzxuT+CY4sPM0Zxfbe9M2F3LE0yhN2ww5vaBKdbTrzEWa0TOlBkM2qQUPAFybjHXfHeRyKpZDlsssjogH8YO5qx4zFRP5ZB9ny39QAqBsfZTuXt2WmOTLEcXkByYXVH8my/8ZqZqofSeBZsZdeauzoLbr0R0=

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,25 +1,30 @@
 language: node_js
 sudo: false
 node_js:
-- '0.12'
+  - '0.12'
+
 cache:
   directories:
-  - node_modules
-  - "$HOME/cache"
+    - node_modules
+    - "$HOME/cache"
+
 before_install:
-- CACHE="${HOME}/cache" CMAKE_VERSION=3.5.0 CMAKE_SHORT_VERSION=3.5 source ./scripts/install_cmake.sh
-- npm prune
+  - CACHE="${HOME}/cache" CMAKE_VERSION=3.5.0 CMAKE_SHORT_VERSION=3.5 source ./scripts/install_cmake.sh
+  - npm prune
+
 script:
-- npm run build
-- npm run docs
-- mkdir _build
-- ctest -S cmake/travis_build.cmake -VV || true
-- if [ -f _build/test_failed ] ; then false ; fi
+  - npm run build
+  - npm run docs
+  - mkdir _build
+  - ctest -S cmake/travis_build.cmake -VV || true
+  - if [ -f _build/test_failed ] ; then false ; fi
+
 after_success:
-- npm run codecov
-- pip install --user GitPython boto3
-- python $TRAVIS_BUILD_DIR/scripts/upload_notes.py --repo $TRAVIS_BUILD_DIR --upload $TRAVIS_BUILD_DIR/_build/build_notes.json
+  - npm run codecov
+  - pip install --user GitPython boto3
+  - python $TRAVIS_BUILD_DIR/scripts/upload_notes.py --repo $TRAVIS_BUILD_DIR --upload $TRAVIS_BUILD_DIR/_build/build_notes.json
+
 env:
   global:
-  - secure: JYWs3zJV09uAb7CvX32pADRYTH2XqSGvImNEI6zVFxJxs9r0JsGgyOTz4PPBgs3dv1OjVBXqxu4GD2ZBKeo0Ax13ZnBNVR/BacupBtIwXbxp/FG2lr+WBzE0YnEBhAF/mW5DEkNBWJyLSiBlxYA5QFAAHYwb/GOADl+Z9Qi2FIU=
-  - secure: on13Ka+3jkLDCXxqzxuT+CY4sPM0Zxfbe9M2F3LE0yhN2ww5vaBKdbTrzEWa0TOlBkM2qQUPAFybjHXfHeRyKpZDlsssjogH8YO5qx4zFRP5ZB9ny39QAqBsfZTuXt2WmOTLEcXkByYXVH8my/8ZqZqofSeBZsZdeauzoLbr0R0=
+    - secure: JYWs3zJV09uAb7CvX32pADRYTH2XqSGvImNEI6zVFxJxs9r0JsGgyOTz4PPBgs3dv1OjVBXqxu4GD2ZBKeo0Ax13ZnBNVR/BacupBtIwXbxp/FG2lr+WBzE0YnEBhAF/mW5DEkNBWJyLSiBlxYA5QFAAHYwb/GOADl+Z9Qi2FIU=
+    - secure: on13Ka+3jkLDCXxqzxuT+CY4sPM0Zxfbe9M2F3LE0yhN2ww5vaBKdbTrzEWa0TOlBkM2qQUPAFybjHXfHeRyKpZDlsssjogH8YO5qx4zFRP5ZB9ny39QAqBsfZTuXt2WmOTLEcXkByYXVH8my/8ZqZqofSeBZsZdeauzoLbr0R0=

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "body-parser": "^1.15.0",
     "bootstrap": "^3.3.6",
     "bootswatch": "^3.3.6",
+    "bowser": "^1.4.6",
     "codecov.io": "^0.1.6",
     "codemirror": "^5.15.2",
     "colorbrewer": "^1.0.0",

--- a/scripts/upload_notes.py
+++ b/scripts/upload_notes.py
@@ -1,0 +1,86 @@
+from __future__ import print_function
+
+import json
+import socket
+from datetime import datetime
+import os
+import argparse
+from StringIO import StringIO
+
+import boto3
+import git
+
+
+def gather_info(repo_path='.'):
+    repo = git.Repo(repo_path)
+    try:
+        branch = repo.active_branch.name
+    except Exception:
+        branch = os.environ.get('TRAVIS_BRANCH')
+
+    info = {
+        'build_outputs': [],
+        'build_timestamp': datetime.now().isoformat(),
+        'datasets': [],
+        'git_branch': branch,
+        'git_repo': 'git@github.com:OpenGeoscience/geojs.git',
+        'git_sha': repo.head.commit.hexsha,
+        'host': socket.gethostname(),
+        'regeneration_command': 'npm run test',
+        'vcs': 'git'
+    }
+    if os.environ.get('TRAVIS') is 'true':
+        info['travis_id'] = os.environ.get('TRAVIS_BUILD_ID')
+        info['host'] = 'travis'
+    return info
+
+
+def upload(data, bucket='geojs-build-outputs'):
+    # assumes credentials coming from environment variables
+    # such as AWS_ACCESS_KEY_ID, AWS_PROFILE, etc.
+    s3 = boto3.client('s3')
+
+    f = StringIO()
+    f.write(data)
+    f.seek(0)
+
+    name = datetime.now().isoformat() + '.json'
+    s3.upload_fileobj(f, bucket, name)
+
+
+def main(args):
+    notes = json.load(open(args.notes, 'r'))
+    info = gather_info(args.repo)
+    info['data'] = notes
+
+    data = json.dumps(info)
+    print(data)
+
+    if args.upload:
+        upload(data)
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(
+        description='Collect performance information and related metadata'
+    )
+
+    parser.add_argument(
+        '--repo',
+        default='.',
+        help='Path of the repository'
+    )
+
+    parser.add_argument(
+        '--upload',
+        action='store_true',
+        default=False,
+        help='Upload results to s3'
+    )
+
+    parser.add_argument(
+        'notes',
+        help='Path to the build notes file'
+    )
+
+    main(parser.parse_args())

--- a/scripts/upload_notes.py
+++ b/scripts/upload_notes.py
@@ -29,7 +29,7 @@ def gather_info(repo_path='.'):
         'regeneration_command': 'npm run test',
         'vcs': 'git'
     }
-    if os.environ.get('TRAVIS') is 'true':
+    if os.environ.get('TRAVIS'):
         info['travis_id'] = os.environ.get('TRAVIS_BUILD_ID')
         info['host'] = 'travis'
     return info

--- a/scripts/upload_notes.py
+++ b/scripts/upload_notes.py
@@ -7,6 +7,7 @@ import os
 import argparse
 from StringIO import StringIO
 import sys
+import uuid
 
 
 def gather_info(repo_path='.'):
@@ -26,11 +27,13 @@ def gather_info(repo_path='.'):
         branch = os.environ.get('TRAVIS_BRANCH')
 
     info = {
+        'uuid': str(uuid.uuid4()),
         'build_outputs': [],
         'build_timestamp': datetime.now().isoformat(),
+        'commit_timestamp': repo.head.commit.committed_datetime.isoformat(),
         'datasets': [],
         'git_branch': branch,
-        'git_repo': 'git@github.com:OpenGeoscience/geojs.git',
+        'git_repo_url': 'git@github.com:OpenGeoscience/geojs.git',
         'git_sha': repo.head.commit.hexsha,
         'host': socket.gethostname(),
         'regeneration_command': 'npm run test',
@@ -68,6 +71,7 @@ def main(args):
     notes = json.load(open(args.notes, 'r'))
     info = gather_info(args.repo)
     info['data'] = notes
+    info['submission_timestamp'] = datetime.now().isoformat()
 
     data = json.dumps(info)
     print(data)

--- a/scripts/upload_notes.py
+++ b/scripts/upload_notes.py
@@ -6,12 +6,19 @@ from datetime import datetime
 import os
 import argparse
 from StringIO import StringIO
-
-import boto3
-import git
+import sys
 
 
 def gather_info(repo_path='.'):
+    try:
+        import git
+    except ImportError:
+        print(
+            'Please install GitPython (`pip install GitPython`)',
+            file=sys.stderr
+        )
+        sys.exit(1)
+
     repo = git.Repo(repo_path)
     try:
         branch = repo.active_branch.name
@@ -38,6 +45,15 @@ def gather_info(repo_path='.'):
 def upload(data, bucket='geojs-build-outputs'):
     # assumes credentials coming from environment variables
     # such as AWS_ACCESS_KEY_ID, AWS_PROFILE, etc.
+    try:
+        import boto3
+    except ImportError:
+        print(
+            'Please install boto3 (`pip install boto3`)',
+            file=sys.stderr
+        )
+        sys.exit(1)
+
     s3 = boto3.client('s3')
 
     f = StringIO()

--- a/tests/test-utils.js
+++ b/tests/test-utils.js
@@ -9,6 +9,7 @@ var $ = require('jquery');
 
 var geo = require('../src');
 var _supported = geo.gl.vglRenderer.supported;
+var bowser = require('bowser');
 
 module.exports = {};
 
@@ -286,6 +287,7 @@ module.exports.logCanvas2D = function logCanvas2D(enable) {
  * @param note: the data to send.  This will be converted to JSON.
  */
 module.exports.submitNote = function submitNote(key, note) {
+  note.browser = bowser;
   return $.ajax({
     url: '/notes?key=' + encodeURIComponent(key),
     data: JSON.stringify(note),


### PR DESCRIPTION
@mgrauer This will push the notes files that we are collecting on cdash up to s3 along with some build metadata.  On travis, the files uploaded to s3 will look something like this:

```json
{
    "build_outputs": [],
    "build_timestamp": "2016-10-17T12:40:07.724645",
    "data": {
        ...
    "datasets": [],
    "git_branch": "upload-s3-artifacts",
    "git_repo": "git@github.com:OpenGeoscience/geojs.git",
    "git_sha": "3950b54d682ace0cf1b3879882d0ba147a291c2b",
    "host": "travis",
    "regeneration_command": "npm run test",
    "travis_id": "168296732",
    "vcs": "git"
}
```

It is also possible to push data from any host in the same format using the `upload_notes.py` script if the user has the aws credentials, otherwise it will just print to stdout.  I pushed historical data mined from cdash in the same format, but for some reason my scripted missed all the builds from 2016.  I'll look into that later.