### PR TITLE
Add an API link to the Sphinx documentation.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -153,7 +153,9 @@ if not os.environ.get('READTHEDOCS', None):
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+
+html_static_path = []
+# html_static_path = ['_static']
 
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -27,6 +27,7 @@ If you have any questions or comments, feel free to join us on our
     developers
     provisioning
     testingutils
+    API Reference <http://opengeoscience.github.io/geojs/apidocs/geo.html>
 
 Indices and tables
 ==================

--- a/docs/testingutils.rst
+++ b/docs/testingutils.rst
@@ -7,4 +7,3 @@ Testing infrastructure
     :maxdepth: 2
 
     baseline_images
-    upload_test_cases

--- a/docs/upload_test_cases.rst
+++ b/docs/upload_test_cases.rst
@@ -1,5 +1,0 @@
-upload_test_cases
-=================
-
-.. automodule:: upload_test_cases
-   :members:

--- a/docs/users.rst
+++ b/docs/users.rst
@@ -141,6 +141,9 @@ class definition inside GeoJS.
 Class overview
 ---------------
 
+The latest version of the full API documentation is at
+`http://opengeoscience.github.io/geojs/apidocs/geo.html <http://opengeoscience.github.io/geojs/apidocs/geo.html>`_.
+
 GeoJS is made up of the following core classes.  Click on the link to go to the
 documentation for each of the classes.
 
@@ -214,9 +217,6 @@ documentation for each of the classes.
     the only implemented reader is
     `geo.jsonReader <http://opengeoscience.github.io/geojs/apidocs/geo.jsonReader.html>`_,
     which is an extendable geojson reader.
-
-The API documentation is in the process of being updated.  You can always find the latest version
-at `http://opengeoscience.github.io/geojs/apidocs/geo.html <http://opengeoscience.github.io/geojs/apidocs/geo.html>`_.
 
 Coordinate systems
 ------------------


### PR DESCRIPTION
Prior to this, the only link to the full API docs was in an under-construction sort of message.

This also removes the outdated upload_test_cases.rst file and cleans up all Sphinx-build warnings.