### PR TITLE
Don't create intermediate colinear points on a line.

### DIFF
--- a/src/annotationLayer.js
+++ b/src/annotationLayer.js
@@ -30,9 +30,13 @@ var textFeature = require('./textFeature');
  * @param {number} [args.adjacentPointProximity=5] The minimum distance in
  *    display coordinates (pixels) between two adjacent points when creating a
  *    polygon or line.  A value of 0 requires an exact match.
- * @param {number} [args.continousPointProximity=5] The minimum distance in
+ * @param {number} [args.continuousPointProximity=5] The minimum distance in
  *    display coordinates (pixels) between two adjacent points when dragging
  *    to create an annotation.  `false` disables continuous drawing mode.
+ * @param {number} [args.continuousPointColinearity=1.0deg] The minimum
+ *    angle between a series of three points when dragging to not interpret
+ *    them as colinear.  Only applies if `continuousPointProximity` is not
+ *    `false`.
  * @param {number} [args.finalPointProximity=10] The maximum distance in
  *    display coordinates (pixels) between the starting point and the mouse
  *    coordinates to signal closing a polygon.  A value of 0 requires an exact
@@ -105,6 +109,9 @@ var annotationLayer = function (args) {
     // in pixels; set to continuousPointProximity to false to disable
     // continuous drawing modes.
     continuousPointProximity: 5,
+    // in radians, minimum angle between continuous points to interpret them as
+    // being coliner
+    continuousPointColinearity: 1.0 * Math.PI / 180,
     finalPointProximity: 10,  // in pixels, 0 is exact
     showLabels: true
   }, args);

--- a/tests/cases/annotation.js
+++ b/tests/cases/annotation.js
@@ -848,6 +848,31 @@ describe('geo.annotation', function () {
       expect(ann.options('vertices').length).toBe(3);
       expect(ann.processAction(evt)).not.toBe(true);
       expect(ann.options('vertices').length).toBe(3);
+      // add a point that will be colinear with the next one
+      var halfway = {
+        x: (vertices[1].x + vertices[2].x) / 2,
+        y: (vertices[1].y + vertices[2].y) / 2
+      };
+      evt = {
+        state: {action: geo.geo_action.annotation_line},
+        mouse: {
+          map: halfway,
+          mapgcs: map.displayToGcs(halfway, null)
+        }
+      };
+      expect(ann.processAction(evt)).toBe(true);
+      expect(ann.options('vertices').length).toBe(4);
+      evt = {
+        state: {action: geo.geo_action.annotation_line},
+        mouse: {
+          map: vertices[2],
+          mapgcs: map.displayToGcs(vertices[2], null)
+        }
+      };
+      // a new colinear point will replace the previous point, so we still have
+      // the same point count
+      expect(ann.processAction(evt)).toBe(true);
+      expect(ann.options('vertices').length).toBe(4);
     });
   });
 


### PR DESCRIPTION
When dragging a line annotation, don't create points that are nearly colinear.

This only applies to the action of dragging; programmatically, you can create points anywhere that is desired.