### PR TITLE
Fix keyboard unbindings.

### DIFF
--- a/src/mapInteractor.js
+++ b/src/mapInteractor.js
@@ -702,7 +702,7 @@ var mapInteractor = function (args) {
       m_boundKeys = bound;
     }
     $node.toggleClass('highlight-focus',
-      m_boundKeys && m_boundKeys.length && m_options.keyboard.focusHighlight);
+      !!(m_boundKeys && m_boundKeys.length && m_options.keyboard.focusHighlight));
 
     // bind touch events
     if ((m_this.hasTouchSupport() || m_options.alwaysTouch) &&
@@ -748,7 +748,7 @@ var mapInteractor = function (args) {
   this._disconnectEvents = function () {
     if (m_boundKeys) {
       if (m_keyHandler) {
-        m_boundKeys.every(m_keyHandler.unbind, m_keyHandler);
+        m_keyHandler.unbind(m_boundKeys);
       }
       m_boundKeys = null;
       m_keyHandler = null;


### PR DESCRIPTION
There was a bug when unbinding key handlers.  Mousetrap always expects an array of key sequences, and we were passing one at a time.

Also, jQuery's toggleClass treats 0 as true, so ensure that we always use a boolean.