### PR TITLE
Remove jQuery as a Bower dependency

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -12,8 +12,7 @@
     "url": "https://github.com/OpenGeoscience/geojs"
   },
   "dependencies": {
-    "d3": "^3.5.16",
-    "jquery": "~2.2.1"
+    "d3": "^3.5.16"
   },
   "ignore": [
     ".git",


### PR DESCRIPTION
This brings the list of Bower dependencies in line with the NPM dependencies.