### PR TITLE
Don't automatically install website node modules.

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,6 @@
     "xmlbuilder": "^8.2.2"
   },
   "scripts": {
-    "postinstall": "cd website && npm install",
     "build": "webpack --config webpack.config.js && webpack --config external.config.js",
     "build-examples": "node examples/build.js && webpack --config webpack-examples.config.js",
     "build-website-examples": "node examples/build-website.js && webpack --config webpack-website-examples.config.js",
@@ -113,7 +112,8 @@
     "stop-test": "forever stop ./testing/test-runners/server.js",
     "docs": "jsdoc --pedantic -d dist/apidocs -r src -c jsdoc.conf.json",
     "website": "cd website && npx hexo server",
-    "build-website": "npm run build && cp -a dist/built/. website/source/built && npm run build-website-examples && npm run build-website-tutorials && npm run docs && cp -ar dist/data/. website/source/data && cp -ar dist/apidocs/. website/source/apidocs && cd website && rm -f db.json && npx hexo generate"
+    "install-website": "cd website && npm install",
+    "build-website": "npm run build && cp -a dist/built/. website/source/built && npm run build-website-examples && npm run build-website-tutorials && npm run docs && cp -ar dist/data/. website/source/data && cp -ar dist/apidocs/. website/source/apidocs && cd website && npm install && rm -f db.json && npx hexo generate"
   },
   "keywords": [
     "map",


### PR DESCRIPTION
When geojs is used as a node module in another project, we should install all of the website's node modules.  Doing so bloats the deployment directory of other projects.  This should be a safe change unless we expect other projects to use the generated geojs website as components within those projects.

This skips installing 10,000 files that total 76 Mb.