### PR TITLE
Remove the map.resize method.

### DIFF
--- a/src/event.js
+++ b/src/event.js
@@ -109,8 +109,6 @@ geo_event.pan = 'geo_pan';
  * @event geo.event.resize
  * @type {object}
  * @property {object} target The map that was resized.
- * @property {number} x The new horizontal offset in pixels.
- * @property {number} y The new vertical offset in pixels.
  * @property {number} width The new width in pixels.
  * @property {number} height The new height in pixels.
  */

--- a/tests/cases/d3PointFeature.js
+++ b/tests/cases/d3PointFeature.js
@@ -24,7 +24,7 @@ describe('d3 point feature', function () {
       map = geo.map({node: '#map-d3-point-feature', center: [0, 0], zoom: 3});
       layer = map.createLayer('feature', {'renderer': 'd3'});
 
-      map.resize(0, 0, width, height);
+      map.size({width: width, height: height});
     });
 
     it('Add features to a layer', function () {

--- a/tests/cases/heatmap.js
+++ b/tests/cases/heatmap.js
@@ -35,7 +35,7 @@ describe('canvas heatmap', function () {
       mockAnimationFrame();
       map = geo.map({node: '#map-canvas-heatmap-feature', center: [0, 0], zoom: 3});
       layer = map.createLayer('feature', {'renderer': 'canvas'});
-      map.resize(0, 0, width, height);
+      map.size({width: width, height: height});
     });
 
     it('Add feature to a layer', function () {

--- a/tests/cases/map.js
+++ b/tests/cases/map.js
@@ -239,7 +239,7 @@ describe('geo.core.map', function () {
       m.discreteZoom(true);
       m.zoom(0);
       expect(m.zoom()).toBe(1);
-      m.resize(0, 0, 600, 600);
+      m.size({width: 600, height: 600});
       expect(m.zoom()).toBe(2);
       m.zoom(3);
       expect(m.zoom()).toBe(3);


### PR DESCRIPTION
We marked the `map.resize` method as deprecated in version 0.6 (commit 27e6b36).  We completely ignore the `x` and `y` coordinates passed to it.  This change removes the resize and the internal `m_x` and `m_y` variables, moving the necessary functionality to the size method.

This also modifies the resize event by removing the `x` and `y` parameters.