### PR TITLE
Guard against undefined colors.

### DIFF
--- a/src/util/init.js
+++ b/src/util/init.js
@@ -252,8 +252,8 @@
      *    returned.
      */
     convertColor: function (color) {
-      if (color.r !== undefined && color.g !== undefined &&
-          color.b !== undefined) {
+      if (color === undefined || (color.r !== undefined &&
+          color.g !== undefined && color.b !== undefined)) {
         return color;
       }
       var opacity;

--- a/tests/cases/colors.js
+++ b/tests/cases/colors.js
@@ -99,6 +99,9 @@ describe('geo.util.convertColor', function () {
         b: 1
       });
     });
+    it('undefined', function () {
+      expect(geo.util.convertColor(undefined)).toBe(undefined);
+    });
   });
 });
 


### PR DESCRIPTION
There was an occasional build failure due to an undefined color.  This happened as some feature was being destroyed and a render timeout function was called.