### PR TITLE
Support for canvas elements on quads.

### DIFF
--- a/examples/quads/main.js
+++ b/examples/quads/main.js
@@ -20,91 +20,125 @@ $(function () {
     features: query.renderer ? undefined : ['quad']
   });
   var quads = layer.createFeature('quad', {selectionAPI: true});
+  var quadData = [{
+    ll: {x: -108, y: 29},
+    ur: {x: -88, y: 49},
+    image: '../../data/tilefancy.png'
+  }, {
+    ll: {x: -88, y: 29},
+    ur: {x: -58, y: 49},
+    image: 'flower1.jpg',
+    opacity: 0.75
+  }, {
+    ul: {x: -108, y: 29},
+    ur: {x: -58, y: 29},
+    ll: {x: -98, y: 9},
+    lr: {x: -68, y: 9},
+    previewImage: null,
+    image: 'flower3.jpg'
+  }, {
+    lr: {x: -58, y: 29},
+    ur: {x: -58, y: 49},
+    ul: {x: -38, y: 54},
+    ll: {x: -33, y: 34},
+    image: 'flower2.jpg',
+    opacity: 0.15
+  }, {
+    ll: {x: -33, y: 34},
+    lr: {x: -33, y: 9},
+    ur: {x: -68, y: 9},
+    ul: {x: -58, y: 29},
+    image: '../../data/tilefancy.png'
+  }, {
+    ll: {x: -128, y: 29},
+    ur: {x: -108, y: 49},
+    image: '../../data/nosuchimage.png'
+  }, {
+    ul: {x: -128, y: 29},
+    ur: {x: -108, y: 29},
+    ll: {x: -123, y: 9},
+    lr: {x: -98, y: 9},
+    previewImage: null,
+    image: '../../data/nosuchimage.png'
+  }, {
+    ul: {x: -148, y: 29},
+    ur: {x: -128, y: 29},
+    ll: {x: -148, y: 9},
+    lr: {x: -123, y: 9},
+    previewImage: previewImage,
+    image: '../../data/nosuchimage.png'
+  }, {
+    ll: {x: -138, y: 29},
+    ur: {x: -128, y: 39},
+    color: '#FF0000'
+  }, {
+    ll: {x: -148, y: 39},
+    ur: {x: -138, y: 49},
+    color: '#FF0000'
+  }, {
+    ll: {x: -138, y: 39},
+    ur: {x: -128, y: 49},
+    color: '#00FFFF'
+  }, {
+    ll: {x: -148, y: 29},
+    ur: {x: -138, y: 39},
+    opacity: 0.25,
+    color: '#0000FF'
+  }];
+  if (query.canvas === 'true') {
+    // You can render a canvas on a quad, but only on the canvas and vgl
+    // renderers.  On the vgl renderer, it may not update when the quad's
+    // canvas element is changed.
+    var canvasElement = document.createElement('canvas');
+    canvasElement.width = 640;
+    canvasElement.height = 480;
+    var context = canvasElement.getContext('2d');
+    var gradient = context.createRadialGradient(320, 240, 0, 320, 240, 320);
+    gradient.addColorStop(0, 'black');
+    gradient.addColorStop(1, 'green');
+    context.fillStyle = gradient;
+    context.fillRect(0, 0, 640, 480);
+    quadData.push({
+      ul: {x: -98, y: 9},
+      ur: {x: -68, y: 9},
+      ll: {x: -98, y: -11},
+      lr: {x: -68, y: -11},
+      image: canvasElement
+    });
+    // change the gradient after 10 seconds
+    window.setTimeout(function () {
+      var gradient = context.createRadialGradient(320, 240, 0, 320, 240, 320);
+      gradient.addColorStop(0, 'green');
+      gradient.addColorStop(1, 'black');
+      context.fillStyle = gradient;
+      context.fillRect(0, 0, 640, 480);
+      quads.draw();
+    }, 10000);
+  }
+  if (query.warped === 'true') {
+    /* You can specify quads so that the corners are 'twisted' and the quad
+     * would be non-convex.  In this case, the quads are each rendered as a
+     * pair of triangles, but they probably aren't what is desired. */
+    quadData.push({
+      ll: {x: -108, y: 49},
+      lr: {x: -88, y: 49},
+      ur: {x: -108, y: 59},
+      ul: {x: -88, y: 59},
+      image: '../../data/tilefancy.png'
+    });
+    quadData.push({
+      ll: {x: -88, y: 49},
+      ur: {x: -68, y: 49},
+      ul: {x: -88, y: 59},
+      lr: {x: -68, y: 59},
+      image: '../../data/tilefancy.png'
+    });
+  }
   var previewImage = new Image();
   previewImage.onload = function () {
 
     quads
-      .data([{
-        ll: {x: -108, y: 29},
-        ur: {x: -88, y: 49},
-        image: '../../data/tilefancy.png'
-      }, {
-        ll: {x: -88, y: 29},
-        ur: {x: -58, y: 49},
-        image: 'flower1.jpg',
-        opacity: 0.75
-      }, {
-        ul: {x: -108, y: 29},
-        ur: {x: -58, y: 29},
-        ll: {x: -98, y: 9},
-        lr: {x: -68, y: 9},
-        previewImage: null,
-        image: 'flower3.jpg'
-      }, {
-        lr: {x: -58, y: 29},
-        ur: {x: -58, y: 49},
-        ul: {x: -38, y: 54},
-        ll: {x: -33, y: 34},
-        image: 'flower2.jpg',
-        opacity: 0.15
-      }, {
-        ll: {x: -33, y: 34},
-        lr: {x: -33, y: 9},
-        ur: {x: -68, y: 9},
-        ul: {x: -58, y: 29},
-        image: '../../data/tilefancy.png'
-      }, {
-        ll: {x: -128, y: 29},
-        ur: {x: -108, y: 49},
-        image: '../../data/nosuchimage.png'
-      }, {
-        ul: {x: -128, y: 29},
-        ur: {x: -108, y: 29},
-        ll: {x: -123, y: 9},
-        lr: {x: -98, y: 9},
-        previewImage: null,
-        image: '../../data/nosuchimage.png'
-      }, {
-        ul: {x: -148, y: 29},
-        ur: {x: -128, y: 29},
-        ll: {x: -148, y: 9},
-        lr: {x: -123, y: 9},
-        previewImage: previewImage,
-        image: '../../data/nosuchimage.png'
-      }, {
-        ll: {x: -138, y: 29},
-        ur: {x: -128, y: 39},
-        color: '#FF0000'
-      }, {
-        ll: {x: -148, y: 39},
-        ur: {x: -138, y: 49},
-        color: '#FF0000'
-      }, {
-        ll: {x: -138, y: 39},
-        ur: {x: -128, y: 49},
-        color: '#00FFFF'
-      }, {
-        ll: {x: -148, y: 29},
-        ur: {x: -138, y: 39},
-        opacity: 0.25,
-        color: '#0000FF'
-      /* You can specify quads so that the corners are 'twisted' and the quad
-       * would be non-convex.  In this case, the quads are each rendered as a
-       * pair of triangles, but they probably aren't what is desired.
-      }, {
-        ll: {x: -108, y: 49},
-        lr: {x: -88, y: 49},
-        ur: {x: -108, y: 59},
-        ul: {x: -88, y: 59},
-        image: '../../data/tilefancy.png'
-      }, {
-        ll: {x: -88, y: 49},
-        ur: {x: -68, y: 49},
-        ul: {x: -88, y: 59},
-        lr: {x: -68, y: 59},
-        image: '../../data/tilefancy.png'
-      */
-      }])
+      .data(quadData)
       .style({
         opacity: function (d) {
           return d.opacity !== undefined ? d.opacity : 1;

--- a/src/canvas/quadFeature.js
+++ b/src/canvas/quadFeature.js
@@ -154,6 +154,7 @@ capabilities[quadFeature.capabilities.image] = true;
 capabilities[quadFeature.capabilities.imageCrop] = true;
 capabilities[quadFeature.capabilities.imageFixedScale] = true;
 capabilities[quadFeature.capabilities.imageFull] = false;
+capabilities[quadFeature.capabilities.canvas] = true;
 
 registerFeature('canvas', 'quad', canvas_quadFeature, capabilities);
 module.exports = canvas_quadFeature;

--- a/src/d3/quadFeature.js
+++ b/src/d3/quadFeature.js
@@ -234,6 +234,7 @@ capabilities[quadFeature.capabilities.image] = true;
 capabilities[quadFeature.capabilities.imageCrop] = false;
 capabilities[quadFeature.capabilities.imageFixedScale] = false;
 capabilities[quadFeature.capabilities.imageFull] = false;
+capabilities[quadFeature.capabilities.canvas] = false;
 
 registerFeature('d3', 'quad', d3_quadFeature, capabilities);
 module.exports = d3_quadFeature;

--- a/src/gl/quadFeature.js
+++ b/src/gl/quadFeature.js
@@ -423,6 +423,7 @@ capabilities[quadFeature.capabilities.image] = true;
 capabilities[quadFeature.capabilities.imageCrop] = true;
 capabilities[quadFeature.capabilities.imageFixedScale] = false;
 capabilities[quadFeature.capabilities.imageFull] = true;
+capabilities[quadFeature.capabilities.canvas] = false;
 
 registerFeature('vgl', 'quad', gl_quadFeature, capabilities);
 module.exports = gl_quadFeature;

--- a/src/polyfills.js
+++ b/src/polyfills.js
@@ -34,4 +34,3 @@ Math.sinh = Math.sinh || function (x) {
   var y = Math.exp(x);
   return (y - 1 / y) / 2;
 };
-

--- a/src/quadFeature.js
+++ b/src/quadFeature.js
@@ -331,7 +331,7 @@ var quadFeature = function (arg) {
       } else {
         image = m_this._objectListGet(m_images, img);
         if (image === undefined) {
-          if (img instanceof Image) {
+          if (img instanceof Image || img instanceof HTMLCanvasElement) {
             image = img;
           } else {
             image = new Image();
@@ -350,7 +350,8 @@ var quadFeature = function (arg) {
         if (d.crop) {
           quad.crop = d.crop;
         }
-        if (image.complete && image.naturalWidth && image.naturalHeight) {
+        if ((image.complete && image.naturalWidth && image.naturalHeight) ||
+             image instanceof HTMLCanvasElement) {
           quad.image = image;
         } else {
           previewColor = undefined;
@@ -482,7 +483,9 @@ quadFeature.capabilities = {
   /* support for fixed-scale quad images */
   imageFixedScale: 'quad.imageFixedScale',
   /* support for arbitrary quad images */
-  imageFull: 'quad.imageFull'
+  imageFull: 'quad.imageFull',
+  /* support for canvas as content in image quads*/
+  canvas: 'quad.canvas'
 };
 
 inherit(quadFeature, feature);


### PR DESCRIPTION
Rather than using an image, a canvas can be rendered on a quad.  On the canvas renderer, after changing the canvas quad, a draw call is sufficient to update it.  On the vgl renderer, the texture is cached, so it will take more work to update the texture.  