### PR TITLE
Fix a bug in pointSearch when a feature's gcs was not the default.

### DIFF
--- a/src/feature.js
+++ b/src/feature.js
@@ -518,8 +518,8 @@ var feature = function (arg) {
    */
   this.gcs = function (val) {
     if (val === undefined) {
-      if ((m_gcs === undefined || m_gcs === null) && m_renderer) {
-        return m_renderer.layer().map().ingcs();
+      if ((m_gcs === undefined || m_gcs === null) && m_layer) {
+        return m_layer.map().ingcs();
       }
       return m_gcs;
     } else {
@@ -535,9 +535,8 @@ var feature = function (arg) {
    * @param {geo.geoPosition} c The input coordinate to convert.
    * @returns {geo.screenPosition} Display space coordinates.
    */
-  ////////////////////////////////////////////////////////////////////////////
   this.featureGcsToDisplay = function (c) {
-    var map = m_renderer.layer().map();
+    var map = m_layer.map();
     c = map.gcsToWorld(c, m_this.gcs());
     c = map.worldToDisplay(c);
     if (m_renderer.baseToLocal) {

--- a/src/lineFeature.js
+++ b/src/lineFeature.js
@@ -164,6 +164,8 @@ var lineFeature = function (arg) {
    * corner extensions due to mitering may be outside of the selection area and
    * that variable width lines will have a greater selection region than their
    * visual size at the narrow end.
+   *
+   * @param {geo.geoPosition} p point to search for in map interface gcs.
    */
   this.pointSearch = function (p) {
     var data = m_this.data(), indices = [], found = [];
@@ -177,7 +179,7 @@ var lineFeature = function (arg) {
     var map = m_this.layer().map(),
         scale = map.unitsPerPixel(map.zoom()),
         scale2 = scale * scale,
-        pt = transform.transformCoordinates(m_this.gcs(), map.gcs(), p),
+        pt = transform.transformCoordinates(map.ingcs(), map.gcs(), p),
         i, j, record;
 
     // minimum l2 distance squared from

--- a/src/pixelmapFeature.js
+++ b/src/pixelmapFeature.js
@@ -126,6 +126,9 @@ var pixelmapFeature = function (arg) {
    * If the specified coordinates are in the rendered quad, use the basis
    * information from the quad to determine the pixelmap index value so that it
    * can be included in the found results.
+   *
+   * @param {geo.geoPosition} coordinate point to search for in map interface
+   *    gcs.
    */
   this.pointSearch = function (coordinate) {
     if (m_quadFeature && m_info) {

--- a/src/pointFeature.js
+++ b/src/pointFeature.js
@@ -203,6 +203,7 @@ var pointFeature = function (arg) {
    */
   this.pointSearch = function (p) {
     var min, max, data, idx = [], found = [], ifound = [], map, pt,
+        fgcs = m_this.gcs(), // this feature's gcs
         corners,
         stroke = m_this.style.get('stroke'),
         strokeWidth = m_this.style.get('strokeWidth'),
@@ -224,10 +225,10 @@ var pointFeature = function (arg) {
     pt = map.gcsToDisplay(p);
     // check all corners to make sure we handle rotations
     corners = [
-      map.displayToGcs({x: pt.x - m_maxRadius, y: pt.y - m_maxRadius}),
-      map.displayToGcs({x: pt.x + m_maxRadius, y: pt.y - m_maxRadius}),
-      map.displayToGcs({x: pt.x - m_maxRadius, y: pt.y + m_maxRadius}),
-      map.displayToGcs({x: pt.x + m_maxRadius, y: pt.y + m_maxRadius})
+      map.displayToGcs({x: pt.x - m_maxRadius, y: pt.y - m_maxRadius}, fgcs),
+      map.displayToGcs({x: pt.x + m_maxRadius, y: pt.y - m_maxRadius}, fgcs),
+      map.displayToGcs({x: pt.x - m_maxRadius, y: pt.y + m_maxRadius}, fgcs),
+      map.displayToGcs({x: pt.x + m_maxRadius, y: pt.y + m_maxRadius}, fgcs)
     ];
     min = {
       x: Math.min(corners[0].x, corners[1].x, corners[2].x, corners[3].x),
@@ -250,7 +251,7 @@ var pointFeature = function (arg) {
       rad = radius(data[i], i);
       rad += stroke(data[i], i) ? strokeWidth(data[i], i) : 0;
       rad2 = rad * rad;
-      p = map.gcsToDisplay(p);
+      p = map.gcsToDisplay(p, fgcs);
       dx = p.x - pt.x;
       dy = p.y - pt.y;
       if (dx * dx + dy * dy <= rad2) {

--- a/src/polygonFeature.js
+++ b/src/polygonFeature.js
@@ -1,6 +1,7 @@
 var $ = require('jquery');
 var inherit = require('./inherit');
 var feature = require('./feature');
+var transform = require('./transform');
 
 /**
  * Polygon feature specification.
@@ -212,14 +213,18 @@ var polygonFeature = function (arg) {
    * Point search method for selection api.  Returns markers containing the
    * given point.
    *
-   * @argument {object} coordinate
-   * @returns {object}
+   * @param {geo.geoPosition} coordinate point to search for in map interface
+   *    gcs.
+   * @returns {object} An object with `index`: a list of quad indices, and
+   *    `found`: a list of quads that contain the specified coordinate.
    */
   this.pointSearch = function (coordinate) {
-    var found = [], indices = [], data = m_this.data();
+    var found = [], indices = [], data = m_this.data(),
+        map = m_this.layer().map(),
+        pt = transform.transformCoordinates(map.ingcs(), m_this.gcs(), coordinate);
     m_coordinates.forEach(function (coord, i) {
       var inside = util.pointInPolygon(
-        coordinate,
+        pt,
         coord.outer,
         coord.inner,
         coord.range

--- a/src/quadFeature.js
+++ b/src/quadFeature.js
@@ -141,8 +141,8 @@ var quadFeature = function (arg) {
    * Point search method for selection api.  Returns markers containing the
    * given point.
    *
-   * @param {object} coordinate Coordinate in input gcs to check if it is
-   *    located in any quad.
+   * @param {geo.geoPosition} coordinate Coordinate in input gcs to check if it
+   *    is located in any quad in map interface gcs.
    * @returns {object} An object with `index`: a list of quad indices, and
    *    `found`: a list of quads that contain the specified coordinate.
    */

--- a/tests/cases/pointFeature.js
+++ b/tests/cases/pointFeature.js
@@ -142,6 +142,12 @@ describe('geo.pointFeature', function () {
       }).toThrow(new Error('no width'));
       /* Stop throwing the exception */
       point.style('strokeWidth', 2);
+      /* Test with an alternate gcs; pointSearch always uses the map's ingcs */
+      point.gcs(map.gcs());
+      point.data([{x: 2226390, y: 1118890}]);
+      pt = point.pointSearch({x: 20, y: 10});
+      expect(pt.index).toEqual([0]);
+      expect(pt.found.length).toBe(1);
     });
     it('boxSearch', function () {
       var map, layer, point, data = testPoints, idx;


### PR DESCRIPTION
`pointSearch` gets a point in the map's interface gcs.  Features' gcs defaults to the map's interface gcs.  If the feature has a different gcs, some pointSearch functions did the wrong thing; this has been fixed, and the feature resolution of gcs has been slightly simplified.