### PR TITLE
Update the documentation on events.

### DIFF
--- a/src/event.js
+++ b/src/event.js
@@ -3,8 +3,8 @@
  * Common object containing all event types that are provided by the GeoJS
  * API.  Each property contained here is a valid target for event handling
  * via {@link geo.object#geoOn}.  The event object provided to handlers is
- * different for each event type.  Each handler is generally be called
- * with the <code>this</code> context being the class that caused the event.<br>
+ * different for each event type.  Each handler is generally called with the
+ * `this` context being the class that caused the event.<br>
  * <br>
  * The following properties are common to all event objects:
  *
@@ -143,7 +143,7 @@ geo_event.mousemove = 'geo_mousemove';
 //////////////////////////////////////////////////////////////////////////////
 /**
  * Triggered on `mouseup` events that happen soon enough and close enough to a
- * mousedown event.  The event object extends {@link geo.mouseState}.
+ * `mousedown` event.  The event object extends {@link geo.mouseState}.
  *
  * @event geo.event.mouseclick
  * @property {geo.mouseButtons} buttonsDown The buttons that were down at the
@@ -428,7 +428,7 @@ geo_event.pixelmap = {
    *
    * @event geo.event.pixelmap.prepared
    * @type {object}
-   * @property {geo.pixelmapFeature} pixelmap The pixelamp object that was
+   * @property {geo.pixelmapFeature} pixelmap The pixelmap object that was
    *    prepared.
    */
   prepared: 'geo_pixelmap_prepared'

--- a/src/event.js
+++ b/src/event.js
@@ -3,15 +3,16 @@
  * Common object containing all event types that are provided by the GeoJS
  * API.  Each property contained here is a valid target for event handling
  * via {@link geo.object#geoOn}.  The event object provided to handlers is
- * different for each event type.  Each handler will generally be called
- * with a the <code>this</code> context being the class that caused the event.<br>
+ * different for each event type.  Each handler is generally be called
+ * with the <code>this</code> context being the class that caused the event.<br>
  * <br>
  * The following properties are common to all event objects:
  *
  * @namespace
  * @alias geo.event
- * @property {string} type The event type that was triggered
- * @property {object} geo A universal event object for controlling propagation
+ * @type {object}
+ * @property {string} event The event type that was triggered.
+ * @property {object} geo A universal event object for controlling propagation.
  *
  * @example
  * map.geoOn(geo.event.layerAdd, function (event) {
@@ -28,23 +29,14 @@ var geo_event = {};
  */
 //////////////////////////////////////////////////////////////////////////////
 
-// The following were not triggered nor used anywhere.  Removing until their
-// purpose is defined more clearly.
-//
-// geo.event.update = 'geo_update';
-// geo.event.opacityUpdate = 'geo_opacityUpdate';
-// geo.event.layerSelect = 'geo_layerSelect';
-// geo.event.layerUnselect = 'geo_layerUnselect';
-// geo.event.query = 'geo_query';
-
 //////////////////////////////////////////////////////////////////////////////
 /**
  * Triggered when a layer is added to the map.
  *
  * @event geo.event.layerAdd
  * @type {object}
- * @property {geo.map} target The current map
- * @property {geo.layer} layer The new layer
+ * @property {geo.map} target The current map.
+ * @property {geo.layer} layer The new layer that was added.
  */
 //////////////////////////////////////////////////////////////////////////////
 geo_event.layerAdd = 'geo_layerAdd';
@@ -55,23 +47,21 @@ geo_event.layerAdd = 'geo_layerAdd';
  *
  * @event geo.event.layerRemove
  * @type {object}
- * @property {geo.map} target The current map
- * @property {geo.layer} layer The old layer
+ * @property {geo.map} target The current map.
+ * @property {geo.layer} layer The old layer that was removed.
  */
 //////////////////////////////////////////////////////////////////////////////
 geo_event.layerRemove = 'geo_layerRemove';
 
 //////////////////////////////////////////////////////////////////////////////
 /**
- * Triggered when the map's zoom level is changed.  Note that zoom is never
- * triggered on the map itself.  Instead it is triggered individually on
- * layers, starting with the base layer.
+ * Triggered when the map's zoom level is changed.
  *
  * @event geo.event.zoom
  * @type {object}
- * @property {number} zoomLevel New zoom level
- * @property {geo.screenPosition} screenPosition The screen position of mouse
- *      pointer
+ * @property {number} zoomLevel New zoom level.
+ * @property {geo.screenPosition} screenPosition The screen position of the
+ *      mouse pointer.
  */
 //////////////////////////////////////////////////////////////////////////////
 geo_event.zoom = 'geo_zoom';
@@ -83,7 +73,10 @@ geo_event.zoom = 'geo_zoom';
  *
  * @event geo.event.rotate
  * @type {object}
- * @property {number} angle The angle of the rotation in radians
+ * @property {number} rotation The angle of the rotation in radians.  This is
+ *      the map's complete rotation, not a delta.
+ * @property {geo.screenPosition} screenPosition The screen position of the
+ *      mouse pointer.
  */
 //////////////////////////////////////////////////////////////////////////////
 geo_event.rotate = 'geo_rotate';
@@ -95,9 +88,9 @@ geo_event.rotate = 'geo_rotate';
  *
  * @event geo.event.pan
  * @type {object}
- * @property {object} screenDelta The number of pixels to pan the map by
- * @property {number} screenDelta.x
- * @property {number} screenDelta.y
+ * @property {object} screenDelta The number of pixels of the pan.
+ * @property {number} screenDelta.x Horizontal pan distance in pixels.
+ * @property {number} screenDelta.y Vertical pan distance in pixels.
  */
 //////////////////////////////////////////////////////////////////////////////
 geo_event.pan = 'geo_pan';
@@ -108,7 +101,7 @@ geo_event.pan = 'geo_pan';
  *
  * @event geo.event.resize
  * @type {object}
- * @property {object} target The map that was resized.
+ * @property {geo.map} target The map that was resized.
  * @property {number} x The new horizontal offset in pixels.
  * @property {number} y The new vertical offset in pixels.
  * @property {number} width The new width in pixels.
@@ -119,46 +112,11 @@ geo_event.resize = 'geo_resize';
 
 //////////////////////////////////////////////////////////////////////////////
 /**
- * Triggered when the world coordinate system changes.  Data in GCS
- * coordinates can be transformed by the following formulas:
- *
- *   x <- (x - origin.x) * scale.x
- *   y <- (y - origin.y) * scale.y
- *   z <- (z - origin.z) * scale.z
- *
- * Data in world coordinates can be updated using the following formulas:
- *
- *   x <- (x * scaleChange.x - origin.x * (scale.x + scaleChange.x)
- *          - scale.x * originChange.x) * scale.x / scaleChange.x
- *   y <- (y * scaleChange.y - origin.y * (scale.y + scaleChange.y)
- *          - scale.y * originChange.y) * scale.y / scaleChange.y
- *   z <- (z * scaleChange.z - origin.z * (scale.z + scaleChange.z)
- *          - scale.z * originChange.z) * scale.z / scaleChange.z
- *
- * @property {geo.map} map The map whose coordinates changed
- * @property {object} origin The new origin in GCS coordinates
- * @property {number} origin.x
- * @property {number} origin.y
- * @property {number} origin.z
- * @property {object} scale The new scale factor
- * @property {number} scale.x
- * @property {number} scale.y
- * @property {number} scale.z
- * @property {object} originChange Relative change from the old origin defined
- *   as `origin - oldorigin`.
- * @property {object} scaleChange Relative change from the old scale defined
- *   as `scale / oldscale`.
- */
-//////////////////////////////////////////////////////////////////////////////
-geo_event.worldChanged = 'geo_worldChanged';
-
-//////////////////////////////////////////////////////////////////////////////
-/**
  * Triggered on every call to {@link geo.map#draw} before the map is rendered.
  *
  * @event geo.event.draw
  * @type {object}
- * @property {geo.map} target The current map
+ * @property {geo.map} target The current map.
  */
 //////////////////////////////////////////////////////////////////////////////
 geo_event.draw = 'geo_draw';
@@ -169,25 +127,29 @@ geo_event.draw = 'geo_draw';
  *
  * @event geo.event.drawEnd
  * @type {object}
- * @property {geo.map} target The current map
+ * @property {geo.map} target The current map.
  */
 //////////////////////////////////////////////////////////////////////////////
 geo_event.drawEnd = 'geo_drawEnd';
 
 //////////////////////////////////////////////////////////////////////////////
 /**
- * Triggered on every 'mousemove' over the map's DOM element.  The event
- * object extends {@link geo.mouseState}.
- * @mixes geo.mouseState
+ * Triggered on every `mousemove` over the map's DOM element unless a click
+ * might occur.  The event object extends {@link geo.mouseState}.
+ *
+ * @event geo.event.mousemove
  */
 //////////////////////////////////////////////////////////////////////////////
 geo_event.mousemove = 'geo_mousemove';
 
 //////////////////////////////////////////////////////////////////////////////
 /**
- * Triggered on every 'mousedown' over the map's DOM element.  The event
- * object extends {@link geo.mouseState}.
- * @mixes geo.mouseState
+ * Triggered on `mouseup` events that happen soon enough and close enough to a
+ * mousedown event.  The event object extends {@link geo.mouseState}.
+ *
+ * @event geo.event.mouseclick
+ * @property {geo.mouseButtons} buttonsDown The buttons that were down at the
+ *      start of the click action.
  */
 //////////////////////////////////////////////////////////////////////////////
 geo_event.mouseclick = 'geo_mouseclick';
@@ -196,7 +158,8 @@ geo_event.mouseclick = 'geo_mouseclick';
 /**
  * Triggered on every 'mousemove' during a brushing selection.
  * The event object extends {@link geo.brushSelection}.
- * @mixes geo.brushSelection
+ *
+ * @event geo.event.brush
  */
 //////////////////////////////////////////////////////////////////////////////
 geo_event.brush = 'geo_brush';
@@ -205,7 +168,8 @@ geo_event.brush = 'geo_brush';
 /**
  * Triggered after a brush selection ends.
  * The event object extends {@link geo.brushSelection}.
- * @mixes geo.brushSelection
+ *
+ * @event geo.event.brushend
  */
 //////////////////////////////////////////////////////////////////////////////
 geo_event.brushend = 'geo_brushend';
@@ -214,45 +178,52 @@ geo_event.brushend = 'geo_brushend';
 /**
  * Triggered when a brush selection starts.
  * The event object extends {@link geo.brushSelection}.
- * @mixes geo.brushSelection
+ *
+ * @event geo.event.brushstart
  */
 //////////////////////////////////////////////////////////////////////////////
 geo_event.brushstart = 'geo_brushstart';
 
 //////////////////////////////////////////////////////////////////////////////
 /**
- * Triggered after a selection ends.
+ * Triggered when brushing results in a selection.
  * The event object extends {@link geo.brushSelection}.
- * @mixes geo.brushSelection
+ *
+ * @event geo.event.select
  */
 //////////////////////////////////////////////////////////////////////////////
 geo_event.select = 'geo_select';
 
 //////////////////////////////////////////////////////////////////////////////
 /**
- * Triggered after a zoom selection ends.
+ * Triggered when brushing results in a zoom selection.
  * The event object extends {@link geo.brushSelection}.
- * @mixes geo.brushSelection
+ *
+ * @event geo.event.zoomselect
  */
 //////////////////////////////////////////////////////////////////////////////
 geo_event.zoomselect = 'geo_zoomselect';
 
 //////////////////////////////////////////////////////////////////////////////
 /**
- * Triggered after an unzoom selection ends.
+ * Triggered when brushing results in a zoom-out selection.
  * The event object extends {@link geo.brushSelection}.
- * @mixes geo.brushSelection
+ *
+ * @event geo.event.unzoomselect
  */
+
 //////////////////////////////////////////////////////////////////////////////
 geo_event.unzoomselect = 'geo_unzoomselect';
 
+//DWM::
 //////////////////////////////////////////////////////////////////////////////
 /**
- * Triggered when an action is initiated with mouse down
+ * Triggered when an action is initiated with mouse down.
  *
- * @property {object} state The action state
- * @property {geo.mouseState} mouse The mouse state
- * @property {object} event The triggering event
+ * @event geo.event.actiondown
+ * @property {geo.actionState} state The action state.
+ * @property {geo.mouseState} mouse The mouse state.
+ * @property {jQuery.Event} event The triggering jQuery event.
  */
 //////////////////////////////////////////////////////////////////////////////
 geo_event.actiondown = 'geo_actiondown';
@@ -261,9 +232,10 @@ geo_event.actiondown = 'geo_actiondown';
 /**
  * Triggered when an action is being processed during mouse movement.
  *
- * @property {object} state The action state
- * @property {geo.mouseState} mouse The mouse state
- * @property {object} event The triggering event
+ * @event geo.event.actionmove
+ * @property {geo.actionState} state The action state.
+ * @property {geo.mouseState} mouse The mouse state.
+ * @property {jQuery.Event} event The triggering event.
  */
 //////////////////////////////////////////////////////////////////////////////
 geo_event.actionmove = 'geo_actionmove';
@@ -272,9 +244,10 @@ geo_event.actionmove = 'geo_actionmove';
 /**
  * Triggered when an action is ended with a mouse up.
  *
- * @property {object} state The action state
- * @property {geo.mouseState} mouse The mouse state
- * @property {object} event The triggering event
+ * @event geo.event.actionup
+ * @property {geo.actionState} state The action state.
+ * @property {geo.mouseState} mouse The mouse state.
+ * @property {jQuery.Event} event The triggering event.
  */
 //////////////////////////////////////////////////////////////////////////////
 geo_event.actionup = 'geo_actionup';
@@ -283,11 +256,14 @@ geo_event.actionup = 'geo_actionup';
 /**
  * Triggered when an action results in a selection.
  *
- * @property {object} state The action state
- * @property {geo.mouseState} mouse The mouse state
- * @property {object} event The triggering event
- * @property {object} lowerLeft Lower left of selection in screen coordinates
- * @property {object} upperRight Upper right of selection in screen coordinates
+ * @event geo.event.actionselection
+ * @property {geo.actionState} state The action state.
+ * @property {geo.mouseState} mouse The mouse state.
+ * @property {jQuery.Event} event The triggering event.
+ * @property {geo.screenPosition} lowerLeft Lower left of selection in screen
+ *      coordinates.
+ * @property {geo.screenPosition} upperRight Upper right of selection in screen
+ *      coordinates.
  */
 //////////////////////////////////////////////////////////////////////////////
 geo_event.actionselection = 'geo_actionselection';
@@ -296,9 +272,10 @@ geo_event.actionselection = 'geo_actionselection';
 /**
  * Triggered when an action is triggered with a mouse wheel event.
  *
- * @property {object} state The action state
- * @property {geo.mouseState} mouse The mouse state
- * @property {object} event The triggering event
+ * @event geo.event.actionwheel
+ * @property {geo.actionState} state The action state.
+ * @property {geo.mouseState} mouse The mouse state.
+ * @property {jQuery.Event} event The triggering event.
  */
 //////////////////////////////////////////////////////////////////////////////
 geo_event.actionwheel = 'geo_actionwheel';
@@ -307,14 +284,21 @@ geo_event.actionwheel = 'geo_actionwheel';
 /**
  * Triggered when an action is triggered via the keyboard.
  *
+ * @event geo.event.keyaction
  * @property {object} move The movement that would happen if the action is
- *      passed through, possibly containing zoomDelta, zoom (absolute),
- *      rotationDelta (in radians), rotation (absolute in radians), panX (in
- *      display pixels), panY (in display pixels).  Set move.cancel to cancel
- *      the entire movement.
+ *      passed through.
+ * @property {number} [move.zoomDelta] A change in the zoom level.
+ * @property {number} [move.zoom] A new zoom level.
+ * @property {number} [move.rotationDelta] A change in the rotation in radians.
+ * @property {number} [move.rotation] A new absolute rotation in radians.
+ * @property {number} [move.panX] A horizontal shift in display pixels.
+ * @property {number} [move.panY] A vertical shift in display pixels.
+ * @property {boolean} [move.cancel] Set to `true` to cancel the entire
+ *      movement.
  * @property {string} action Action based on key
- * @property {number} factor Factor based on metakeys [0-2].
- * @property {object} event The triggering event
+ * @property {number} factor Factor based on metakeys [0-2].  0 means a small
+ *      movement is preferred, 1 a medium movement, and 2 a large movement.
+ * @property {jQuery.Event} event The triggering event
  */
 //////////////////////////////////////////////////////////////////////////////
 geo_event.keyaction = 'geo_keyaction';
@@ -322,18 +306,17 @@ geo_event.keyaction = 'geo_keyaction';
 //////////////////////////////////////////////////////////////////////////////
 /**
  * Triggered before a map navigation animation begins.  Set
- * <code>event.geo.cancelAnimation</code> to cancel the animation
- * of the navigation.  This will cause the map to navigate to the
- * target location immediately.  Set <code>event.geo.cancelNavigation</code>
- * to cancel the navigation completely.  The transition options can
- * be modified in place.
+ * `event.geo.cancelAnimation` to cancel the animation of the navigation.  This
+ * will cause the map to navigate to the target location immediately.  Set
+ * `event.geo.cancelNavigation` to cancel the navigation completely.  The
+ * transition options can be modified in place.
  *
  * @event geo.event.transitionstart
  * @type {object}
- * @property {geo.geoPosition} center The target center
- * @property {number} zoom The target zoom level
- * @property {number} duration The duration of the transition in milliseconds
- * @property {function} ease The easing function
+ * @property {geo.geoPosition} center The target center.
+ * @property {number} zoom The target zoom level.
+ * @property {number} duration The duration of the transition in milliseconds.
+ * @property {function} ease The easing function.
  */
 //////////////////////////////////////////////////////////////////////////////
 geo_event.transitionstart = 'geo_transitionstart';
@@ -344,34 +327,37 @@ geo_event.transitionstart = 'geo_transitionstart';
  *
  * @event geo.event.transitionend
  * @type {object}
- * @property {geo.geoPosition} center The target center
- * @property {number} zoom The target zoom level
- * @property {number} duration The duration of the transition in milliseconds
- * @property {function} ease The easing function
+ * @property {geo.geoPosition} center The target center.
+ * @property {number} zoom The target zoom level.
+ * @property {number} duration The duration of the transition in milliseconds.
+ * @property {function} ease The easing function.
  */
 //////////////////////////////////////////////////////////////////////////////
 geo_event.transitionend = 'geo_transitionend';
 
 //////////////////////////////////////////////////////////////////////////////
 /**
- * Triggered if a map navigation animation is cancelled.
+ * Triggered if a map navigation animation is canceled.
  *
  * @event geo.event.transitioncancel
  * @type {object}
- * @property {geo.geoPosition} center The target center
- * @property {number} zoom The target zoom level
- * @property {number} duration The duration of the transition in milliseconds
- * @property {function} ease The easing function
+ * @property {geo.geoPosition} center The target center.
+ * @property {number} zoom The target zoom level.
+ * @property {number} duration The duration of the transition in milliseconds.
+ * @property {function} ease The easing function.
  */
 //////////////////////////////////////////////////////////////////////////////
 geo_event.transitioncancel = 'geo_transitioncancel';
 
+//DWM::
 //////////////////////////////////////////////////////////////////////////////
 /**
  * Triggered when the parallel projection mode is changes.
  *
- * @property paralellProjection {boolean} True if parallel projection is turned
- *                                        on.
+ * @event geo.event.parallelprojection
+ * @type {object}
+ * @property {boolean} paralellProjection `true` if parallel projection is
+ *      turned on.
  */
 //////////////////////////////////////////////////////////////////////////////
 geo_event.parallelprojection = 'geo_parallelprojection';
@@ -389,13 +375,45 @@ geo_event.parallelprojection = 'geo_parallelprojection';
  */
 ////////////////////////////////////////////////////////////////////////////
 geo_event.feature = {
+  /**
+   * The event is the feature version of {@link geo.event.mousemove}.
+   * @event geo.event.feature.mousemove
+   */
   mousemove:  'geo_feature_mousemove',
+  /**
+   * The event is the feature version of {@link geo.event.mouseover}.
+   * @event geo.event.feature.mouseover
+   */
   mouseover:  'geo_feature_mouseover',
+  /**
+   * The event is the feature version of {@link geo.event.mouseout}.
+   * @event geo.event.feature.mouseout
+   */
   mouseout:   'geo_feature_mouseout',
+  /**
+   * The event is the feature version of {@link geo.event.mouseon}.
+   * @event geo.event.feature.mouseon
+   */
   mouseon:    'geo_feature_mouseon',
+  /**
+   * The event is the feature version of {@link geo.event.mouseoff}.
+   * @event geo.event.feature.mouseoff
+   */
   mouseoff:   'geo_feature_mouseoff',
+  /**
+   * The event is the feature version of {@link geo.event.mouseclick}.
+   * @event geo.event.feature.mouseclick
+   */
   mouseclick: 'geo_feature_mouseclick',
+  /**
+   * The event is the feature version of {@link geo.event.brushend}.
+   * @event geo.event.feature.brushend
+   */
   brushend:   'geo_feature_brushend',
+  /**
+   * The event is the feature version of {@link geo.event.brush}.
+   * @event geo.event.feature.brush
+   */
   brush:      'geo_feature_brush'
 };
 
@@ -406,31 +424,40 @@ geo_event.feature = {
  */
 ////////////////////////////////////////////////////////////////////////////
 geo_event.pixelmap = {
-  /* The image associated with the pixel map url has been prepared and rendered
-   * once. */
+  /**
+   * Report that an image associated with a pixel map has been prepared and
+   * rendered once.
+   *
+   * @event geo.event.pixelmap.prepared
+   * @type {object}
+   * @property {geo.pixelmapFeature} pixelmap The pixelamp object that was
+   *    prepared.
+   */
   prepared: 'geo_pixelmap_prepared'
 };
 
 ////////////////////////////////////////////////////////////////////////////
 /**
  * These events are triggered by the map screenshot feature.
- * @namespace geo.event.pixelmap
+ * @namespace geo.event.screenshot
  */
 ////////////////////////////////////////////////////////////////////////////
 geo_event.screenshot = {
   ////////////////////////////////////////////////////////////////////////////
   /**
-   * Triggered when a scrrenshot has been completed.
+   * Triggered when a screenshot has been completed.
    *
-   * @namespace geo.event.screenshot
-   * @property {object} canvas The canvas used to take the screenshot
-   * @property {string|object} screenshot the screenshot as a dataURL string or
-   *      the canvas, depending on the screenshot request.
+   * @event geo.event.screenshot.ready
+   * @property {HTMLCanvasElement} canvas The canvas used to take the
+   *    screenshot.
+   * @property {string|HTMLCanvasElement} screenshot The screenshot as a
+   *    dataURL string or the canvas, depending on the screenshot request.
    */
   ////////////////////////////////////////////////////////////////////////////
   ready: 'geo_screenshot_ready'
 };
 
+//DWM::
 ////////////////////////////////////////////////////////////////////////////
 /**
  * These events are triggered by the camera when it's internal state is
@@ -445,37 +472,21 @@ geo_event.camera = {};
  * Triggered after a general view matrix change (any change in the visible
  * bounds).  This is equivalent to the union of pan and zoom.
  *
- * @property {geo.camera} camera The camera instance
+ * @event geo.event.camera.view
+ * @type {object}
+ * @property {geo.camera} camera The camera instance.
  */
 //////////////////////////////////////////////////////////////////////////////
 geo_event.camera.view = 'geo_camera_view';
 
 //////////////////////////////////////////////////////////////////////////////
 /**
- * Triggered after a pan in the x/y plane (no zoom level change).
- *
- * @property {geo.camera} camera The camera instance
- * @property {object} delta The translation delta in world coordinates.
- */
-//////////////////////////////////////////////////////////////////////////////
-geo_event.camera.pan = 'geo_camera_pan';
-
-//////////////////////////////////////////////////////////////////////////////
-/**
- * Triggered after a view matrix change that is not a simple pan.  This
- * includes, but is not limited to, pure zooms.
- *
- * @property {geo.camera} camera The camera instance
- */
-//////////////////////////////////////////////////////////////////////////////
-geo_event.camera.zoom = 'geo_camera_zoom';
-
-//////////////////////////////////////////////////////////////////////////////
-/**
  * Triggered after a projection change.
  *
- * @property {geo.camera} camera The camera instance
- * @property {string} type The projection type ('perspective'|'parallel')
+ * @event geo.event.camera.projection
+ * @property {geo.camera} camera The camera instance.
+ * @property {string} type The projection type, either `'perspective'` or
+ *      `'parallel'`.
  */
 //////////////////////////////////////////////////////////////////////////////
 geo_event.camera.projection = 'geo_camera_projection';
@@ -484,10 +495,9 @@ geo_event.camera.projection = 'geo_camera_projection';
 /**
  * Triggered after a viewport change.
  *
- * @property {geo.camera} camera The camera instance
- * @property {object} viewport The new viewport
- * @property {number} viewport.width The new width
- * @property {number} viewport.height The new height
+ * @event geo.event.camera.viewport
+ * @property {geo.camera} camera The camera instance.
+ * @property {geo.screenSize} viewport The new viewport size.
  */
 //////////////////////////////////////////////////////////////////////////////
 geo_event.camera.viewport = 'geo_camera_viewport';
@@ -504,6 +514,8 @@ geo_event.annotation = {};
 /**
  * Triggered when an annotation has been added.
  *
+ * @event geo.event.annotation.add
+ * @type {object}
  * @property {geo.annotation} annotation The annotation that was added.
  */
 //////////////////////////////////////////////////////////////////////////////
@@ -513,6 +525,8 @@ geo_event.annotation.add = 'geo_annotation_add';
 /**
  * Triggered when an annotation is about to be added.
  *
+ * @event geo.event.annotation.add_before
+ * @type {object}
  * @property {geo.annotation} annotation The annotation that will be added.
  */
 //////////////////////////////////////////////////////////////////////////////
@@ -523,6 +537,8 @@ geo_event.annotation.add_before = 'geo_annotation_add_before';
  * Triggered when an annotation has been altered.  This is currently only
  * triggered when updating existing annotations via the geojson function.
  *
+ * @event geo.event.annotation.update
+ * @type {object}
  * @property {geo.annotation} annotation The annotation that was altered.
  */
 //////////////////////////////////////////////////////////////////////////////
@@ -532,6 +548,8 @@ geo_event.annotation.update = 'geo_annotation_update';
 /**
  * Triggered when an annotation has been removed.
  *
+ * @event geo.event.annotation.remove
+ * @type {object}
  * @property {geo.annotation} annotation The annotation that was removed.
  */
 //////////////////////////////////////////////////////////////////////////////
@@ -541,7 +559,9 @@ geo_event.annotation.remove = 'geo_annotation_remove';
 /**
  * Triggered when an annotation's state changes.
  *
- * @property {geo.annotation} annotation The annotation that changed/
+ * @event geo.event.annotation.state
+ * @type {object}
+ * @property {geo.annotation} annotation The annotation that changed.
  */
 //////////////////////////////////////////////////////////////////////////////
 geo_event.annotation.state = 'geo_annotation_state';
@@ -550,7 +570,12 @@ geo_event.annotation.state = 'geo_annotation_state';
 /**
  * Triggered when the annotation mode is changed.
  *
- * @property {string|null} mode the new annotation mode.
+ * @event geo.event.annotation.mode
+ * @type {object}
+ * @property {string?} mode The new annotation mode.  This is one of the values
+ *      from `geo.annotation.annotationState`.
+ * @property {string?} oldMode The annotation mode before this change.  This is
+ *      one of the values from `geo.annotation.annotationState`.
  */
 //////////////////////////////////////////////////////////////////////////////
 geo_event.annotation.mode = 'geo_annotation_mode';

--- a/src/event.js
+++ b/src/event.js
@@ -154,7 +154,7 @@ geo_event.mouseclick = 'geo_mouseclick';
 
 //////////////////////////////////////////////////////////////////////////////
 /**
- * Triggered on every 'mousemove' during a brushing selection.
+ * Triggered on every `mousemove` during a brushing selection.
  * The event object extends {@link geo.brushSelection}.
  *
  * @event geo.event.brush

--- a/src/map.js
+++ b/src/map.js
@@ -386,7 +386,6 @@ var map = function (arg) {
 
     camera_bounds(bounds, m_rotation);
     evt = {
-      geo: {},
       zoomLevel: m_zoom,
       screenPosition: origin ? origin.map : undefined
     };
@@ -504,7 +503,6 @@ var map = function (arg) {
     camera_bounds(bounds, m_rotation);
 
     var evt = {
-      geo: {},
       rotation: m_rotation,
       screenPosition: origin ? origin.map : undefined
     };
@@ -563,8 +561,7 @@ var map = function (arg) {
     m_this.modified();
     // trigger a pan event
     m_this.geoTrigger(geo_event.pan, {
-      geo: coordinates,
-      screenDelta: null
+      screenDelta: {x: 0, y: 0}
     });
     return m_this;
   };
@@ -595,7 +592,6 @@ var map = function (arg) {
       m_this.modified();
 
       m_this.geoTrigger(geo_event.layerAdd, {
-        type: geo_event.layerAdd,
         target: m_this,
         layer: newLayer
       });
@@ -622,7 +618,6 @@ var map = function (arg) {
       m_this.modified();
 
       m_this.geoTrigger(geo_event.layerRemove, {
-        type: geo_event.layerRemove,
         target: m_this,
         layer: layer
       });
@@ -842,7 +837,6 @@ var map = function (arg) {
     var i, layers = m_this.children();
 
     m_this.geoTrigger(geo_event.draw, {
-      type: geo_event.draw,
       target: m_this
     });
 
@@ -853,7 +847,6 @@ var map = function (arg) {
     }
 
     m_this.geoTrigger(geo_event.drawEnd, {
-      type: geo_event.drawEnd,
       target: m_this
     });
 

--- a/src/mapInteractor.js
+++ b/src/mapInteractor.js
@@ -764,6 +764,8 @@ var mapInteractor = function (args) {
   ////////////////////////////////////////////////////////////////////////////
   /**
    * Stores the current mouse position from an event
+   *
+   * @param {jQuery.Event} evt JQuery event with the mouse position.
    */
   ////////////////////////////////////////////////////////////////////////////
   this._getMousePosition = function (evt) {
@@ -790,8 +792,6 @@ var mapInteractor = function (args) {
       m_mouse.mapgcs = m_this.map().displayToGcs(m_mouse.map, null);
     } catch (e) {
       // catch georeferencing problems and move on
-      // needed for handling the map before the base layer
-      // is attached
       m_mouse.geo = m_mouse.mapgcs = null;
     }
   };
@@ -836,8 +836,9 @@ var mapInteractor = function (args) {
   ////////////////////////////////////////////////////////////////////////////
   /**
    * Compute a selection information object.
+   *
    * @private
-   * @returns {object}
+   * @returns {geo.brushSelection}
    */
   ////////////////////////////////////////////////////////////////////////////
   this._getSelection = function () {
@@ -1833,6 +1834,8 @@ var mapInteractor = function (args) {
   ////////////////////////////////////////////////////////////////////////////
   /**
    * Get the current interactor state
+   *
+   * @returns {geo.interactorState}
    */
   ////////////////////////////////////////////////////////////////////////////
   this.state = function () {

--- a/src/object.js
+++ b/src/object.js
@@ -27,8 +27,8 @@ var object = function () {
    *  Bind a handler that will be called once when all internal promises are
    *  resolved.
    *
-   *  @param {function} handler A function taking no arguments
-   *  @returns {geo.object[]|geo.object} this
+   *  @param {function} handler A function taking no arguments.
+   *  @returns {this}
    */
   //////////////////////////////////////////////////////////////////////////////
   this.onIdle = function (handler) {
@@ -45,7 +45,8 @@ var object = function () {
    *  Add a new promise object preventing idle event handlers from being called
    *  until it is resolved.
    *
-   *  @param {Promise} promise A promise object
+   *  @param {Promise} promise A promise object.
+   *  @returns {this}
    */
   //////////////////////////////////////////////////////////////////////////////
   this.addPromise = function (promise) {
@@ -66,14 +67,13 @@ var object = function () {
 
   //////////////////////////////////////////////////////////////////////////////
   /**
-   *  Bind an event handler to this object
+   *  Bind an event handler to this object.
    *
-   *  @param {String} event
-   *    An event from {geo.events}
-   *  @param {function} handler
-   *    A function that will be called when ``event`` is triggered.  The
-   *    function will be given an event object as a first parameter and
-   *    optionally a second argument provided by the triggerer.
+   *  @param {string} event An event from {@link geo.event} or a user-defined
+   *    value.
+   *  @param {function} handler A function that is called when `event` is
+   *    triggered.  The function is passed a {@link geo.event} object.
+   *  @returns {this}
    */
   //////////////////////////////////////////////////////////////////////////////
   this.geoOn = function (event, handler) {
@@ -92,10 +92,13 @@ var object = function () {
 
   //////////////////////////////////////////////////////////////////////////////
   /**
-   *  Trigger an event (or events) on this object and call all handlers
+   *  Trigger an event (or events) on this object and call all handlers.
    *
-   *  @param {String} event An event from {geo.event}
-   *  @param {Object} args An optional argument to pass to handlers
+   *  @param {string|string[]} event An event or list of events from
+   *        {@link geo.event} or defined by the user.
+   *  @param {object} [args] Additional information to add to the
+   *    {@link geo.event} object passed to the handlers.
+   *  @returns {this}
    */
   //////////////////////////////////////////////////////////////////////////////
   this.geoTrigger = function (event, args) {
@@ -123,12 +126,15 @@ var object = function () {
 
   //////////////////////////////////////////////////////////////////////////////
   /**
-   *  Remove handlers from an event (or an array of events).  If no event is
+   *  Remove handlers from one event or an array of events.  If no event is
    *  provided all handlers will be removed.
    *
-   *  @param {string?} event An event from {geo.events}
-   *  @param {object?} arg A function or array of functions to remove from the events
-   *                      or if falsey remove all handlers from the events
+   *  @param {string|string[]} [event] An event or a list of events from
+   *        {@link geo.event} or defined by the user, or `undefined` to remove
+   *        all events (in which case `arg` is ignored).
+   *  @param {(function|function[])?} [arg] A function or array of functions to
+   *        remove from the events or a falsey value to remove all handlers
+   *        from the events.
    */
   //////////////////////////////////////////////////////////////////////////////
   this.geoOff = function (event, arg) {
@@ -151,8 +157,6 @@ var object = function () {
       });
       return m_this;
     }
-    // What do we do if the handler is not already bound?
-    //   ignoring for now...
     if (m_eventHandlers.hasOwnProperty(event)) {
       m_eventHandlers[event] = m_eventHandlers[event].filter(function (f) {
         return f !== arg;

--- a/src/typedef.js
+++ b/src/typedef.js
@@ -149,7 +149,7 @@
  *
  * @typedef geo.actionRecord
  * @type {object}
- * @property {string} action The name of the action, from geo.action.
+ * @property {string} action The name of the action, from (@link geo.action}.
  * @property {string} [owner] A name of an owning process that can be used to
  *      locate or filter actions.
  * @property {string} [name] A human-readable name that can be used to locate
@@ -161,7 +161,7 @@
  *      buttons), `wheel` (the mouse wheel), `pan` (touch pan), `rotate` (touch
  *      rotate).
  * @property {string|object} [modifiers] The name of a modifier key or an
- *      object withe modifiers as the keys and boolean values.  The listed
+ *      object with modifiers as the keys and boolean values.  The listed
  *      modifiers must be set or unset depending on the boolean value.
  *      Modifiers include `shift`, `ctrl`, `alt`, and `meta`.
  * @property {boolean|string} [selectionRectangle] If truthy, a selection

--- a/src/typedef.js
+++ b/src/typedef.js
@@ -7,25 +7,28 @@
 /**
  * General object specification for map types.  Any additional values in the
  * object are passed to the map constructor.
+ *
  * @typedef geo.map.spec
  * @type {object}
  * @property {object[]} [data=[]] The default data array to apply to each
- *      feature if none exists
- * @property {geo.layer.spec[]} [layers=[]] Layers to create
+ *      feature if none exists.
+ * @property {geo.layer.spec[]} [layers=[]] Layers to create.
  */
 
 /**
- * General representation of rectangular bounds in world coordinates
+ * General representation of rectangular bounds in world coordinates.
+ *
  * @typedef geo.geoBounds
  * @type {object}
- * @property {number} left Horizontal coordinate of the top-left corner
- * @property {number} top Vertical coordinate of the top-left corner
- * @property {number} right Horizontal coordinate of the bottom-right corner
- * @property {number} bottom Vertical coordinate of the bottom-right corner
+ * @property {number} left Horizontal coordinate of the top-left corner.
+ * @property {number} top Vertical coordinate of the top-left corner.
+ * @property {number} right Horizontal coordinate of the bottom-right corner.
+ * @property {number} bottom Vertical coordinate of the bottom-right corner.
  */
 
 /**
  * A location and zoom value.
+ *
  * @typedef geo.zoomAndCenter
  * @type {object}
  * @property {geo.geoPosition} center The center coordinates.
@@ -33,46 +36,51 @@
  */
 
 /**
- * General representation of rectangular bounds in pixel coordinates
+ * General representation of rectangular bounds in pixel coordinates.
+ *
  * @typedef geo.screenBounds
  * @type {object}
- * @property {geo.screenPosition} upperLeft Upper left corner
- * @property {geo.screenPosition} upperRight Upper right corner
- * @property {geo.screenPosition} lowerLeft Lower left corner
- * @property {geo.screenPosition} lowerRight Lower right corner
+ * @property {geo.screenPosition} upperLeft Upper left corner.
+ * @property {geo.screenPosition} upperRight Upper right corner.
+ * @property {geo.screenPosition} lowerLeft Lower left corner.
+ * @property {geo.screenPosition} lowerRight Lower right corner.
  */
 
 /**
  * General representation of a point on the screen.
+ *
  * @typedef geo.screenPosition
  * @type {object}
- * @property {Number} x Horizontal coordinate in pixels
- * @property {Number} y Vertical coordinate in pixels
+ * @property {number} x Horizontal coordinate in pixels.
+ * @property {number} y Vertical coordinate in pixels.
  */
 
 /**
  * General represention of a point on the earth.  The coordinates are most
  * commonly in longitude and latitude, but the coordinate system is changed
  * by the interface gcs.
+ *
  * @typedef geo.geoPosition
  * @type {object}
- * @property {number} x Horizontal coordinate, often degrees longitude
- * @property {number} y Vertical coordinate, often degrees latitude
- * @property {number} [z=0] Altitude coordinate
+ * @property {number} x Horizontal coordinate, often degrees longitude.
+ * @property {number} y Vertical coordinate, often degrees latitude.
+ * @property {number} [z=0] Altitude coordinate.
  */
 
 /**
  * Represention of a point on the map.  The coordinates are in the map's
  * reference system, possibly with an affine transformation.
+ *
  * @typedef geo.worldPosition
  * @type {object}
  * @property {number} x Horizontal coordinate in map coordinates.
  * @property {number} y Vertical coordinate in map coordinates.
- * @property {number} [z=0] Altitude coordinate, often zero
+ * @property {number} [z=0] Altitude coordinate, often zero.
  */
 
 /**
- * Represention of a size in pixels
+ * Represention of a size in pixels.
+ *
  * @typedef geo.screenSize
  * @type {object}
  * @property {number} width Width in pixels.
@@ -81,44 +89,124 @@
 
 /**
  * The status of all mouse buttons.
+ *
  * @typedef geo.mouseButtons
  * @type {object}
- * @property {true|false} left The left mouse button
- * @property {true|false} right The right mouse button
- * @property {true|false} middle The middle mouse button
+ * @property {boolean} left True if the left mouse button is down.
+ * @property {boolean} right True if the right mouse button is down.
+ * @property {boolean} middle True if the middle mouse button is down.
  */
 
 /**
- * The status of all modifier keys these are copied from the
+ * The status of all modifier keys.  These are usually copied from the
  * standard DOM events.
+ *
  * @typedef geo.modifierKeys
  * @type {object}
- * @property {true|false} alt <code>Event.alt</code>
- * @property {true|false} ctrl <code>Event.ctrl</code>
- * @property {true|false} shift <code>Event.shift</code>
- * @property {true|false} meta <code>Event.meta</code>
+ * @property {boolean} alt True if the alt or option key is down.
+ * @property {boolean} ctrl True if the control key is down.
+ * @property {boolean} shift True if the shift key is down.
+ * @property {boolean} meta True if the meta, windows, or command key
+ *      is down.
  */
 
 /**
- * Provides information about the state of the mouse
+ * The state of the mouse.
+ *
  * @typedef geo.mouseState
  * @type {object}
- * @property {geo.screenPosition} page Mouse location in pixel space
- * @property {geo.geoPosition} map Mouse location in world space
- * @property {geo.mouseButtons} buttons The current state of the mouse buttons
- * @property {geo.modifierKeys} modifiers The current state of all modifier keys
- * @property {Date} time The timestamp the event took place
- * @property {Number} deltaTime The time in milliseconds since the last mouse event
+ * @property {geo.screenPosition} page Mouse location in pixel space.
+ * @property {geo.geoPosition} map Mouse location in gcs space.
+ * @property {geo.mouseButtons} buttons The current state of the mouse buttons.
+ * @property {geo.modifierKeys} modifiers The current state of all modifier
+ *      keys.
+ * @property {Date} time The timestamp the event took place.
+ * @property {number} deltaTime The time in milliseconds since the last mouse
+ *      event.
  * @property {geo.screenPosition} velocity The velocity of the mouse pointer
- * in pixels per second
+ *      in pixels per millisecond.
  */
 
 /**
+ * The current brush selection (this is when a rectangular area is selected by
+ * dragging).
+ *
  * @typedef geo.brushSelection
  * @type {object}
- * @property {geo.screenBounds} display The selection bounds in pixel space
- * @property {geo.geoBounds} gcs The selection bounds in world space
- * @property {geo.mouseState} mouse The current mouse state
+ * @property {geo.screenBounds} display The selection bounds in pixel space.
+ * @property {object} gcs The selection bounds in the map's gcs.
+ * @property {geo.geoPosition} gcs.upperLeft Upper left corner.
+ * @property {geo.geoPosition} gcs.upperRight Upper right corner.
+ * @property {geo.geoPosition} gcs.lowerLeft Lower left corner.
+ * @property {geo.geoPosition} gcs.lowerRight Lower right corner.
+ * @property {geo.mouseState} mouse The current mouse state.
  * @property {geo.mouseState} origin The mouse state at the start of the
- * brush action
+ *      brush action.
+ */
+
+/**
+ * The conditions that are necessary to make an action occur.
+ *
+ * @typedef geo.actionRecord
+ * @type {object}
+ * @property {string} action The name of the action, from geo.action.
+ * @property {string} [owner] A name of an owning process that can be used to
+ *      locate or filter actions.
+ * @property {string} [name] A human-readable name that can be used to locate
+ *      or filter actions.
+ * @property {string|object} input The name of an input that is used for the
+ *      action, or an object with input names as keys and boolean values of
+ *      inputs that are required to occur or required to not occur to trigger
+ *      the action.  Input names include `left`, `right`, `middle` (for mouse
+ *      buttons), `wheel` (the mouse wheel), `pan` (touch pan), `rotate` (touch
+ *      rotate).
+ * @property {string|object} [modifiers] The name of a modifier key or an
+ *      object withe modifiers as the keys and boolean values.  The listed
+ *      modifiers must be set or unset depending on the boolean value.
+ *      Modifiers include `shift`, `ctrl`, `alt`, and `meta`.
+ * @property {boolean|string} [selectionRectangle] If truthy, a selection
+ *      rectangle is shown during the action.  If a string, the name of an
+ *      event that is triggered when the selection is complete.
+ */
+
+/**
+ * The current action state a map interactor.
+ *
+ * @typedef geo.actionState
+ * @type {object}
+ * @property {string} action Name of the action that is being handled.
+ * @property {geo.actionRecord} actionRecord The action record which triggered
+ *      the current action.
+ * @property {string} [origAction] The name of an action that triggered this
+ *      action.
+ * @property {geo.mouseState} origin The mouse state at the start of the
+ *      action.
+ * @property {number} initialZoom The zoom level at the start of the action.
+ * @property {number} initialRotation The map's rotation in radians at the
+ *      start of the action.
+ * @property {number} initialEventRotation The rotation reported by the
+ *      event that triggered this action.  For example, this could be the
+ *      angle between two multi-touch points.
+ * @property {object} delta The total movement of during the action in gcs
+ *      coordinates.
+ * @property {number} delta.x The horizontal movement during the action.
+ * @property {number} delta.y The vertical movement during the action.
+ * @property {boolean} boundDocumentHandlers `true` if the mouse is down and
+ *      being tracked.
+ * @property {Date} [start] The time when the action started.
+ * @property {function} [handler] A function to call on every animation from
+ *      while the action is occurring.
+ * @property {geo.mouseState} [momentum] The mouse location when a momentum
+ *      action starts.
+ * @property {boolean} [zoomrotateAllowRotation] Truthy if enough movement has
+ *      occurred that rotations are allowed.
+ * @property {boolean} [zoomrotateAllowZoom] Truthy if enough movement has
+ *      occurred that zooms are allowed.
+ * @property {boolean} [zoomrotateAllowPan] Truthy if enough movement has
+ *      occurred that pans are allowed.
+ * @property {number} [lastRotationDelta] When rotating, the last amount that
+ *      was rotated from the start of the action.  This is used to debounce
+ *      jitter on touch events.
+ * @property {geo.geoPosition} [initialEventGeo] The position of the mouse
+ *      when significant movement first occurred.
  */


### PR DESCRIPTION
Remove `type` as a field in events, as we usually use `event` (and `event` is always present).

Make some events more consistent.

This also updates documentation in typedef.js and object.js.