### PR TITLE
Add a new jsdoc plugin to fix event names

### DIFF
--- a/jsdoc.conf.json
+++ b/jsdoc.conf.json
@@ -3,6 +3,7 @@
     "template": "node_modules/jaguarjs-jsdoc"
   },
   "plugins": [
+    "jsdoc/plugins/events",
     "node_modules/jsdoc-autoprivate/autoprivate.js",
     "plugins/markdown"
   ],

--- a/jsdoc/plugins/events.js
+++ b/jsdoc/plugins/events.js
@@ -1,0 +1,34 @@
+function fixEventName(event) {
+  return event.replace('event:', '');
+}
+
+/**
+ * Define a jsdoc plugin to replace the `longname` of
+ * event doclets from `geo.event.event:pan` to `geo.event.pan`.
+ */
+exports.handlers = {
+  /**
+   * Replace the `longname` of all event doclets.
+   */
+  newDoclet: function (e) {
+    var doclet = e.doclet;
+    if (doclet.kind === 'event') {
+      doclet.longname = fixEventName(doclet.longname);
+    }
+  },
+
+  /**
+   * Replace the displayed name of events to match the changed
+   * doclet names.
+   */
+  parseComplete: function (e) {
+    e.doclets.forEach(function (doclet) {
+      if (doclet.fires) {
+        doclet.fires = doclet.fires.map(fixEventName);
+      }
+      if (doclet.listens) {
+        doclet.listens = doclet.listens.map(fixEventName);
+      }
+    });
+  }
+};


### PR DESCRIPTION
Originally, I was going to vendor the upstream templates here, but this change can be made with a simple plugin.  For bigger changes, we still may need to customize the jaguar template.