### PR TITLE
Add pixel coordinate utility function.

### DIFF
--- a/examples/deepzoom/main.js
+++ b/examples/deepzoom/main.js
@@ -1,6 +1,10 @@
+/* globals utils */
+
 // Run after the DOM loads
 $(function () {
   'use strict';
+
+  var query = utils.getQuery();
 
   // custom tileLayer for deepzoom
   var DeepZoom = function (arg) {
@@ -13,38 +17,47 @@ $(function () {
       return geo.imageTile({
         index: index,
         size: {x: this._options.tileWidth, y: this._options.tileHeight},
+        queue: this._queue,
         url: this._options.url(source || index)
       });
     };
   };
 
-  DeepZoom.defaults = $.extend({}, geo.tileLayer.defaults, {
-    minLevel: 0,
-    maxLevel: 9,
+  // We know the size of the image we are requesting, and we want to use
+  // pixel coordinates on our map.
+  var sizeX = 103583, sizeY = 70014, tileSize = 256;
+  var defaultParams = geo.util.pixelCoordinateParams(
+        '#map', sizeX, sizeY, tileSize, tileSize);
+
+  DeepZoom.defaults = $.extend({}, geo.tileLayer.defaults, defaultParams.layer, {
     levelOffset: 8,
-    attribution: '',
-    wrapX: false,
-    wrapY: false,
     url: function (index) {
       return 'http://node15.cci.emory.edu/cgi-bin/iipsrv.fcgi?DeepZoom=/bigdata2/' +
       'PYRAMIDS/CDSA/ACC_Diagnostic/nationwidechildrens.org_ACC.diagnostic_images.' +
       'Level_1.304.4.0/TCGA-OR-A5J1-01Z-00-DX1.600C7D8C-F04C-4125-AF14-B1E76DC01A1E.' +
       'svs.dzi.tif_files/' + (index.level + 8) + '/' + index.x + '_' + index.y + '.jpg';
-    },
-    tileOffset : function (level) {
-      var s = Math.pow(2, level - 1) * 256;
-      return {x: s, y: s};
     }
   });
   geo.inherit(DeepZoom, geo.tileLayer);
   geo.registerLayer('tiledFish', DeepZoom);
   // Create a map object
-  var map = geo.map({
-    node: '#map'
-  });
+  var map = geo.map($.extend({}, defaultParams.map, {
+    node: '#map',
+    clampBoundsX: false,
+    clampBoundsY: false,
+    clampZoom: false,
+    zoom: 2
+  }));
 
-  // Add the osm layer with a custom tile url
+  // Add the osm layer with a custom tile url.
+  // We ask to use the quad.imageFixedScale feature, since the IIP server
+  // returns partial tiles at the right and bottom edges.  If the tile server
+  // returns complete tiles that we need to crop, we would ask for the
+  // quad.imageCrop feature instead.
   map.createLayer(
-    'tiledFish'
+    'tiledFish', {
+      renderer: query.renderer ? (query.renderer === 'html' ? null : query.renderer) : undefined,
+      features: query.renderer ? undefined : ['quad.imageFixedScale']
+    }
   );
 });

--- a/src/canvas/quadFeature.js
+++ b/src/canvas/quadFeature.js
@@ -152,6 +152,7 @@ var capabilities = {};
 capabilities[quadFeature.capabilities.color] = false;
 capabilities[quadFeature.capabilities.image] = true;
 capabilities[quadFeature.capabilities.imageCrop] = true;
+capabilities[quadFeature.capabilities.imageFixedScale] = true;
 capabilities[quadFeature.capabilities.imageFull] = false;
 
 registerFeature('canvas', 'quad', canvas_quadFeature, capabilities);

--- a/src/d3/quadFeature.js
+++ b/src/d3/quadFeature.js
@@ -232,6 +232,7 @@ var capabilities = {};
 capabilities[quadFeature.capabilities.color] = true;
 capabilities[quadFeature.capabilities.image] = true;
 capabilities[quadFeature.capabilities.imageCrop] = false;
+capabilities[quadFeature.capabilities.imageFixedScale] = false;
 capabilities[quadFeature.capabilities.imageFull] = false;
 
 registerFeature('d3', 'quad', d3_quadFeature, capabilities);

--- a/src/gl/quadFeature.js
+++ b/src/gl/quadFeature.js
@@ -421,6 +421,7 @@ var capabilities = {};
 capabilities[quadFeature.capabilities.color] = true;
 capabilities[quadFeature.capabilities.image] = true;
 capabilities[quadFeature.capabilities.imageCrop] = true;
+capabilities[quadFeature.capabilities.imageFixedScale] = false;
 capabilities[quadFeature.capabilities.imageFull] = true;
 
 registerFeature('vgl', 'quad', gl_quadFeature, capabilities);

--- a/src/osmLayer.js
+++ b/src/osmLayer.js
@@ -54,6 +54,8 @@ module.exports = (function () {
         index: index,
         size: {x: this._options.tileWidth, y: this._options.tileHeight},
         queue: this._queue,
+        overlap: this._options.tileOverlap,
+        scale: this._options.tileScale,
         url: this._options.url(urlParams.x, urlParams.y, urlParams.level || 0,
                                this._options.subdomains)
       });

--- a/src/quadFeature.js
+++ b/src/quadFeature.js
@@ -479,6 +479,8 @@ quadFeature.capabilities = {
   image: 'quad.image',
   /* support for cropping quad images */
   imageCrop: 'quad.imageCrop',
+  /* support for fixed-scale quad images */
+  imageFixedScale: 'quad.imageFixedScale',
   /* support for arbitrary quad images */
   imageFull: 'quad.imageFull'
 };

--- a/tests/cases/osmLayer.js
+++ b/tests/cases/osmLayer.js
@@ -280,6 +280,28 @@ describe('geo.core.osmLayer', function () {
     });
   });
 
+  describe('pixel coordinates', function () {
+    it('util.pixelCoordinateParams', function () {
+      var sizeX = 12345, sizeY = 5678, tileSize = 240;
+      var params = geo.util.pixelCoordinateParams('#map-osm-layer', sizeX, sizeY, tileSize, tileSize);
+      expect(params.map.ingcs).toBe('+proj=longlat +axis=esu');
+      expect(params.layer.tileRounding).toBe(Math.ceil);
+      expect(params.layer.tileOffset()).toEqual({x: 0, y: 0});
+      expect(params.layer.tilesAtZoom(3)).toEqual({x: 7, y: 3});
+      expect(params.layer.tilesMaxBounds(3)).toEqual({x: 1543, y: 709});
+      map = create_map(params.map);
+      map.createLayer('osm', $.extend(
+        {}, params.layer, {renderer: null, url: '/data/white.jpg', zoom: 3}));
+      expect(map.node().find('[data-tile-layer="0"]').length).toBe(1);
+    });
+    waitForIt('.geo-tile-container', function () {
+      return map.node().find('.geo-tile-container').length > 0;
+    });
+    it('check for tiles', function () {
+      expect(map.node().find('.geo-tile-container').length).toBeGreaterThan(0);
+    });
+    it('destroy', destroy_map);
+  });
   describe('geo.d3.osmLayer', function () {
     var layer, mapinfo = {};
     it('test that tiles are created', function () {


### PR DESCRIPTION
Add a utility function to make it easier to create maps and tile layers in pixel coordinates with common settings and functions.  It seems wasteful to have this code in each non-map example.

Fix the deepzoom example.  The IIP Server sends partial tiles at the right and bottom edge of the tile set.  Our canvas renderer happens to work with this because it doesn't scale the tile images (which means it won't work on a retina tile).  Added a capabilities flag so we can ask for that feature rather than specifying a renderer.