### PR TITLE
Finish removing event `type` properties.

### DIFF
--- a/src/map.js
+++ b/src/map.js
@@ -682,7 +682,6 @@ var map = function (arg) {
     m_this.center(oldCenter);
 
     m_this.geoTrigger(geo_event.resize, {
-      type: geo_event.resize,
       target: m_this,
       width: m_width,
       height: m_height


### PR DESCRIPTION
We store the event name in the `event` proeprty of an event.  In a few
places were also storing it in the `type` property.  The `type` property
wasn't used consistently and has mostly been removed.  This finishes
removing it.

This closes #703.