### PR TITLE
Units per pixel should be set in the pixelCoordinateParams utility function

### DIFF
--- a/src/util/init.js
+++ b/src/util/init.js
@@ -648,6 +648,7 @@
         ingcs: '+proj=longlat +axis=esu',
         gcs: '+proj=longlat +axis=enu',
         maxBounds: {left: 0, top: 0, right: width, bottom: height},
+        unitsPerPixel: Math.pow(2, maxLevel),
         center: {x: width / 2, y: height / 2},
         min: minLevel,
         max: maxLevel,

--- a/tests/cases/osmLayer.js
+++ b/tests/cases/osmLayer.js
@@ -285,6 +285,7 @@ describe('geo.core.osmLayer', function () {
       var sizeX = 12345, sizeY = 5678, tileSize = 240;
       var params = geo.util.pixelCoordinateParams('#map-osm-layer', sizeX, sizeY, tileSize, tileSize);
       expect(params.map.ingcs).toBe('+proj=longlat +axis=esu');
+      expect(params.map.unitsPerPixel).toEqual(64);
       expect(params.layer.tileRounding).toBe(Math.ceil);
       expect(params.layer.tileOffset()).toEqual({x: 0, y: 0});
       expect(params.layer.tilesAtZoom(3)).toEqual({x: 7, y: 3});


### PR DESCRIPTION
Otherwise, tile sets that aren't powers of two will be mis-centered by default.  The consumer of `pixelCoordinateParams` can still set unitsPerPixel, but this removes that necessity.