### PR TITLE
Add a codecov configuration file.

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,15 @@
+comment: false
+coverage:
+  status:
+    # We have some variation in tests due to variations in the test runs.  We
+    # want to ignore these changes, but not let code coverage slip too much.
+    project:
+      default:
+        threshold: 0.1
+    # This applies to the changed code.  We allow it to be much less covered
+    # than the main code, since we use the project threshold for that.
+    patch:
+      default:
+        threshold: 25
+        only_pulls: true
+


### PR DESCRIPTION
Minor variations in testing result in codecov showing failures when we should let the changes through.