### PR TITLE
Replace rather than modify default arrays.

### DIFF
--- a/src/mapInteractor.js
+++ b/src/mapInteractor.js
@@ -90,38 +90,54 @@ var mapInteractor = function (args) {
       actions: [{
         action: geo_action.pan,
         input: 'left',
-        modifiers: {shift: false, ctrl: false}
+        modifiers: {shift: false, ctrl: false},
+        owner: 'geo.mapInteractor',
+        name: 'button pan'
       }, {
         action: geo_action.zoom,
         input: 'right',
-        modifiers: {shift: false, ctrl: false}
+        modifiers: {shift: false, ctrl: false},
+        owner: 'geo.mapInteractor',
+        name: 'button zoom'
       }, {
         action: geo_action.zoom,
         input: 'wheel',
-        modifiers: {shift: false, ctrl: false}
+        modifiers: {shift: false, ctrl: false},
+        owner: 'geo.mapInteractor',
+        name: 'wheel zoom'
       }, {
         action: geo_action.rotate,
         input: 'left',
-        modifiers: {shift: false, ctrl: true}
+        modifiers: {shift: false, ctrl: true},
+        owner: 'geo.mapInteractor',
+        name: 'button rotate'
       }, {
         action: geo_action.rotate,
         input: 'wheel',
-        modifiers: {shift: false, ctrl: true}
+        modifiers: {shift: false, ctrl: true},
+        owner: 'geo.mapInteractor',
+        name: 'wheel rotate'
       }, {
         action: geo_action.select,
         input: 'left',
         modifiers: {shift: true, ctrl: true},
-        selectionRectangle: geo_event.select
+        selectionRectangle: geo_event.select,
+        owner: 'geo.mapInteractor',
+        name: 'drag select'
       }, {
         action: geo_action.zoomselect,
         input: 'left',
         modifiers: {shift: true, ctrl: false},
-        selectionRectangle: geo_event.zoomselect
+        selectionRectangle: geo_event.zoomselect,
+        owner: 'geo.mapInteractor',
+        name: 'drag zoom'
       }, {
         action: geo_action.unzoomselect,
         input: 'right',
         modifiers: {shift: true, ctrl: false},
-        selectionRectangle: geo_event.unzoomselect
+        selectionRectangle: geo_event.unzoomselect,
+        owner: 'geo.mapInteractor',
+        name: 'drag unzoom'
       }],
 
       click: {
@@ -155,6 +171,14 @@ var mapInteractor = function (args) {
     },
     m_options
   );
+  /* We don't want to merge the original arrays array with a array passed in
+   * the args, so override that as necessary for actions. */
+  if (args && args.actions) {
+    m_options.actions = $.extend(true, [], args.actions);
+  }
+  if (args && args.momentum && args.momentum.actions) {
+    m_options.momentum.actions = $.extend(true, [], args.momentum.actions);
+  }
 
   // options supported:
   // {
@@ -921,7 +945,7 @@ var mapInteractor = function (args) {
 
   ////////////////////////////////////////////////////////////////////////////
   /**
-   * Based on the screen coordinates of a selection, zoom or unzoom and
+   * Based on the screen coodinates of a selection, zoom or unzoom and
    * recenter.
    *
    * @private

--- a/tests/cases/mapInteractor.js
+++ b/tests/cases/mapInteractor.js
@@ -189,6 +189,17 @@ describe('mapInteractor', function () {
     expect(interactor.map()).toBe(map);
   });
 
+  it('Test initialization with array values.', function () {
+    var map = mockedMap('#mapNode1');
+    var interactor = geo.mapInteractor({
+      map: map,
+      actions: [{action: geo.geo_action.pan, input: 'left'}],
+      momentum: {actions: [geo.geo_action.pan]}
+    });
+    expect(interactor.options().actions.length).toBe(1);
+    expect(interactor.options().momentum.actions.length).toBe(1);
+  });
+
   it('Test pan wheel event propagation', function () {
     var map = mockedMap('#mapNode1');
 


### PR DESCRIPTION
When constructing a mapInteractor with options, make sure the whole set is replaced.  We use jquery's extend method.  When using this on something like $.extend([1, 2, 3], [4, 5]), you end up with [4, 5, 3], but for this purpose we want to end up with just the new array.

Also, give default names and an owner to the mapInteractor map actions so that they can be more easily referenced.