### PR TITLE
Fix some feature issues.

### DIFF
--- a/src/annotationLayer.js
+++ b/src/annotationLayer.js
@@ -627,11 +627,10 @@ var annotationLayer = function (args) {
           $.each(featureLevel, function (type, featureSpec) {
             /* Create features as needed */
             if (!m_features[idx][type]) {
-              try {
-                var feature = m_this.createFeature(type, {
-                  gcs: m_this.map().gcs()
-                });
-              } catch (err) {
+              var feature = m_this.createFeature(type, {
+                gcs: m_this.map().gcs()
+              });
+              if (!feature) {
                 /* We can't create the desired feature, porbably because of the
                  * selected renderer.  Issue one warning only. */
                 var key = 'error_feature_' + type;

--- a/src/feature.js
+++ b/src/feature.js
@@ -121,6 +121,16 @@ var feature = function (arg) {
 
   ////////////////////////////////////////////////////////////////////////////
   /**
+   * Returns an array of line indices that are contained in the given box.
+   */
+  ////////////////////////////////////////////////////////////////////////////
+  this.boxSearch = function (lowerLeft, upperRight, opts) {
+    // base class method does nothing
+    return [];
+  };
+
+  ////////////////////////////////////////////////////////////////////////////
+  /**
    * Private mousemove handler
    */
   ////////////////////////////////////////////////////////////////////////////
@@ -130,6 +140,10 @@ var feature = function (arg) {
         over = m_this.pointSearch(mouse.geo),
         newFeatures = [], oldFeatures = [], lastTop = -1, top = -1;
 
+    // exit if we have no old or new found entries
+    if (!m_selectedFeatures.length && !over.index.length) {
+      return;
+    }
     // Get the index of the element that was previously on top
     if (m_selectedFeatures.length) {
       lastTop = m_selectedFeatures[m_selectedFeatures.length - 1];
@@ -212,11 +226,12 @@ var feature = function (arg) {
    * Private mouseclick handler
    */
   ////////////////////////////////////////////////////////////////////////////
-  this._handleMouseclick = function () {
+  this._handleMouseclick = function (evt) {
     var mouse = m_this.layer().map().interactor().mouse(),
         data = m_this.data(),
         over = m_this.pointSearch(mouse.geo);
 
+    mouse.buttonsDown = evt.buttonsDown;
     feature.eventID += 1;
     over.index.forEach(function (i, idx) {
       m_this.geoTrigger(geo_event.feature.mouseclick, {
@@ -510,7 +525,7 @@ var feature = function (arg) {
   ////////////////////////////////////////////////////////////////////////////
   this._init = function (arg) {
     if (!m_layer) {
-      throw 'Feature requires a valid layer';
+      throw new Error('Feature requires a valid layer');
     }
     m_style = $.extend({},
                 {'opacity': 1.0}, arg.style === undefined ? {} :
@@ -549,7 +564,6 @@ var feature = function (arg) {
     m_this._unbindMouseHandlers();
     m_selectedFeatures = [];
     m_style = {};
-    arg = {};
     s_exit();
   };
 
@@ -588,8 +602,6 @@ feature.eventID = 0;
 feature.create = function (layer, spec) {
   'use strict';
 
-  var type = spec.type;
-
   // Check arguments
   if (!(layer instanceof require('./layer'))) {
     console.warn('Invalid layer');
@@ -599,13 +611,13 @@ feature.create = function (layer, spec) {
     console.warn('Invalid spec');
     return null;
   }
+  var type = spec.type;
   var feature = layer.createFeature(type);
   if (!feature) {
     console.warn('Could not create feature type "' + type + '"');
     return null;
   }
 
-  spec = spec || {};
   spec.data = spec.data || [];
   return feature.style(spec);
 };

--- a/src/featureLayer.js
+++ b/src/featureLayer.js
@@ -36,6 +36,8 @@ var featureLayer = function (arg) {
   /**
    * Create feature give a name
    *
+   * @param {string} featureName the name of the feature to create
+   * @param {object} arg properties for the new feature
    * @returns {geo.Feature} Will return a new feature
    */
   ////////////////////////////////////////////////////////////////////////////
@@ -43,40 +45,66 @@ var featureLayer = function (arg) {
 
     var newFeature = registry.createFeature(
       featureName, m_this, m_this.renderer(), arg);
-
-    m_this.addChild(newFeature);
-    m_features.push(newFeature);
-    m_this.features(m_features);
-    m_this.modified();
+    if (newFeature) {
+      this.addFeature(newFeature);
+    }
     return newFeature;
+  };
+
+  ////////////////////////////////////////////////////////////////////////////
+  /**
+   * Add a feature to the layer if it is not already present.
+   *
+   * @param {object} feature the feature to add.
+   */
+  ////////////////////////////////////////////////////////////////////////////
+  this.addFeature = function (feature) {
+    /* try to remove the feature first so that we don't have two copies */
+    this.removeFeature(feature);
+    m_this.addChild(feature);
+    m_features.push(feature);
+    m_this.dataTime().modified();
+    m_this.modified();
+    return m_this;
+  };
+
+  ////////////////////////////////////////////////////////////////////////////
+  /**
+   * Remove feature without destroying it
+   *
+   * @param {object} feature the feature to remove.
+   */
+  ////////////////////////////////////////////////////////////////////////////
+  this.removeFeature = function (feature) {
+    var pos;
+
+    pos = m_features.indexOf(feature);
+    if (pos >= 0) {
+      m_features.splice(pos, 1);
+      m_this.removeChild(feature);
+      m_this.dataTime().modified();
+      m_this.modified();
+    }
+
+    return m_this;
   };
 
   ////////////////////////////////////////////////////////////////////////////
   /**
    * Delete feature
    *
+   * @param {object} feature the feature to delete.
    */
   ////////////////////////////////////////////////////////////////////////////
   this.deleteFeature = function (feature) {
-    var i;
 
-    for (i = 0; i < m_features.length; i += 1) {
-      if (m_features[i] === feature) {
-        m_features[i]._exit();
-        m_this.dataTime().modified();
-        m_this.modified();
+    // call _exit first, as destroying the feature affect other features
+    if (feature) {
+      if (m_features.indexOf(feature) >= 0) {
+        feature._exit();
       }
+      this.removeFeature(feature);
     }
-
-    // Loop through a second to time actually remove
-    // the given feature from the array because the
-    // `_exit` call above may mutate it.
-    for (i = 0; i < m_features.length; i += 1) {
-      if (m_features[i] === feature) {
-        m_features.splice(i, 1);
-      }
-    }
-    m_this.removeChild(feature);
 
     return m_this;
   };
@@ -90,11 +118,21 @@ var featureLayer = function (arg) {
   ////////////////////////////////////////////////////////////////////////////
   this.features = function (val) {
     if (val === undefined) {
-      return m_features;
+      return m_features.slice();
     } else {
-      m_features = val.slice(0);
-      m_this.dataTime().modified();
-      m_this.modified();
+      // delete existing features that aren't in the new array.  Since features
+      // can affect other features during their exit process, make sure each
+      // feature still exists as we work through the list.
+      var existing = m_features.slice();
+      var i;
+      for (i = 0; i < existing.length; i += 1) {
+        if (val.indexOf(existing[i]) < 0 && m_features.indexOf(existing[i]) >= 0) {
+          this.deleteFeature(existing[i]);
+        }
+      }
+      for (i = 0; i < val.length; i += 1) {
+        this.addFeature(val[i]);
+      }
       return m_this;
     }
   };
@@ -162,11 +200,6 @@ var featureLayer = function (arg) {
     /// Call base class update
     s_update.call(m_this, request);
 
-    if (m_features && m_features.length === 0) {
-      console.log('[info] No valid data source found.');
-      return;
-    }
-
     if (m_this.dataTime().getMTime() > m_this.updateTime().getMTime()) {
       for (i = 0; i < m_features.length; i += 1) {
         m_features[i].renderer(m_this.renderer());
@@ -215,21 +248,9 @@ var featureLayer = function (arg) {
    */
   ////////////////////////////////////////////////////////////////////////////
   this.clear = function () {
-    var i;
-
-    if (!m_features.length) {
-      return m_this;
+    while (m_features.length) {
+      m_this.deleteFeature(m_features[0]);
     }
-
-    for (i = 0; i < m_features.length; i += 1) {
-      m_features[i]._exit();
-      m_this.removeChild(m_features[i]);
-    }
-
-    m_this.dataTime().modified();
-    m_this.modified();
-    m_features = [];
-
     return m_this;
   };
 

--- a/src/registry.js
+++ b/src/registry.js
@@ -166,7 +166,7 @@ util.rendererForFeatures = function (featureList) {
  *      capabilities in multiple categories (renderers), then the feature
  *      should expose a simple dictionary of supported and unsupported
  *      features.  For instance, the quad feature has color quads, image quads,
- *      and image quads that support full transformations.  The capabailities
+ *      and image quads that support full transformations.  The capabilities
  *      should be defined in the base feature in a capabilities object so that
  *      they can be referenced by that rather than an explicit string.
  * @returns {object} if this feature replaces an existing one, this was the
@@ -339,7 +339,7 @@ util.createWidget = function (name, layer, arg) {
  *      annotation.  Each key is a feature that is used.  If the value is true,
  *      the that feature is always needed.  If a list, then it is the set of
  *      annotation states for which that feature is required.  These can be
- *      used to pick an pparopriate renderer when creating an annotation layer.
+ *      used to pick an appropriate renderer when creating an annotation layer.
  * @returns {object} if this annotation replaces an existing one, this was the
  *      value that was replaced.  In this case, a warning is issued.
  */
@@ -392,7 +392,7 @@ util.listAnnotations = function () {
  *   used with that annotation.  For example, ['polygon', 'rectangle'] lists
  *   features required to show those annotations in any mode,  whereas
  *   {polygon: [annotationState.done], rectangle: [annotationState.done]} only
- *   lists features thatre are needed to show the completed annotations.
+ *   lists features that are needed to show the completed annotations.
  * @return {array} a list of features needed for the specified annotations.
  *   There may be duplicates in the list.
  */
@@ -425,7 +425,7 @@ util.featuresForAnnotations = function (annotationList) {
 /**
  * Check if there is a renderer that is supported and supports a list of
  * annotations.  If not, display a warning.  This generates a list of required
- * features, then picks the first renderer that supports all of thse features.
+ * features, then picks the first renderer that supports all of these features.
  *
  * @param {array|object|undefined} annotationList A list of annotations that
  *   will be used with this renderer.  Instead of a list, if this is an object,

--- a/src/tileLayer.js
+++ b/src/tileLayer.js
@@ -122,7 +122,7 @@ module.exports = (function () {
    *   This function takes a zoom level argument and returns, in units of
    *   pixels, the coordinates of the point (0, 0) at the given zoom level
    *   relative to the bottom left corner of the domain.
-   * @param {function} [options.tileMaxBounds=null]
+   * @param {function} [options.tilesMaxBounds=null]
    *   This function takes a zoom level argument and returns, in units of
    *   pixels, the top, left, right, and bottom maximum value for which tiles
    *   should be drawn at the given zoom level relative to the bottom left

--- a/tests/cases/feature.js
+++ b/tests/cases/feature.js
@@ -1,0 +1,262 @@
+// Test geo.feature
+
+var geo = require('../test-utils').geo;
+var $ = require('jquery');
+
+describe('geo.feature', function () {
+  'use strict';
+
+  beforeEach(function () {
+    sinon.stub(console, 'warn', function () {});
+  });
+  afterEach(function () {
+    console.warn.restore();
+  });
+
+  function create_map(opts) {
+    var node = $('<div id="map"/>').css({width: '640px', height: '360px'});
+    $('#map').remove();
+    $('body').append(node);
+    opts = $.extend({}, opts);
+    opts.node = node;
+    return geo.map(opts);
+  }
+
+  describe('create', function () {
+    it('create function', function () {
+      var map, layer, feat;
+      map = create_map();
+      layer = map.createLayer('feature', {renderer: 'd3'});
+
+      feat = geo.feature.create();
+      expect(feat).toBeNull();
+      expect(console.warn.calledOnce).toBe(true);
+      expect(console.warn.calledWith('Invalid layer')).toBe(true);
+      console.warn.reset();
+
+      feat = geo.feature.create(layer);
+      expect(feat).toBeNull();
+      expect(console.warn.calledOnce).toBe(true);
+      expect(console.warn.calledWith('Invalid spec')).toBe(true);
+      console.warn.reset();
+
+      feat = geo.feature.create(layer, {type: 'no_feature'});
+      expect(feat).toBeNull();
+      expect(console.warn.calledOnce).toBe(true);
+      expect(console.warn.calledWith(
+        'Could not create feature type "no_feature"')).toBe(true);
+      console.warn.reset();
+
+      feat = geo.feature.create(layer, {type: 'point'});
+      expect(feat).not.toBeNull();
+      layer.deleteFeature(feat);
+
+      feat = geo.feature({layer: layer});
+      expect(feat.layer()).toBe(layer);
+      expect(feat.renderer()).toBe(null);
+    });
+  });
+  describe('Check private class mathods', function () {
+    var map, layer, feat, points = {index: [], found: []}, box = [],
+        events = {};
+    it('_init', function () {
+      map = create_map();
+      layer = map.createLayer('feature', {renderer: null});
+      expect(function () {
+        geo.feature();
+      }).toThrow(new Error('Feature requires a valid layer'));
+      feat = geo.feature({layer: layer});
+      expect(feat.style('opacity')).toBe(1);
+      expect(feat.selectionAPI()).toBe(false);
+    });
+    it('_exit', function () {
+      feat = geo.feature({layer: layer});
+      feat._exit();
+      expect(feat.style('opacity')).toBe(undefined);
+    });
+    it('empty functions', function () {
+      feat = geo.feature({layer: layer});
+      expect(feat._build()).toBe(undefined);
+      expect(feat._update()).toBe(undefined);
+    });
+    it('_bindMouseHandlers', function () {
+      feat = geo.feature({layer: layer, selectionAPI: true});
+      layer.addFeature(feat);  /* needed to propagate interactions */
+      feat.pointSearch = function () {
+        return points;
+      };
+      feat.boxSearch = function () {
+        return box;
+      };
+      points.index = [1];
+      feat.geoOn(geo.event.feature.mouseover, function (evt) { events.mouseover = evt; });
+      feat.geoOn(geo.event.feature.mouseout, function (evt) { events.mouseout = evt; });
+      feat.geoOn(geo.event.feature.mousemove, function (evt) { events.mousemove = evt; });
+      feat.geoOn(geo.event.feature.mouseon, function (evt) { events.mouseon = evt; });
+      feat.geoOn(geo.event.feature.mouseoff, function (evt) { events.mouseoff = evt; });
+      feat.geoOn(geo.event.feature.mouseclick, function (evt) { events.mouseclick = evt; });
+      feat.geoOn(geo.event.feature.brush, function (evt) { events.brush = evt; });
+      feat.geoOn(geo.event.feature.brushend, function (evt) { events.brushend = evt; });
+      map.interactor().simulateEvent('mousemove', {map: {x: 20, y: 20}});
+      expect(events.mouseover.index).toBe(1);
+    });
+    it('_unbindMouseHandlers', function () {
+      feat._unbindMouseHandlers();
+      events = {};
+      points.index = [2];
+      map.interactor().simulateEvent('mousemove', {map: {x: 20, y: 21}});
+      expect(events.mouseover).toBe(undefined);
+      feat._bindMouseHandlers();
+      points.index = [3];
+      map.interactor().simulateEvent('mousemove', {map: {x: 20, y: 22}});
+      expect(events.mouseover.index).toBe(3);
+    });
+    it('_handleMousemove', function () {
+      points.index = [3];
+      events = {};
+      feat._handleMousemove();
+      /* since the selected points didn't change, we should only have a move event */
+      expect(Object.getOwnPropertyNames(events)).toEqual(['mousemove']);
+      points.index = [];
+      events = {};
+      feat._handleMousemove();
+      expect(Object.getOwnPropertyNames(events).sort()).toEqual(['mouseoff', 'mouseout']);
+      events = {};
+      feat._handleMousemove();
+      expect(Object.getOwnPropertyNames(events)).toEqual([]);
+      points.index = [4, 5];
+      events = {};
+      feat._handleMousemove();
+      expect(Object.getOwnPropertyNames(events).sort()).toEqual(['mousemove', 'mouseon', 'mouseover']);
+      points.index = [5, 4];
+      events = {};
+      feat._handleMousemove();
+      expect(Object.getOwnPropertyNames(events).sort()).toEqual(['mousemove', 'mouseoff', 'mouseon']);
+    });
+    it('_handleMouseclick', function () {
+      points.index = [];
+      events = {};
+      feat._handleMouseclick({buttonsDown: {left: true}});
+      expect(Object.getOwnPropertyNames(events)).toEqual([]);
+      points.index = [6];
+      events = {};
+      feat._handleMouseclick({buttonsDown: {left: true}});
+      expect(Object.getOwnPropertyNames(events)).toEqual(['mouseclick']);
+      expect(events.mouseclick.index).toEqual(6);
+      expect(events.mouseclick.mouse.buttonsDown.left).toBe(true);
+    });
+    it('_handleBrush', function () {
+      box = [7, 8];
+      events = {};
+      feat._handleBrush({gcs: {}});
+      expect(Object.getOwnPropertyNames(events)).toEqual(['brush']);
+      expect(events.brush.index).toEqual(8);
+    });
+    it('_handleBrushend', function () {
+      box = [9];
+      events = {};
+      feat._handleBrushend({gcs: {}});
+      expect(Object.getOwnPropertyNames(events)).toEqual(['brushend']);
+      expect(events.brushend.index).toEqual(9);
+    });
+  });
+  describe('Check public class methods', function () {
+    var map, layer, feat;
+    it('pointSearch', function () {
+      map = create_map();
+      layer = map.createLayer('feature', {renderer: 'd3'});
+      feat = geo.feature({layer: layer, renderer: layer.renderer()});
+      expect(feat.pointSearch()).toEqual({index: [], found: []});
+    });
+    it('boxSearch', function () {
+      expect(feat.boxSearch()).toEqual([]);
+    });
+    it('featureGcsToDisplay', function () {
+      var pos = feat.featureGcsToDisplay({x: -24.6094, y: 13.0688});
+      expect(pos.x).toBeCloseTo(40);
+      expect(pos.y).toBeCloseTo(30);
+      feat.gcs('EPSG:3857');
+      pos = feat.featureGcsToDisplay({x: -2739503, y: 1467591});
+      expect(pos.x).toBeCloseTo(40);
+      expect(pos.y).toBeCloseTo(30);
+    });
+    it('visible', function () {
+      expect(feat.visible()).toBe(true);
+      var modTime = feat.getMTime();
+      expect(feat.visible(false)).toBe(feat);
+      expect(feat.visible()).toBe(false);
+      expect(feat.getMTime()).toBeGreaterThan(modTime);
+    });
+  });
+  describe('Check class accessors', function () {
+    var map, layer, feat;
+    it('style', function () {
+      map = create_map();
+      layer = map.createLayer('feature', {renderer: 'd3'});
+      feat = geo.feature({layer: layer, renderer: layer.renderer()});
+      expect(feat.style()).toEqual({opacity: 1});
+      expect(feat.style('opacity')).toBe(1);
+      expect(feat.style('radius')).toBe(undefined);
+      expect(feat.style('radius', 10)).toBe(feat);
+      expect(feat.style('radius')).toBe(10);
+      expect(feat.style({radius: 5})).toBe(feat);
+      expect(feat.style('radius')).toBe(5);
+      expect(feat.style.get('radius')()).toBe(5);
+      var all = feat.style.get();
+      expect(Object.getOwnPropertyNames(all).sort()).toEqual(['opacity', 'radius']);
+      expect(all.radius()).toBe(5);
+      feat.style('strokeColor', 'red');
+      expect(feat.style.get('strokeColor')()).toEqual({r: 1, g: 0, b: 0});
+      feat.style('strokeColor', function () { return 'lime'; });
+      expect(feat.style.get('strokeColor')()).toEqual({r: 0, g: 1, b: 0});
+    });
+    it('layer', function () {
+      expect(feat.layer()).toBe(layer);
+    });
+    it('renderer', function () {
+      expect(feat.renderer()).toBe(layer.renderer());
+    });
+    it('gcs', function () {
+      expect(feat.gcs()).toBe(map.ingcs());
+      expect(feat.gcs('EPSG:3857')).toBe(feat);
+      expect(feat.gcs()).toBe('EPSG:3857');
+    });
+    it('bin', function () {
+      expect(feat.bin()).toBe(0);
+      expect(feat.bin(5)).toBe(feat);
+      expect(feat.bin()).toBe(5);
+    });
+    it('dataTime', function () {
+      var ts = geo.timestamp();
+      expect(feat.dataTime() instanceof geo.timestamp).toBe(true);
+      expect(feat.dataTime()).not.toBe(ts);
+      expect(feat.dataTime(ts)).toBe(feat);
+      expect(feat.dataTime()).toBe(ts);
+    });
+    it('buildTime', function () {
+      var ts = geo.timestamp();
+      expect(feat.buildTime() instanceof geo.timestamp).toBe(true);
+      expect(feat.buildTime()).not.toBe(ts);
+      expect(feat.buildTime(ts)).toBe(feat);
+      expect(feat.buildTime()).toBe(ts);
+    });
+    it('updateTime', function () {
+      var ts = geo.timestamp();
+      expect(feat.updateTime() instanceof geo.timestamp).toBe(true);
+      expect(feat.updateTime()).not.toBe(ts);
+      expect(feat.updateTime(ts)).toBe(feat);
+      expect(feat.updateTime()).toBe(ts);
+    });
+    it('data', function () {
+      expect(feat.data()).toEqual([]);
+      expect(feat.data([1])).toBe(feat);
+      expect(feat.data()).toEqual([1]);
+      expect(feat.style('data')).toEqual([1]);
+    });
+    it('selectionAPI', function () {
+      expect(feat.selectionAPI()).toBe(false);
+      feat = geo.feature({layer: layer, renderer: layer.renderer(), selectionAPI: true});
+      expect(feat.selectionAPI()).toBe(true);
+    });
+  });
+});

--- a/tests/cases/featureLayer.js
+++ b/tests/cases/featureLayer.js
@@ -1,0 +1,146 @@
+// Test geo.featureLayer
+
+var geo = require('../test-utils').geo;
+var $ = require('jquery');
+
+describe('geo.featureLayer', function () {
+  'use strict';
+
+  beforeEach(function () {
+    sinon.stub(console, 'log', function () {});
+  });
+  afterEach(function () {
+    console.log.restore();
+  });
+
+  function create_map(opts) {
+    var node = $('<div id="map"/>').css({width: '640px', height: '360px'});
+    $('#map').remove();
+    $('body').append(node);
+    opts = $.extend({}, opts);
+    opts.node = node;
+    return geo.map(opts);
+  }
+
+  describe('create', function () {
+    it('create function', function () {
+      var map, layer;
+
+      map = create_map();
+      layer = geo.featureLayer({map: map});
+      expect(layer instanceof geo.featureLayer).toBe(true);
+      expect(layer.initialized()).toBe(false);
+
+      layer = map.createLayer('feature', {renderer: 'd3'});
+      expect(layer instanceof geo.featureLayer).toBe(true);
+      expect(layer.initialized()).toBe(true);
+    });
+  });
+  describe('Check private class methods', function () {
+    var map, layer;
+    it('_init', function () {
+      map = create_map();
+      layer = geo.featureLayer({map: map});
+      expect(layer.initialized()).toBe(false);
+      layer._init();
+      expect(layer.initialized()).toBe(true);
+      layer._init();
+      expect(layer.initialized()).toBe(true);
+    });
+    it('_exit', function () {
+      layer = geo.featureLayer({map: map});
+      layer._init();
+      expect(layer.features().length).toBe(0);
+      layer.addFeature(geo.feature({layer: layer}));
+      expect(layer.features().length).toBe(1);
+      layer._exit();
+      expect(layer.features().length).toBe(0);
+    });
+    it('_update', function () {
+      layer = map.createLayer('feature', {renderer: 'd3'});
+      expect(layer._update()).toBe(layer);
+      var feat = layer.createFeature('point');
+      sinon.stub(feat, '_update', function () {});
+      expect(layer._update()).toBe(layer);
+      expect(feat._update.calledOnce).toBe(true);
+    });
+  });
+  describe('Check public class methods', function () {
+    var map, layer, feat1, feat2, feat3;
+    it('createFeature', function () {
+      map = create_map();
+      layer = map.createLayer('feature', {renderer: 'd3'});
+
+      feat1 = layer.createFeature('point');
+      expect(feat1).not.toBe(null);
+      expect(layer.features().length).toBe(1);
+      feat2 = layer.createFeature('point');
+      expect(feat2).not.toBe(null);
+      expect(feat1).not.toBe(feat2);
+      expect(layer.features().length).toBe(2);
+      expect(layer.createFeature('none')).toBe(null);
+      expect(layer.features().length).toBe(2);
+    });
+    it('addFeature', function () {
+      layer.addFeature(feat1);
+      expect(layer.features().length).toBe(2);
+      expect(layer.features()).toEqual([feat2, feat1]);
+      feat3 = geo.feature({layer: layer, renderer: layer.renderer()});
+      layer.addFeature(feat3);
+      expect(layer.features().length).toBe(3);
+      expect(layer.features()).toEqual([feat2, feat1, feat3]);
+    });
+    it('removeFeature', function () {
+      layer.removeFeature(feat3);
+      expect(layer.features().length).toBe(2);
+      layer.removeFeature(feat3);
+      expect(layer.features().length).toBe(2);
+      sinon.stub(feat2, '_exit', function () {});
+      layer.removeFeature(feat2);
+      expect(layer.features().length).toBe(1);
+      expect(feat2._exit.calledOnce).toBe(false);
+      feat2._exit.restore();
+    });
+    it('deleteFeature', function () {
+      sinon.stub(feat1, '_exit', function () {});
+      sinon.stub(feat2, '_exit', function () {});
+      layer.deleteFeature(feat2);
+      expect(layer.features().length).toBe(1);
+      expect(feat2._exit.calledOnce).toBe(false);
+      layer.deleteFeature(feat1);
+      expect(layer.features().length).toBe(0);
+      expect(feat1._exit.calledOnce).toBe(true);
+    });
+    it('features', function () {
+      feat1 = layer.createFeature('point');
+      expect(layer.features().length).toBe(1);
+      expect(layer.features()).toEqual([feat1]);
+      layer.features([feat2]);
+      expect(layer.features().length).toBe(1);
+      expect(layer.features()).toEqual([feat2]);
+      layer.features([feat3, feat2]);
+      expect(layer.features().length).toBe(2);
+      expect(layer.features()).toEqual([feat3, feat2]);
+      // feat1 was deleted when we changed features, so make a new one
+      feat1 = geo.feature({layer: layer, renderer: layer.renderer()});
+      layer.features([feat2, feat1]);
+      expect(layer.features().length).toBe(2);
+      expect(layer.features()).toEqual([feat2, feat1]);
+    });
+    it('draw', function () {
+      sinon.stub(feat1, 'draw', function () {});
+      expect(layer.draw()).toBe(layer);
+      expect(feat1.draw.calledOnce).toBe(true);
+    });
+    it('clear', function () {
+      var modTime = layer.getMTime();
+      expect(layer.clear()).toBe(layer);
+      expect(layer.features().length).toBe(0);
+      expect(layer.getMTime()).toBeGreaterThan(modTime);
+      modTime = layer.getMTime();
+      expect(layer.clear()).toBe(layer);
+      expect(layer.features().length).toBe(0);
+      expect(layer.getMTime()).toBe(modTime);
+    });
+  });
+});


### PR DESCRIPTION
Features now have a default `boxSearch` so that brushing events don't throw errors.

When a `mousemove` event is processed, less work is done if the point search has no hits.

Mouse `buttonDown` properties are propagated through to the feature `mouseclick` event so that the button that was used is known.

Better error handling on feature creation.  This allows the `annotationLayer` to avoid using a try catch block.

`featureLayer`'s method for replacing the list of features didn't properly add or remove children.  Now, features can be added and removed independently of their creation and destruction, though removing a feature from a layer will still leave it attached to its renderer.

Unit tests for `feature` and `featureLayer`.

Fixed some typos in comments.