### PR TITLE
Remove the lag between layers.

### DIFF
--- a/src/d3/d3Renderer.js
+++ b/src/d3/d3Renderer.js
@@ -40,7 +40,6 @@ var d3Renderer = function (arg) {
       m_diagonal = null,
       m_scale = 1,
       m_transform = {dx: 0, dy: 0, rx: 0, ry: 0, rotation: 0},
-      m_renderAnimFrameRef = null,
       m_renderIds = {},
       m_removeIds = {},
       m_svg = null,
@@ -509,9 +508,7 @@ var d3Renderer = function (arg) {
       m_this._renderFeature(id, parentId);
     } else {
       m_renderIds[id] = true;
-      if (m_renderAnimFrameRef === null) {
-        m_renderAnimFrameRef = window.requestAnimationFrame(m_this._renderFrame);
-      }
+      m_this.layer().map().scheduleAnimationFrame(m_this._renderFrame);
     }
   };
 
@@ -524,7 +521,6 @@ var d3Renderer = function (arg) {
     m_removeIds = {};
     var ids = m_renderIds;
     m_renderIds = {};
-    m_renderAnimFrameRef = null;
     for (id in ids) {
       if (ids.hasOwnProperty(id)) {
         m_this._renderFeature(id);
@@ -578,9 +574,7 @@ var d3Renderer = function (arg) {
   ////////////////////////////////////////////////////////////////////////////
   this._removeFeature = function (id) {
     m_removeIds[id] = true;
-    if (m_renderAnimFrameRef === null) {
-      m_renderAnimFrameRef = window.requestAnimationFrame(m_this._renderFrame);
-    }
+    m_this.layer().map().scheduleAnimationFrame(m_this._renderFrame);
     delete m_features[id];
     if (m_renderIds[id]) {
       delete m_renderIds[id];

--- a/src/gl/polygonFeature.js
+++ b/src/gl/polygonFeature.js
@@ -340,11 +340,11 @@ var gl_polygonFeature = function (arg) {
   ////////////////////////////////////////////////////////////////////////////
   this._update = function (opts) {
     if (opts && opts.mayDelay) {
-      m_updateAnimFrameRef = window.requestAnimationFrame(this._update);
+      m_updateAnimFrameRef = m_this.layer().map().scheduleAnimationFrame(m_this._update);
       return;
     }
     if (m_updateAnimFrameRef) {
-      window.cancelAnimationFrame(m_updateAnimFrameRef);
+      m_this.layer().map().scheduleAnimationFrame(m_this._update, 'remove');
       m_updateAnimFrameRef = null;
     }
     s_update.call(m_this);

--- a/src/gl/quadFeature.js
+++ b/src/gl/quadFeature.js
@@ -239,6 +239,7 @@ var gl_quadFeature = function (arg) {
     if (m_clrModelViewUniform) {
       m_clrModelViewUniform.setOrigin(m_quads.origin);
     }
+    m_this._updateTextures();
     m_this.buildTime().modified();
   };
 
@@ -329,8 +330,6 @@ var gl_quadFeature = function (arg) {
     var context = renderState.m_context,
         opacity = 1,
         crop = {x: 1, y: 1}, quadcrop;
-
-    m_this._updateTextures();
 
     context.bindBuffer(vgl.GL.ARRAY_BUFFER, m_glBuffers.imgQuadsPosition);
     $.each(m_quads.imgQuads, function (idx, quad) {

--- a/src/mapInteractor.js
+++ b/src/mapInteractor.js
@@ -1431,11 +1431,11 @@ var mapInteractor = function (args) {
       }
 
       if (m_state.handler) {
-        window.requestAnimationFrame(m_state.handler);
+        m_this.map().scheduleAnimationFrame(m_state.handler);
       }
     };
     if (m_state.handler) {
-      window.requestAnimationFrame(m_state.handler);
+      m_this.map().scheduleAnimationFrame(m_state.handler);
     }
   };
 

--- a/src/util/init.js
+++ b/src/util/init.js
@@ -781,7 +781,7 @@
       } else if (!stop && !m_originalRequestAnimationFrame) {
         m_originalRequestAnimationFrame = window.requestAnimationFrame;
         window.requestAnimationFrame = function (callback) {
-          m_originalRequestAnimationFrame.call(window, function (timestamp) {
+          return m_originalRequestAnimationFrame.call(window, function (timestamp) {
             var track = m_timingData.requestAnimationFrame, recent;
             /* Some environments have unsynchronized performance and time
              * counters.  The nowDelta factor compensates for this.  For

--- a/tests/cases/d3GraphFeature.js
+++ b/tests/cases/d3GraphFeature.js
@@ -20,12 +20,12 @@ describe('d3 graph feature', function () {
     var map, layer, feature;
 
     it('Setup map', function () {
+      mockAnimationFrame();
       map = geo.map({node: '#map-d3-graph-feature', center: [0, 0], zoom: 3});
       layer = map.createLayer('feature', {'renderer': 'd3'});
     });
 
     it('Add features to a layer', function () {
-      mockAnimationFrame();
       var selection, nodes;
 
       nodes = [

--- a/tests/cases/d3PointFeature.js
+++ b/tests/cases/d3PointFeature.js
@@ -20,6 +20,7 @@ describe('d3 point feature', function () {
     var map, width = 800, height = 600, layer, feature1, feature2;
 
     it('Setup map', function () {
+      mockAnimationFrame();
       map = geo.map({node: '#map-d3-point-feature', center: [0, 0], zoom: 3});
       layer = map.createLayer('feature', {'renderer': 'd3'});
 
@@ -27,7 +28,6 @@ describe('d3 point feature', function () {
     });
 
     it('Add features to a layer', function () {
-      mockAnimationFrame();
       var selection;
       feature1 = layer.createFeature('point', {selectionAPI: true})
         .data([{y: 0, x: 0}, {y: 10, x: 0}, {y: 0, x: 10}])

--- a/tests/cases/d3VectorFeature.js
+++ b/tests/cases/d3VectorFeature.js
@@ -10,6 +10,7 @@ describe('d3 vector feature', function () {
   var map, layer, feature1;
 
   it('Create a map with a d3 feature layer', function () {
+    mockAnimationFrame();
     d3.select('body').append('div').attr('id', 'map-d3-vector');
     map = geo.map({node: '#map-d3-vector',
       center: [0, 0],
@@ -36,7 +37,6 @@ describe('d3 vector feature', function () {
   });
 
   it('Add features to a layer', function () {
-    mockAnimationFrame();
     var vectorLines, featureGroup, markers;
     feature1 = layer.createFeature('vector')
     .data([{y: 0, x: 0}, {y: 10, x: 0}, {y: 0, x: 10}])

--- a/tests/cases/map.js
+++ b/tests/cases/map.js
@@ -390,8 +390,8 @@ describe('geo.core.map', function () {
       expect(closeToEqual(zc.center, {x: 0, y: 0})).toBe(true);
     });
     it('transition', function () {
-      var m = create_map(), start, wasCalled;
       mockAnimationFrame();
+      var m = create_map(), start, wasCalled;
       expect(m.transition()).toBe(null);
       start = new Date().getTime();
       m.transition({

--- a/tests/cases/mapInteractor.js
+++ b/tests/cases/mapInteractor.js
@@ -136,6 +136,9 @@ describe('mapInteractor', function () {
     map.gcs = function (arg) {
       return 'EPSG:3857';
     };
+    map.scheduleAnimationFrame = function (callback) {
+      return window['requestAnimationFrame'](callback);
+    };
     return map;
   }
 
@@ -1327,6 +1330,7 @@ describe('mapInteractor', function () {
   });
 
   it('Test momentum', function () {
+    mockAnimationFrame();
     var map = mockedMap('#mapNode1'), start;
 
     var interactor = geo.mapInteractor({
@@ -1338,7 +1342,6 @@ describe('mapInteractor', function () {
       }],
       throttle: false
     });
-    mockAnimationFrame();
     mockDate();
     // initiate a pan and release
     interactor.simulateEvent(
@@ -1380,6 +1383,7 @@ describe('mapInteractor', function () {
   });
 
   it('Test springback', function () {
+    mockAnimationFrame();
     $('#mapNode1').css({width: '400px', height: '400px'});
     var map = mockedMap('#mapNode1'), start;
 
@@ -1393,7 +1397,6 @@ describe('mapInteractor', function () {
       }],
       throttle: false
     });
-    mockAnimationFrame();
     mockDate();
     // pan past the max bounds
     interactor.simulateEvent(

--- a/tests/test-utils.js
+++ b/tests/test-utils.js
@@ -341,6 +341,7 @@ module.exports.mockAnimationFrame = function (mockDate) {
     animFrameIndex += 1;
     var id = animFrameIndex;
     animFrameCallbacks.push({id: id, callback: callback});
+    return id;
   }
 
   /* Replace window.cancelAnimationFrame with this function.


### PR DESCRIPTION
Pedantically, this wasn't a lag, but rather missed frames.

A variety of actions can trigger rerendering.  We want to perform animations before other updates.  To ensure that renderings are well ordered and not called too often, we were removing an animation frame request and then creating a new one to ensure that the callback happened at the end of the animation frame cycle.  However, sometimes this would defer the animation frame callback until a later cycle rather than just at the end of the next cycle.

By using a single animation queue, we ensure that get all of the callbacks we want in the animation cycle.  This has the fringe benefit that it has less overhead in Chrome.  Furthermore, by using a shared array for the animation queue, two map instances can be synchronized, whereas, before, there was likely to be a lag between them.

A few other minor optimizations have been made: vgl textures are built in the _build step not in the animation frame.  The vgl camera is only updated just as needed, so if two pan events happen in a single frame, only one update will occur.

Resolves issue #526.