### PR TITLE
Several minor improvements.

### DIFF
--- a/examples/wms/main.js
+++ b/examples/wms/main.js
@@ -17,7 +17,7 @@ $(function () {
   wms.url(
     function (x, y, zoom) {
       // Compute the bounding box
-      var bb = wms.gcsTileBounds({x: x, y: y, level: zoom}, projection);
+      var bb = this.gcsTileBounds({x: x, y: y, level: zoom}, projection);
       var bbox_mercator = bb.left + ',' + bb.bottom + ',' + bb.right + ',' + bb.top;
 
       // Set the WMS server parameters

--- a/src/d3/d3Renderer.js
+++ b/src/d3/d3Renderer.js
@@ -189,9 +189,9 @@ var d3Renderer = function (arg) {
     }
     m_diagonal = Math.pow(width * width + height * height, 0.5);
     m_corners = {
-      upperLeft: map.displayToGcs({'x': 0, 'y': 0}, null),
-      lowerRight: map.displayToGcs({'x': width, 'y': height}, null),
-      center: map.displayToGcs({'x': width / 2, 'y': height / 2}, null)
+      upperLeft: map.displayToGcs({x: 0, y: 0}, null),
+      lowerRight: map.displayToGcs({x: width, y: height}, null),
+      center: map.displayToGcs({x: width / 2, y: height / 2}, null)
     };
   }
 

--- a/src/osmLayer.js
+++ b/src/osmLayer.js
@@ -56,8 +56,9 @@ module.exports = (function () {
         queue: this._queue,
         overlap: this._options.tileOverlap,
         scale: this._options.tileScale,
-        url: this._options.url(urlParams.x, urlParams.y, urlParams.level || 0,
-                               this._options.subdomains)
+        url: this._options.url.call(
+            this, urlParams.x, urlParams.y, urlParams.level || 0,
+            this._options.subdomains)
       });
     }.bind(this);
   };

--- a/src/registry.js
+++ b/src/registry.js
@@ -280,6 +280,7 @@ util.createLayer = function (name, map, arg) {
       $.extend(true, options, arg);
     }
     layer = layers[name](options);
+    layer.layerName = name;
     layer._init();
     return layer;
   } else {

--- a/src/tileLayer.js
+++ b/src/tileLayer.js
@@ -446,8 +446,9 @@ module.exports = (function () {
         index: index,
         size: {x: this._options.tileWidth, y: this._options.tileHeight},
         queue: this._queue,
-        url: this._options.url(urlParams.x, urlParams.y, urlParams.level || 0,
-                               this._options.subdomains)
+        url: this._options.url.call(
+            this, urlParams.x, urlParams.y, urlParams.level || 0,
+            this._options.subdomains)
       });
     };
 

--- a/tests/cases/map.js
+++ b/tests/cases/map.js
@@ -139,6 +139,32 @@ describe('geo.core.map', function () {
       expect(m.unitsPerPixel()).toBeCloseTo(200000 * 16);
       expect(m.unitsPerPixel(4)).toBeCloseTo(200000);
     });
+    it('animationQueue', function () {
+      mockAnimationFrame();
+      var m = create_map(), queue = [], queue2 = [],
+          queue3 = [window.requestAnimationFrame(function () { })];
+      expect(m.animationQueue()).toEqual([]);
+      expect(m.animationQueue()).not.toBe(queue);
+      expect(m.animationQueue(queue)).toBe(m);
+      expect(m.animationQueue()).toBe(queue);
+      m.scheduleAnimationFrame(function () { });
+      expect(queue.length).toBe(2);
+      expect(m.animationQueue(queue2)).toBe(m);
+      expect(queue2.length).toBe(2);
+      expect(queue2).toEqual(queue);
+      expect(m.animationQueue(queue3)).toBe(m);
+      expect(queue3.length).toBe(2);
+      expect(queue3).not.toEqual(queue2);
+      unmockAnimationFrame();
+    });
+    it('autoResize', function () {
+      var m = create_map();
+      expect(m.autoResize()).toBe(true);
+      expect(m.autoResize(false)).toBe(m);
+      expect(m.autoResize()).toBe(false);
+      expect(m.autoResize(true)).toBe(m);
+      expect(m.autoResize()).toBe(true);
+    });
     it('gcs and ingcs', function () {
       var m = create_map(), units = m.unitsPerPixel(), bounds;
       var error = console.error;

--- a/tests/cases/osmLayer.js
+++ b/tests/cases/osmLayer.js
@@ -123,7 +123,7 @@ describe('geo.core.osmLayer', function () {
   describe('default osmLayer', function () {
 
     describe('html', function () {
-      var layer;
+      var layer, lastThis;
       it('creation', function () {
         map = create_map();
         layer = map.createLayer('osm', {renderer: null, url: '/testdata/white.jpg'});
@@ -142,6 +142,19 @@ describe('geo.core.osmLayer', function () {
       });
       waitForIt('.geo-tile-container', function () {
         return map.node().find('.geo-tile-container').length > 0;
+      });
+      it('tile function', function () {
+        map.deleteLayer(layer);
+        layer = map.createLayer('osm', {renderer: null, mapOpacity: 0.5, url: function (x, y, z) {
+          lastThis = this;
+          return '/testdata/white.jpg';
+        }});
+      });
+      waitForIt('.geo-tile-container', function () {
+        return map.node().find('.geo-tile-container').length > 0;
+      });
+      it('tile function test', function () {
+        expect(lastThis).toBe(layer);
       });
       /* The follow is a test of tileLayer as attached to a map.  We don't
        * currently expose the tileLayer class directly to the createLayer

--- a/tests/cases/tileLayer.js
+++ b/tests/cases/tileLayer.js
@@ -957,14 +957,18 @@ describe('geo.tileLayer', function () {
     });
 
     it('_getTile', function () {
+      var lastThis;
       var t, l = geo.tileLayer({
             map: map(),
             tileWidth: 110,
             tileHeight: 120,
-            url: function (x, y, z) { return {x: x, y: y, level: z}; }
+            url: function (x, y, z) {
+              lastThis = this;
+              return {x: x, y: y, level: z};
+            }
           });
-
       t = l._getTile({x: 1, y: 1, level: 0}, {x: 0, y: 0, level: 0});
+      expect(lastThis).toBe(l);
       expect(t._url).toEqual({x: 0, y: 0, level: 0});
       expect(t.size).toEqual({x: 110, y: 120});
       expect(t.index).toEqual({x: 1, y: 1, level: 0});


### PR DESCRIPTION
- When calling a tile url function, use the layer as the context.

  This would allow, for instance, two layers in different projections to use the same function which could then use `this.gcsTileBounds()` to determine the extent of the tile correctly for the layer.

- Allow getting and setting the animation queue.  This allows, for instance, linking two map's animation queues after they have been created.

- Allow getting and setting the `autoResize` flag.