### PR TITLE
Add a screenshot button in the examples header.

### DIFF
--- a/examples/common/css/examples.css
+++ b/examples/common/css/examples.css
@@ -18,3 +18,14 @@ html, body {
   height: calc(100% - 60px);
   overflow: hidden;
 }
+
+li.gj-screenshot-result,li.gj-screenshot-waiting {
+  display: none;
+}
+li a.gj-screenshot-download {
+  padding: 0;
+}
+li.gj-screenshot-result img {
+  max-height: 60px;
+  max-width: 120px;
+}

--- a/examples/common/css/examples.css
+++ b/examples/common/css/examples.css
@@ -19,6 +19,9 @@ html, body {
   overflow: hidden;
 }
 
+.gj-screenshot-link {
+  cursor: pointer;
+}
 li.gj-screenshot-result,li.gj-screenshot-waiting {
   display: none;
 }

--- a/examples/common/js/examples.js
+++ b/examples/common/js/examples.js
@@ -34,3 +34,23 @@ var exampleUtils = {
 };
 
 window.utils = exampleUtils;
+
+/* Add a function to take a screenshot.  Show the screenshot so that a user can
+ * click on it to save it or right-click to copy it. */
+$(function () {
+  $('.gj-screenshot-link').on('click', function () {
+    $('.gj-screenshot-result').hide();
+    $('.gj-screenshot-waiting').show();
+    var map = $('#map').data('data-geojs-map');
+    map.screenshot({wait:'idle'}).then(function (res) {
+      $('.gj-screenshot-waiting').hide();
+      $('.gj-screenshot-result img').attr({src: res});
+      $('.gj-screenshot-download').attr({href: res});
+      $('.gj-screenshot-result').show();
+      /* If you want to trigger an automatic download, enable this line (and,
+       * perhaps, always hide the waiting and result elements).
+      $('.gj-screenshot-download')[0].click();
+       */
+    });
+  });
+});

--- a/examples/common/js/examples.js
+++ b/examples/common/js/examples.js
@@ -53,4 +53,10 @@ $(function () {
        */
     });
   });
+  $('.gj-screenshot-link').keypress(function (evt) {
+    if (evt.which === 13) {
+      $('.gj-screenshot-link').click();
+      return false;
+    }
+  });
 });

--- a/examples/common/templates/index.jade
+++ b/examples/common/templates/index.jade
@@ -37,7 +37,7 @@ html(lang="en")
             ul.nav.navbar-nav.navbar-right
               block screenShode
                 li
-                  a.gj-screenshot-link
+                  a.gj-screenshot-link(tabindex=0)
                     | Screenshot
                 li.gj-screenshot-waiting
                   a ...

--- a/examples/common/templates/index.jade
+++ b/examples/common/templates/index.jade
@@ -35,6 +35,15 @@ html(lang="en")
           .collapse.navbar-collapse#gj-navbar-collapse
             block headerButtons
             ul.nav.navbar-nav.navbar-right
+              block screenShode
+                li
+                  a.gj-screenshot-link
+                    | Screenshot
+                li.gj-screenshot-waiting
+                  a ...
+                li.gj-screenshot-result
+                  a.gj-screenshot-download(download='screenshot.png')
+                    img
               block showSource
                 if docHTML
                   li

--- a/examples/common/templates/index.jade
+++ b/examples/common/templates/index.jade
@@ -35,7 +35,7 @@ html(lang="en")
           .collapse.navbar-collapse#gj-navbar-collapse
             block headerButtons
             ul.nav.navbar-nav.navbar-right
-              block screenShode
+              block screenShot
                 li
                   a.gj-screenshot-link(tabindex=0)
                     | Screenshot

--- a/examples/index.jade
+++ b/examples/index.jade
@@ -24,6 +24,8 @@ block prepend headerButtons
           a(href="http://geojs.readthedocs.org/en/latest/") Developers guide
           a(href="http://my.cdash.org/index.php?project=geojs") Testing
 
+block screenShot
+
 block mainContent
   .jumbotron
     .container

--- a/src/map.js
+++ b/src/map.js
@@ -1660,8 +1660,27 @@ var map = function (arg) {
     var context = result.getContext('2d');
     // optionally start with a white or custom background
     if (opts.background !== false && opts.background !== null) {
-      context.fillStyle = opts.background !== undefined ? opts.background : 'white';
-      context.fillRect(0, 0, result.width, result.height);
+      var background = opts.background;
+      if (opts.background === undefined) {
+        /* If we are using the map's current background, start with white as a
+         * fallback, then fill with the backgrounds of all parents and the map
+         * node.  Since each may be partially transparent, this is required to
+         * match the web page's color.  It won't use background patterns. */
+        context.fillStyle = 'white';
+        context.fillRect(0, 0, result.width, result.height);
+        m_this.node().parents().get().reverse().forEach(function (elem) {
+          background = window.getComputedStyle(elem).backgroundColor;
+          if (background && background !== 'transparent') {
+            context.fillStyle = background;
+            context.fillRect(0, 0, result.width, result.height);
+          }
+        });
+        background = window.getComputedStyle(m_this.node()[0]).backgroundColor;
+      }
+      if (background && background !== 'transparent') {
+        context.fillStyle = background;
+        context.fillRect(0, 0, result.width, result.height);
+      }
     }
     // for each layer, copy to our new canvas.
     layers.forEach(function (layer) {

--- a/src/util/init.js
+++ b/src/util/init.js
@@ -765,7 +765,17 @@
       while (parents && parents > 0) {
         parent = parent.parent();
         if (parent.is('div')) {
-          container = $('<div>').attr('class', parent.attr('class')).css({width: '100%', height: '100%'});
+          /* Create a containing div with the parent's class and id (so css
+           * will be used), but override size and background. */
+          container = $('<div>').attr({
+            'class': parent.attr('class'),
+            id: parent.attr('id')
+          }).css({
+            width: '100%',
+            height: '100%',
+            background: 'none',
+            margin: 0
+          });
           container.append(elem);
           elem = container;
         }
@@ -781,8 +791,8 @@
       container.append($('<head>'));
       var body = $('<body>');
       container.append(body);
-      // we must specify the new body as have no background, or we'll clobber
-      // other layers
+      /* We must specify the new body as having no background, or we'll clobber
+       * other layers. */
       body.css({
         width: parent.width() + 'px',
         height: parent.height() + 'px',


### PR DESCRIPTION
I don't know if we want this added to the examples, but it helps show off the feature, and is simpler than doing a proper screenshot widget.  If you think it is undesirable, we can get rid of the PR.

Another way to do this is to just show a save dialog with the screenshot (and not show a thumbnail of it).  In this version you can right-click on the image and copy it instead of being forced to download it.