### PR TITLE
Update eslint and enable linting of docstrings

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,19 +1,19 @@
 {
     "extends": "semistandard",
     "rules": {
-        "indent": [2, 2, {"VariableDeclarator": 2, "SwitchCase": 1}],
-        "padded-blocks": 0,
-        "space-before-function-paren": [2, {"anonymous": "always", "named": "never"}],
-        "one-var": 0,
-        "no-throw-literal": 0,
-        "new-cap": 0,
-        "spaced-comment": 0,
-        "operator-linebreak": 0,
-        "key-spacing": 0,
-        "no-unneeded-ternary": 0,
-        "yoda": 0,
-        "no-useless-call": 0,
-        "camelcase": 0
+        "indent": ["error", 2, {"VariableDeclarator": 2, "SwitchCase": 1}],
+        "padded-blocks": "off",
+        "space-before-function-paren": ["error", {"anonymous": "always", "named": "never"}],
+        "one-var": "off",
+        "no-throw-literal": "off",
+        "new-cap": "off",
+        "spaced-comment": "off",
+        "operator-linebreak": "off",
+        "key-spacing": "off",
+        "no-unneeded-ternary": "off",
+        "yoda": "off",
+        "no-useless-call": "off",
+        "camelcase": "off"
     },
     "env": {
         "browser": true

--- a/src/.eslintrc
+++ b/src/.eslintrc
@@ -1,0 +1,27 @@
+{
+    "rules": {
+        "valid-jsdoc": ["warn", {
+            "preferType": {
+                "Object": "object",
+                "Number": "number",
+                "String": "string",
+                "Boolean": "boolean",
+                "bool": "boolean"
+            },
+            "prefer": {
+                "return": "returns"
+            },
+            "requireReturn": false,
+            "requireReturnDescription": false,
+            "requireParamDescription": false,
+            "matchDescription": "^[^a-z][\\s\\S]*\\.$"
+        }],
+        "require-jsdoc": ["error", {
+            "require": {
+                "FunctionDeclaration": false,
+                "MethodDefinition": true,
+                "ClassDeclaration": true
+            }
+        }]
+    }
+}


### PR DESCRIPTION
This updates to eslint v3.  Technically, v4 is out as of yesterday, but our peer dependencies haven't been updated yet.  There are a number of new rules (mostly whitespace) that needed to be fix.  Thankfully most of the changes only required running `eslint --fix .`.

The main purpose of this PR is to add linting of our docstrings.  The rules I choose are designed to enforce the style of the docstrings added in `map.js` in #698.  I have the rules set to warnings for now until we get around to fixing them all, which could take a while.

I also made a PR against eslint to add enforcement of parameter and return value descriptions (https://github.com/eslint/eslint/pull/8716).  If and when this is merged, we can enforce our docstring conventions there as well.