### PR TITLE
Fix gaps in tiles when they aren't aligned.

### DIFF
--- a/src/gl/quadFeature.js
+++ b/src/gl/quadFeature.js
@@ -42,7 +42,7 @@ var gl_quadFeature = function (arg) {
     'uniform highp vec2 crop;',
     'void main(void) {',
     '  mediump vec4 color = texture2D(sampler2d, iTextureCoord);',
-    '  if (iTextureCoord.s > crop.s || 1.0 - iTextureCoord.t > crop.t) {',
+    '  if ((crop.s < 1.0 && iTextureCoord.s > crop.s) || (crop.t < 1.0 && 1.0 - iTextureCoord.t > crop.t)) {',
     '    discard;',
     '  }',
     '  color.w *= opacity;',


### PR DESCRIPTION
Non pixel-perfect tile alignment, where there are no lower level tiles, was showing slight gaps between the tiles.  The code to crop right and bottom edges was being invoked, because the texture coordinates of an unaligned tile occasionally are greater than 1.

To test this would require a new selenium test, since it is purely an artifact of how textures are rendered on quads in the vgl renderer.