### PR TITLE
Make it easier to disable or replace keyboard actions.

### DIFF
--- a/src/mapInteractor.js
+++ b/src/mapInteractor.js
@@ -152,7 +152,7 @@ var mapInteractor = function (args) {
       keyboard: {
         actions: {
           /* Specific actions can be disabled by removing them from this object
-           * or stting an empty list as the key bindings.  Additional actions
+           * or setting an empty list as the key bindings.  Additional actions
            * can be added to the dictionary, each of which gets a list of key
            * bindings.  See Mousetrap documentation for special key names. */
           'zoom.in': ['plus', 'shift+plus', 'shift+ctrl+plus', '=', 'shift+=', 'shift+ctrl+='],
@@ -224,6 +224,9 @@ var mapInteractor = function (args) {
   }
   if (args && args.momentum && args.momentum.actions) {
     m_options.momentum.actions = $.extend(true, [], args.momentum.actions);
+  }
+  if (args && args.keyboard && args.keyboard.actions !== undefined) {
+    m_options.keyboard.actions = $.extend(true, {}, args.keyboard.actions);
   }
 
   // options supported:

--- a/tests/cases/mapInteractor.js
+++ b/tests/cases/mapInteractor.js
@@ -1681,5 +1681,14 @@ describe('mapInteractor', function () {
     keyboardSettings.focusHighlight = true;
     expect(interactor.keyboard(keyboardSettings)).toBe(interactor);
     expect(map.node().hasClass('highlight-focus')).toBe(true);
+
+    // test creating a interactor with a different set of keyboard actions
+    interactor = geo.mapInteractor({map: map, keyboard: {actions: {'zoom.0': ['1']}}});
+    triggered = 0;
+    interactor.simulateEvent('keyboard', {keys: '1'});
+    expect(triggered).toBe(1);
+    triggered = 0;
+    interactor.simulateEvent('keyboard', {keys: '2'});
+    expect(triggered).toBe(0);
   });
 });


### PR DESCRIPTION
If keyboard.actions is specified in the interactor constructor, replace the set of keyboard actions rather than modify it.  Otherwise, it is too annoying to disable or replace.