### PR TITLE
Don't pixel align if the map isn't aligned.

### DIFF
--- a/src/camera.js
+++ b/src/camera.js
@@ -303,10 +303,17 @@
 
     /**
      * Getter/setter for the viewport.
+     *
+     * The viewport consists of a width and height in pixels, plus a left and
+     * top offset in pixels.  The offsets are only used to determine if pixel
+     * alignment is possible.
      */
     Object.defineProperty(this, 'viewport', {
       get: function () {
-        return {width: this._viewport.width, height: this._viewport.height};
+        return {
+          width: this._viewport.width, height: this._viewport.height,
+          left: this._viewport.left, top: this._viewport.top
+        };
       },
       set: function (viewport) {
         if (!(viewport.width > 0 &&
@@ -335,7 +342,10 @@
           ]);
         }
 
-        this._viewport = {width: viewport.width, height: viewport.height};
+        this._viewport = {
+          width: viewport.width, height: viewport.height,
+          left: viewport.left, top: viewport.top
+        };
         this._update();
         this.geoTrigger(geo_event.camera.viewport, {
           camera: this,

--- a/src/gl/vglRenderer.js
+++ b/src/gl/vglRenderer.js
@@ -189,8 +189,11 @@ var vglRenderer = function (arg) {
       m_lastZoom = map.zoom();
       cam.setViewMatrix(view, true);
       cam.setProjectionMatrix(proj);
+      var viewport = camera.viewport;
       if (proj[1] || proj[2] || proj[3] || proj[4] || proj[6] || proj[7] ||
           proj[8] || proj[9] || proj[11] || proj[15] !== 1 || !ortho ||
+          (viewport.left && viewport.left % 1) ||
+          (viewport.top && viewport.top % 1) ||
           (parseFloat(m_lastZoom.toFixed(6)) !==
            parseFloat(m_lastZoom.toFixed(0)))) {
         /* Don't align texels */
@@ -202,11 +205,11 @@ var vglRenderer = function (arg) {
          * probably be divided by window.devicePixelRatio. */
         cam.viewAlignment = function () {
           var align = {
-            roundx: 2.0 / camera.viewport.width,
-            roundy: 2.0 / camera.viewport.height
+            roundx: 2.0 / viewport.width,
+            roundy: 2.0 / viewport.height
           };
-          align.dx = (camera.viewport.width % 2) ? align.roundx * 0.5 : 0;
-          align.dy = (camera.viewport.height % 2) ? align.roundy * 0.5 : 0;
+          align.dx = (viewport.width % 2) ? align.roundx * 0.5 : 0;
+          align.dy = (viewport.height % 2) ? align.roundy * 0.5 : 0;
           return align;
         };
       }

--- a/src/gl/vglRenderer.js
+++ b/src/gl/vglRenderer.js
@@ -190,6 +190,15 @@ var vglRenderer = function (arg) {
       cam.setViewMatrix(view, true);
       cam.setProjectionMatrix(proj);
       var viewport = camera.viewport;
+      /* Test if we should align texels.  We won't if the projection matrix
+       * is not simple, if there is a rotation that isn't a multiple of 90
+       * degrees, if the viewport is not at an integer location, or if the zoom
+       * level is not close to an integer.
+       *   Note that the test for the viewport is strict (val % 1 is non-zero
+       * if the value is not an integer), as, in general, the alignment is only
+       * non-integral if a percent offset or calculation was used in css
+       * somewhere.  The test for zoom level always has some allowance for
+       * precision, as it is often the result of repeated computations. */
       if (proj[1] || proj[2] || proj[3] || proj[4] || proj[6] || proj[7] ||
           proj[8] || proj[9] || proj[11] || proj[15] !== 1 || !ortho ||
           (viewport.left && viewport.left % 1) ||

--- a/src/map.js
+++ b/src/map.js
@@ -151,7 +151,10 @@ var map = function (arg) {
   m_unitsPerPixel = (arg.unitsPerPixel || (
     m_maxBounds.right - m_maxBounds.left) / 256);
 
-  m_camera.viewport = {width: m_width, height: m_height};
+  m_camera.viewport = {
+    width: m_width, height: m_height,
+    left: m_node.offset().left, top: m_node.offset().top
+  };
   arg.center = util.normalizeCoordinates(arg.center);
   arg.autoResize = arg.autoResize === undefined ? true : arg.autoResize;
   m_clampBoundsX = arg.clampBoundsX === undefined ? false : arg.clampBoundsX;
@@ -683,7 +686,10 @@ var map = function (arg) {
     if (newZoom !== m_zoom) {
       m_this.zoom(newZoom);
     }
-    m_this.camera().viewport = {width: m_width, height: m_height};
+    m_this.camera().viewport = {
+      width: m_width, height: m_height,
+      left: m_node.offset().left, top: m_node.offset().top
+    };
     m_this.center(oldCenter);
 
     m_this.geoTrigger(geo_event.resize, {


### PR DESCRIPTION
If the map is not at an integer offset on the page, don't try to align texels.  This only applies to the vgl renderer.