### PR TITLE
Fix import order in tutorials.

### DIFF
--- a/tutorials/basic/index.pug
+++ b/tutorials/basic/index.pug
@@ -9,8 +9,8 @@ block mainTutorial
     <!DOCTYPE html>
     <html>
     <head>
-      <script type="text/javascript" src="../../built/geo.min.js"></script>
       <script type="text/javascript" src="../../built/geo.ext.min.js"></script>
+      <script type="text/javascript" src="../../built/geo.min.js"></script>
     </head>
     <body>
       <div id="map"></div>
@@ -19,7 +19,8 @@ block mainTutorial
 
   :markdown-it
     The second script, ``geo.ext.min.js``, is optional.  It adds support
-    for svg elements and touch interaction.
+    for svg elements and touch interaction.  It needs to be added before
+    ``geo.min.js``.
 
     Some CSS will make our map fill the page:
 

--- a/tutorials/common/tutorials.js
+++ b/tutorials/common/tutorials.js
@@ -13,8 +13,8 @@ var processBlockInfo = {
     /* We could also load from the CDN:
      *   https://cdnjs.cloudflare.com/ajax/libs/geojs/0.12.2/geo.min.js
      * or the non-minified versions to make debug easier. */
-    '  <script type="text/javascript" src="../../built/geo.min.js"></script>\n' +
     '  <script type="text/javascript" src="../../built/geo.ext.min.js"></script>\n' +
+    '  <script type="text/javascript" src="../../built/geo.min.js"></script>\n' +
     '</head>\n' +
     '<body>\n' +
     '  <div id="map"></div>\n' +


### PR DESCRIPTION
geo.ext.js has to be imported before geo.js for Hammer to be used.  With this change, the tutorials work on an iPad.