### PR TITLE
Pin proj4 to version 2.3.16

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "nib": "^1.1.2",
     "node-resemble": "^1.1.3",
     "phantomjs-prebuilt": "^2.1.5",
-    "proj4": "^2.3.14",
+    "proj4": "2.3.16",
     "raw-body": "^2.1.6",
     "sinon": "1.17.3",
     "style-loader": "^0.13.1",


### PR DESCRIPTION
Proj4 just released version 2.4 as ES6 modules.  We will need to either use Babel to transform these modules to commonjs or switch to webpack v2.  For the moment, I'm just pinning to the most recent version before 2.4.