### PR TITLE
Add isObject utility function.  Use Array.isArray.

### DIFF
--- a/src/gl/polygonFeature.js
+++ b/src/gl/polygonFeature.js
@@ -3,10 +3,12 @@ var registerFeature = require('../registry').registerFeature;
 var polygonFeature = require('../polygonFeature');
 
 /**
- * Create a new instance of polygonFeature
+ * Create a new instance of gl.polygonFeature.
  *
- * @class geo.gl.polygonFeature
+ * @class
+ * @alias geo.gl.polygonFeature
  * @extends geo.polygonFeature
+ * @param {geo.polygonFeature.spec} arg
  * @returns {geo.gl.polygonFeature}
  */
 var gl_polygonFeature = function (arg) {
@@ -89,7 +91,6 @@ var gl_polygonFeature = function (arg) {
    * Array.map is slower in Chrome that using a loop, so loops are used in
    * places that would be conceptually served by maps.
    *
-   * @memberof geo.gl.polygonFeature
    * @param {boolean} onlyStyle if true, use the existing geoemtry and just
    *    recalculate the style.
    */
@@ -126,7 +127,7 @@ var gl_polygonFeature = function (arg) {
         if (!polygon) {
           return;
         }
-        outer = polygon.outer || (polygon instanceof Array ? polygon : []);
+        outer = polygon.outer || (Array.isArray(polygon) ? polygon : []);
 
         /* expand to an earcut polygon geometry.  We had been using a map call,
          * but using loops is much faster in Chrome (4 versus 33 ms for one
@@ -260,8 +261,10 @@ var gl_polygonFeature = function (arg) {
   }
 
   /**
-   * Initialize
-   * @memberof geo.gl.polygonFeature
+   * Initialize.
+   *
+   * @param {geo.polygonFeature.spec} arg An object with options for the
+   *    feature.
    */
   this._init = function (arg) {
     var prog = vgl.shaderProgram(),
@@ -307,9 +310,8 @@ var gl_polygonFeature = function (arg) {
   };
 
   /**
-   * Build
+   * Build.
    *
-   * @memberof geo.gl.polygonFeature
    * @override
    */
   this._build = function () {
@@ -323,9 +325,8 @@ var gl_polygonFeature = function (arg) {
   };
 
   /**
-   * Update
+   * Update.
    *
-   * @memberof geo.gl.polygonFeature
    * @override
    */
   this._update = function (opts) {
@@ -350,8 +351,7 @@ var gl_polygonFeature = function (arg) {
   };
 
   /**
-   * Destroy
-   * @memberof geo.gl.polygonFeature
+   * Destroy.
    */
   this._exit = function () {
     m_this.renderer().contextRenderer().removeActor(m_actor);

--- a/src/polygonFeature.js
+++ b/src/polygonFeature.js
@@ -3,41 +3,47 @@ var inherit = require('./inherit');
 var feature = require('./feature');
 
 /**
- * Create a new instance of class polygonFeature
+ * Polygon feature specification.
  *
- * @class geo.polygonFeature
- * @extends geo.feature
- * @param {Object} arg Options object
- * @param {Object|Function} [arg.position] Position of the data.  Default is
+ * @typedef {geo.feature.spec} geo.polygonFeature.spec
+ * @param {object|Function} [position] Position of the data.  Default is
  *   (data).
- * @param {Object|Function} [arg.polygon] Polygons from the data.  Default is
- *   (data).  Typically, the data is an array of polygons, each of which is
- *   of the form {outer: [(coordinates)], inner: [[(coordinates of first
- *   hole)], [(coordinates of second hole)], ...]}.  The inner record is
- *   optional.  Alternately, if there are no holes, a polygon can just be an
- *   array of coordinates.  Coordinates are in the form {x: (x), y: (y),
- *   z: (z)}, with z being optional.  The first and last point of each polygon
- *   must be the same.
- * @param {Object} [arg.style] Style object with default style options.
- * @param {boolean|Function} [arg.style.fill] True to fill polygon.  Defaults
- *   to true.
- * @param {Object|Function} [arg.style.fillColor] Color to fill each polygon.
+ * @param {object|Function} [polygon] Polygons from the data.  Default is
+ *   (data).  Typically, the data is an array of polygons, each of which is of
+ *   the form {outer: [(coordinates)], inner: [[(coordinates of first hole)],
+ *   [(coordinates of second hole)], ...]}.  The inner record is optional.
+ *   Alternately, if there are no holes, a polygon can just be an array of
+ *   coordinates in the form of geo.geoPosition.  The first and last point of
+ *   each polygon may be the same.
+ * @param {object} [style] Style object with default style options.
+ * @param {boolean|Function} [style.fill] True to fill polygon.  Defaults to
+ *   true.
+ * @param {object|Function} [style.fillColor] Color to fill each polygon.  The
+ *   color can vary by vertex.  Colors can be css names or hex values, or an
+ *   object with r, g, b on a [0-1] scale.
+ * @param {number|Function} [style.fillOpacity] Opacity for each polygon.  The
+ *   opacity can vary by vertex.  Opacity is on a [0-1] scale.
+ * @param {boolean|Function} [style.stroke] True to stroke polygon.  Defaults
+ *   to false.
+ * @param {object|Function} [style.strokeColor] Color to stroke each polygon.
  *   The color can vary by vertex.  Colors can be css names or hex values, or
  *   an object with r, g, b on a [0-1] scale.
- * @param {number|Function} [arg.style.fillOpacity] Opacity for each polygon.
- *   The opacity can vary by vertex.  Opacity is on a [0-1] scale.
- * @param {boolean|Function} [arg.style.stroke] True to stroke polygon.
- *   Defaults to false.
- * @param {Object|Function} [arg.style.strokeColor] Color to stroke each
- *   polygon.  The color can vary by vertex.  Colors can be css names or hex
- *   values, or an object with r, g, b on a [0-1] scale.
- * @param {number|Function} [arg.style.strokeOpacity] Opacity for each polygon
+ * @param {number|Function} [style.strokeOpacity] Opacity for each polygon
  *   stroke.  The opacity can vary by vertex.  Opacity is on a [0-1] scale.
- * @param {number|Function} [arg.style.strokeWidth] The weight of the polygon
+ * @param {number|Function} [style.strokeWidth] The weight of the polygon
  *   stroke in pixels.  The width can vary by vertex.
- * @param {boolean|Function} [arg.style.uniformPolygon] Boolean indicating if
- *   each polygon has a uniform style (uniform fill color, fill opacity, stroke
+ * @param {boolean|Function} [style.uniformPolygon] Boolean indicating if each
+ *   polygon has a uniform style (uniform fill color, fill opacity, stroke
  *   color, and stroke opacity).   Defaults to false.  Can vary by polygon.
+ */
+
+/**
+ * Create a new instance of class polygonFeature.
+ *
+ * @class
+ * @alias geo.polygonFeature
+ * @extends geo.feature
+ * @param {geo.polygonFeature.spec} arg
  * @returns {geo.polygonFeature}
  */
 var polygonFeature = function (arg) {
@@ -78,10 +84,9 @@ var polygonFeature = function (arg) {
   /**
    * Get/set data.
    *
-   * @memberof geo.polygonFeature
-   * @param {Object} [data] if specified, use this for the data and return the
+   * @param {object} [arg] if specified, use this for the data and return the
    *    feature.  If not specified, return the current data.
-   * @returns {geo.polygonFeature|Object}
+   * @returns {geo.polygonFeature|object}
    */
   this.data = function (arg) {
     var ret = s_data(arg);
@@ -97,7 +102,6 @@ var polygonFeature = function (arg) {
    * the computation in world coordinates, but we will need to work in GCS
    * for other projections.  Also compute the extents of the outside of each
    * polygon for faster checking if points are in the polygon.
-   * @memberof geo.polygonFeature
    * @private
    */
   function getCoordinates() {
@@ -110,7 +114,7 @@ var polygonFeature = function (arg) {
       }
       var outer, inner, range, coord, j, x, y;
 
-      coord = poly.outer || (poly instanceof Array ? poly : []);
+      coord = poly.outer || (Array.isArray(poly) ? poly : []);
       outer = new Array(coord.length);
       for (j = 0; j < coord.length; j += 1) {
         outer[j] = posFunc.call(m_this, coord[j], j, d, i);
@@ -168,10 +172,9 @@ var polygonFeature = function (arg) {
   /**
    * Get/set polygon accessor.
    *
-   * @memberof geo.polygonFeature
-   * @param {Object} [polygon] if specified, use this for the polygon accessor
+   * @param {object} [val] if specified, use this for the polygon accessor
    *    and return the feature.  If not specified, return the current polygon.
-   * @returns {geo.polygonFeature|Object}
+   * @returns {object|this} The current polygon or this feature.
    */
   this.polygon = function (val) {
     if (val === undefined) {
@@ -188,11 +191,10 @@ var polygonFeature = function (arg) {
   /**
    * Get/Set position accessor.
    *
-   * @memberof geo.polygonFeature
-   * @param {Object} [position] if specified, use this for the position
-   *    accessor and return the feature.  If not specified, return the current
+   * @param {object} [val] if specified, use this for the position accessor
+   *    and return the feature.  If not specified, return the current
    *    position.
-   * @returns {geo.polygonFeature|Object}
+   * @returns {object|this} The current position or this feature.
    */
   this.position = function (val) {
     if (val === undefined) {
@@ -210,7 +212,6 @@ var polygonFeature = function (arg) {
    * Point search method for selection api.  Returns markers containing the
    * given point.
    *
-   * @memberof geo.polygonFeature
    * @argument {object} coordinate
    * @returns {object}
    */
@@ -237,6 +238,15 @@ var polygonFeature = function (arg) {
   /**
    * Get/Set style used by the feature.  This calls the super function, then
    * checks if strokes are required.
+   *
+   * @param {string|object} [arg1] If `undefined`, return the current style
+   *    object.  If a string and `arg2` is undefined, return the style
+   *    associated with the specified key.  If a string and `arg2` is defined,
+   *    set the named style to the specified value.  Otherwise, extend the
+   *    current style with the values in the specified object.
+   * @param {*} [arg2] If `arg1` is a string, the new value for that style.
+   * @returns {object|this} Either the entire style object, the value of a
+   *    specific style, or the current class instance.
    */
   this.style = function (arg1, arg2) {
     var result = s_style.apply(this, arguments);
@@ -317,7 +327,7 @@ var polygonFeature = function (arg) {
         if (!polygon) {
           continue;
         }
-        loop = polygon.outer || (polygon instanceof Array ? polygon : []);
+        loop = polygon.outer || (Array.isArray(polygon) ? polygon : []);
         lineData.push(m_this._getLoopData(data[i], i, loop));
         if (polygon.inner) {
           polygon.inner.forEach(function (loop) {
@@ -335,8 +345,10 @@ var polygonFeature = function (arg) {
   };
 
   /**
-  * Redraw the object.
-  */
+   * Redraw the object.
+   *
+   * @returns {object} The results of the superclass draw function.
+   */
   this.draw = function () {
     var result = s_draw();
     if (m_lineFeature) {
@@ -346,9 +358,11 @@ var polygonFeature = function (arg) {
   };
 
   /**
-  * When the feature is marked as modified, mark our sub-feature as modified,
-  * too.
-  */
+   * When the feature is marked as modified, mark our sub-feature as
+   * modified, too.
+   *
+   * @returns {object} The results of the superclass modified function.
+   */
   this.modified = function () {
     var result = s_modified();
     if (m_lineFeature) {
@@ -358,8 +372,7 @@ var polygonFeature = function (arg) {
   };
 
   /**
-   * Destroy
-   * @memberof geo.polygonFeature
+   * Destroy.
    */
   this._exit = function () {
     if (m_lineFeature && m_this.layer()) {
@@ -371,8 +384,10 @@ var polygonFeature = function (arg) {
   };
 
   /**
-   * Initialize
-   * @memberof geo.polygonFeature
+   * Initialize.
+   *
+   * @param {geo.polygonFeature.spec} arg An object with options for the
+   *    feature.
    */
   this._init = function (arg) {
     arg = arg || {};

--- a/src/transform.js
+++ b/src/transform.js
@@ -254,7 +254,9 @@ transform.transformCoordinates = function (
     }
     return {x: output.x, y: output.y};
   }
-  if (Array.isArray(coordinates) && coordinates.length === 1 && util.isObject(coordinates[0]) && 'x' in coordinates[0] && 'y' in coordinates[0]) {
+  if (Array.isArray(coordinates) && coordinates.length === 1 &&
+      util.isObject(coordinates[0]) && 'x' in coordinates[0] &&
+      'y' in coordinates[0]) {
     output = trans.forward({x: coordinates[0].x, y: coordinates[0].y, z: coordinates[0].z || 0});
     if ('z' in coordinates[0]) {
       return [output];

--- a/src/transform.js
+++ b/src/transform.js
@@ -1,4 +1,5 @@
 var proj4 = require('proj4');
+var util = require('./util');
 
 /**
  * This purpose of this class is to provide a generic interface for computing
@@ -65,7 +66,12 @@ var transform = function (options) {
   }
 
   /**
-   * Get/Set the source projection
+   * Get/Set the source projection.
+   *
+   * @param {string} [arg] The new source projection.  If `undefined`, return
+   *    the current source projection.
+   * @returns {string|this} The current source projection if it was queried,
+   *    otherwise the current transform object.
    */
   this.source = function (arg) {
     if (arg === undefined) {
@@ -77,7 +83,12 @@ var transform = function (options) {
   };
 
   /**
-   * Get/Set the target projection
+   * Get/Set the target projection.
+   *
+   * @param {string} [arg] The new target projection.  If `undefined`, return
+   *    the current target projection.
+   * @returns {string|this} The current target projection if it was queried,
+   *    otherwise the current transform object.
    */
   this.target = function (arg) {
     if (arg === undefined) {
@@ -89,15 +100,11 @@ var transform = function (options) {
   };
 
   /**
-   * Perform a forward transformation (source -> target)
+   * Perform a forward transformation (source -> target).
    * @protected
    *
-   * @param {object}   point      The point coordinates
-   * @param {number}   point.x    The x-coordinate (i.e. longitude)
-   * @param {number}   point.y    The y-coordinate (i.e. latitude)
-   * @param {number}  [point.z=0] The z-coordinate (i.e. elevation)
-   *
-   * @returns {object} A point object in the target coordinates
+   * @param {geo.geoPosition} point The point in source coordinates.
+   * @returns {geo.geoPosition} A point object in the target coordinates.
    */
   this._forward = function (point) {
     var pt = m_proj.forward(point);
@@ -106,15 +113,11 @@ var transform = function (options) {
   };
 
   /**
-   * Perform an inverse transformation (target -> source)
+   * Perform an inverse transformation (target -> source).
    * @protected
    *
-   * @param {object}   point     The point coordinates
-   * @param {number}   point.x   The x-coordinate (i.e. longitude)
-   * @param {number}   point.y   The y-coordinate (i.e. latitude)
-   * @param {number}  [point.z=0] The z-coordinate (i.e. elevation)
-   *
-   * @returns {object} A point object in the source coordinates
+   * @param {geo.geoPosition} point The point in target coordinates.
+   * @returns {geo.geoPosition} A point object in the source coordinates.
    */
   this._inverse = function (point) {
     var pt = m_proj.inverse(point);
@@ -123,14 +126,13 @@ var transform = function (options) {
   };
 
   /**
-   * Perform a forward transformation (source -> target) in place
+   * Perform a forward transformation (source -> target) in place.
+   * @protected
    *
-   * @param {object[]} point      The point coordinates or array of points
-   * @param {number}   point.x    The x-coordinate (i.e. longitude)
-   * @param {number}   point.y    The y-coordinate (i.e. latitude)
-   * @param {number}  [point.z=0] The z-coordinate (i.e. elevation)
-   *
-   * @returns {object} A point object or array in the target coordinates
+   * @param {geo.geoPosition|geo.geoPosition[]} point The point coordinates
+   *    or array of points in source coordinates.
+   * @returns {geo.geoPosition|geo.geoPosition[]} A point object or array in
+   *    the target coordinates.
    */
   this.forward = function (point) {
     if (Array.isArray(point)) {
@@ -140,15 +142,13 @@ var transform = function (options) {
   };
 
   /**
-   * Perform an inverse transformation (target -> source) in place
+   * Perform an inverse transformation (target -> source) in place.
    * @protected
    *
-   * @param {object[]} point      The point coordinates or array of points
-   * @param {number}   point.x    The x-coordinate (i.e. longitude)
-   * @param {number}   point.y    The y-coordinate (i.e. latitude)
-   * @param {number}  [point.z=0] The z-coordinate (i.e. elevation)
-   *
-   * @returns {object} A point object in the source coordinates
+   * @param {geo.geoPosition|geo.geoPosition[]} point The point coordinates
+   *    or array of points in target coordinates.
+   * @returns {geo.geoPosition|geo.geoPosition[]} A point object or array in
+   *    the source coordinates.
    */
   this.inverse = function (point) {
     if (Array.isArray(point)) {
@@ -188,7 +188,7 @@ var transform = function (options) {
 transform.defs = proj4.defs;
 
 /**
- * Look up a projection definition from epsg.io
+ * Look up a projection definition from epsg.io.
  * For the moment, we only handle `EPSG` codes.
  *
  * @param {string} projection A projection alias (e.g. EPSG:4326)
@@ -224,18 +224,19 @@ transform.lookup = function (projection) {
 /**
  * Transform an array of coordinates from one projection into another.  The
  * transformation may occur in place (modifying the input coordinate array),
- * depending on the input format.  The coordinates can be an object with x, y,
- * and (optionally z) or an array of 2 or 3 values, or an array of either of
- * those, or a single flat array with 2 or 3 components per coordinate.  Arrays
- * are always modified in place.  Individual point objects are not altered; new
- * point objects are returned unless no transform is needed.
+ * depending on the input format.  The coordinates can be an object with x,
+ * y, and (optionally z) or an array of 2 or 3 values, or an array of either
+ * of those, or a single flat array with 2 or 3 components per coordinate.
+ * Arrays are always modified in place.  Individual point objects are not
+ * altered; new point objects are returned unless no transform is needed.
  *
- * @param {string}        srcPrj The source projection
- * @param {string}        tgtPrj The destination projection
- * @param {geoPosition[]} coordinates An array of coordinate objects
- * @param {number}        numberOfComponents for flat arrays, either 2 or 3.
- *
- * @returns {geoPosition[]} The transformed coordinates
+ * @param {string} srcPrj The source projection.
+ * @param {string} tgtPrj The destination projection.
+ * @param {geoPosition|geoPosition[]|number[]} coordinates An array of
+ *      coordinate objects.  These may be in object or array form, or a flat
+ *      array.
+ * @param {number} numberOfComponents For flat arrays, either 2 or 3.
+ * @returns {geoPosition|geoPosition[]|number[]} The transformed coordinates.
  */
 transform.transformCoordinates = function (
         srcPrj, tgtPrj, coordinates, numberOfComponents) {
@@ -246,14 +247,14 @@ transform.transformCoordinates = function (
   }
 
   var trans = transform({source: srcPrj, target: tgtPrj}), output;
-  if (coordinates instanceof Object && 'x' in coordinates && 'y' in coordinates) {
+  if (util.isObject(coordinates) && 'x' in coordinates && 'y' in coordinates) {
     output = trans.forward({x: coordinates.x, y: coordinates.y, z: coordinates.z || 0});
     if ('z' in coordinates) {
       return output;
     }
     return {x: output.x, y: output.y};
   }
-  if (coordinates instanceof Array && coordinates.length === 1 && coordinates[0] instanceof Object && 'x' in coordinates[0] && 'y' in coordinates[0]) {
+  if (Array.isArray(coordinates) && coordinates.length === 1 && util.isObject(coordinates[0]) && 'x' in coordinates[0] && 'y' in coordinates[0]) {
     output = trans.forward({x: coordinates[0].x, y: coordinates[0].y, z: coordinates[0].z || 0});
     if ('z' in coordinates[0]) {
       return [output];
@@ -270,11 +271,11 @@ transform.transformCoordinates = function (
  * values, or an array of either of those, or a single flat array with 2 or 3
  * components per coordinate.  The array is modified in place.
  *
- * @param {object} trans The transformation object.
- * @param {geoPosition[]} coordinates An array of coordinate objects
- * @param {number} numberOfComponents for flat arrays, either 2 or 3.
- *
- * @returns {geoPosition[]} The transformed coordinates
+ * @param {transform} trans The transformation object.
+ * @param {geoPosition[]|number[]} coordinates An array of coordinate
+ *      objects or a flat array.
+ * @param {number} numberOfComponents For flat arrays, either 2 or 3.
+ * @returns {geoPosition[]|number[]} The transformed coordinates
  */
 transform.transformCoordinatesArray = function (trans, coordinates, numberOfComponents) {
   var i, count, offset, xAcc, yAcc, zAcc, writer, output, projPoint;
@@ -286,7 +287,7 @@ transform.transformCoordinatesArray = function (trans, coordinates, numberOfComp
 
   // Helper methods
   function handleArrayCoordinates() {
-    if (coordinates[0] instanceof Array) {
+    if (Array.isArray(coordinates[0])) {
       if (coordinates[0].length === 2) {
         xAcc = function (index) {
           return coordinates[index][0];
@@ -407,7 +408,7 @@ transform.transformCoordinatesArray = function (trans, coordinates, numberOfComp
     }
   }
 
-  if (coordinates instanceof Array) {
+  if (Array.isArray(coordinates)) {
     output = [];
     output.length = coordinates.length;
     count = coordinates.length;
@@ -415,13 +416,12 @@ transform.transformCoordinatesArray = function (trans, coordinates, numberOfComp
     if (!coordinates.length) {
       return output;
     }
-    if (coordinates[0] instanceof Array ||
-        coordinates[0] instanceof Object) {
+    if (Array.isArray(coordinates[0]) || util.isObject(coordinates[0])) {
       offset = 1;
 
-      if (coordinates[0] instanceof Array) {
+      if (Array.isArray(coordinates[0])) {
         handleArrayCoordinates();
-      } else if (coordinates[0] instanceof Object) {
+      } else if (util.isObject(coordinates[0])) {
         handleObjectCoordinates();
       }
     } else {
@@ -439,19 +439,16 @@ transform.transformCoordinatesArray = function (trans, coordinates, numberOfComp
 };
 
 /**
- * Apply an affine transformation consisting of a translation
- * then a scaling to the given coordinate array.  Note, the
- * transformation occurs in place so the input coordinate
- * object are mutated.
- *
- * (Possibly extend to support rotations as well)
+ * Apply an affine transformation consisting of a translation then a scaling
+ * to the given coordinate array.  Note, the transformation occurs in place
+ * so the input coordinate object are mutated.
  *
  * @param {object} def
- * @param {object} def.origin The transformed origin
- * @param {object} def.scale The transformed scale factor
- * @param {object[]} coords An array of coordinate objects
- *
- * @returns {object[]} The transformed coordinates
+ * @param {geo.geoPosition} def.origin The transformed origin
+ * @param {object} def.scale The transformed scale factor.  This is an object
+ *  with `x`, `y`, and `z` parameters.
+ * @param {geo.geoPosition[]} coords An array of coordinate objects.
+ * @returns {geo.geoPosition[]} The transformed coordinates.
  */
 transform.affineForward = function (def, coords) {
   'use strict';
@@ -465,19 +462,16 @@ transform.affineForward = function (def, coords) {
 };
 
 /**
- * Apply an inverse affine transformation which is the
- * inverse to {@link geo.transform.affineForward}.  Note, the
- * transformation occurs in place so the input coordinate
- * object are mutated.
- *
- * (Possibly extend to support rotations as well)
+ * Apply an inverse affine transformation which is the inverse to {@link
+ * geo.transform.affineForward}.  Note, the transformation occurs in place so
+ * the input coordinate object are mutated.
  *
  * @param {object} def
- * @param {object} def.origin The transformed origin
- * @param {object} def.scale The transformed scale factor
- * @param {object[]} coords An array of coordinate objects
- *
- * @returns {object[]} The transformed coordinates
+ * @param {geo.geoPosition} def.origin The transformed origin
+ * @param {object} def.scale The transformed scale factor.  This is an object
+ *  with `x`, `y`, and `z` parameters.
+ * @param {geo.geoPosition[]} coords An array of coordinate objects.
+ * @returns {geo.geoPosition[]} The transformed coordinates.
  */
 transform.affineInverse = function (def, coords) {
   'use strict';

--- a/src/util/index.js
+++ b/src/util/index.js
@@ -1027,6 +1027,18 @@ var util = module.exports = {
     }
   },
 
+  /**
+   * Test if an item is an object.  This uses typeof not instanceof, since
+   * instanceof will return false for some things that we expect to be objects.
+   *
+   * @param {*} value The item to test.
+   * @returns {boolean} True if the tested item is an object.
+   */
+  isObject: function (value) {
+    var type = typeof value;
+    return value !== null && value !== undefined && (type === 'object' || type === 'function');
+  },
+
   ///////////////////////////////////////////////////////////////////////////
   /*
    * Utility member properties.

--- a/tests/cases/util.js
+++ b/tests/cases/util.js
@@ -1,0 +1,35 @@
+/* global $ */
+
+/* Test util functions that aren't tested elsewhere. */
+
+describe('geo.util', function () {
+  'use strict';
+
+  var geo = require('../test-utils').geo,
+      util = geo.util;
+
+  it('isObject', function () {
+    expect(util.isObject({})).toBe(true);
+    expect(util.isObject(Function)).toBe(true);
+    expect(util.isObject([1, 2, 3])).toBe(true);
+    expect(util.isObject(null)).toBe(false);
+    expect(util.isObject(undefined)).toBe(false);
+    expect(util.isObject(6)).toBe(false);
+    expect(util.isObject('abc')).toBe(false);
+    expect(util.isObject(true)).toBe(false);
+    /* eslint-disable no-new-wrappers */
+    expect(util.isObject(new Number(6))).toBe(true);
+    expect(util.isObject(new String('abc'))).toBe(true);
+    expect(util.isObject(new Boolean(true))).toBe(true);
+    /* eslint-enable no-new-wrappers */
+    // test that objects from iframes are still objects
+    var iframe = $('<iframe>');
+    $('body').append(iframe);
+    var iframeWindow = iframe[0].contentWindow;
+    expect(util.isObject(new iframeWindow.Object())).toBe(true);
+    // they aren't using instanceof
+    expect((new iframeWindow.Object()) instanceof Object).toBe(false);
+    expect(({}) instanceof iframeWindow.Object).toBe(false);
+    iframe.remove();
+  });
+});


### PR DESCRIPTION
Fix jsdocs on all touched files.  Add tests.

Prior to this, we were using `instanceof Object` and `instanceof Array`.  For testing the upcoming tutorials branch, it is handy to be able to pass an object created in a parent window to a map running in an iframe.  However, `<parent object> instanceof Object` returned false in a map in the iframe, which makes it hard to interact with the map.  Similarly, the MDN docs recommend using `Array.isArray` over `instanceof` for this same reason.  Using `instanceof` to detect our own classes and `Float32Array` and similar structures still works without causing issues.  It is possible we will want to do something similar for detecting HTML Image and Canvas elements, but for now these have been left alone.