### PR TITLE
Use the average perimeter as the center of a polygon or line.

### DIFF
--- a/src/annotation.js
+++ b/src/annotation.js
@@ -131,26 +131,43 @@ var annotation = function (type, args) {
   };
 
   /**
-   * Return the coordinate associated with the label.
+   * Return the coordinate associated with the center of the annotation.
    *
-   * @returns {geo.geoPosition|undefined} The map gcs position for the label,
+   * @returns {geo.geoPosition|undefined} The map gcs position for the center,
    *    or `undefined` if no such position exists.
    */
-  this._labelPosition = function () {
-    var coor = this._coordinates(), position = {x: 0, y: 0}, i;
+  this._centerPosition = function () {
+    var coor = this._coordinates(), position, p0, p1, w, sumw, i;
     if (!coor || !coor.length) {
       return undefined;
     }
     if (coor.length === 1) {
       return coor[0];
     }
+    position = {x: 0, y: 0};
+    sumw = 0;
+    p0 = coor[coor.length - 1];
     for (i = 0; i < coor.length; i += 1) {
-      position.x += coor[i].x;
-      position.y += coor[i].y;
+      p1 = p0;
+      p0 = coor[i];
+      w = Math.sqrt(Math.pow(p1.x - p0.x, 2) + Math.pow(p1.y - p0.y, 2));
+      position.x += (p0.x + p1.x) * w;
+      position.y += (p0.y + p1.y) * w;
+      sumw += 2 * w;
     }
-    position.x /= coor.length;
-    position.y /= coor.length;
-    return position;
+    position.x /= sumw;
+    position.y /= sumw;
+    return sumw ? position : p0;  // return p0 if all points are the same
+  };
+
+  /**
+   * Return the coordinate associated with the label.
+   *
+   * @returns {geo.geoPosition|undefined} The map gcs position for the label,
+   *    or `undefined` if no such position exists.
+   */
+  this._labelPosition = function () {
+    return this._centerPosition();
   };
 
   /**

--- a/src/annotation.js
+++ b/src/annotation.js
@@ -131,43 +131,13 @@ var annotation = function (type, args) {
   };
 
   /**
-   * Return the coordinate associated with the center of the annotation.
-   *
-   * @returns {geo.geoPosition|undefined} The map gcs position for the center,
-   *    or `undefined` if no such position exists.
-   */
-  this._centerPosition = function () {
-    var coor = this._coordinates(), position, p0, p1, w, sumw, i;
-    if (!coor || !coor.length) {
-      return undefined;
-    }
-    if (coor.length === 1) {
-      return coor[0];
-    }
-    position = {x: 0, y: 0};
-    sumw = 0;
-    p0 = coor[coor.length - 1];
-    for (i = 0; i < coor.length; i += 1) {
-      p1 = p0;
-      p0 = coor[i];
-      w = Math.sqrt(Math.pow(p1.x - p0.x, 2) + Math.pow(p1.y - p0.y, 2));
-      position.x += (p0.x + p1.x) * w;
-      position.y += (p0.y + p1.y) * w;
-      sumw += 2 * w;
-    }
-    position.x /= sumw;
-    position.y /= sumw;
-    return sumw ? position : p0;  // return p0 if all points are the same
-  };
-
-  /**
    * Return the coordinate associated with the label.
    *
    * @returns {geo.geoPosition|undefined} The map gcs position for the label,
    *    or `undefined` if no such position exists.
    */
   this._labelPosition = function () {
-    return this._centerPosition();
+    return util.centerFromPerimeter(this._coordinates());
   };
 
   /**

--- a/src/util/index.js
+++ b/src/util/index.js
@@ -746,6 +746,39 @@ var util = module.exports = {
   },
 
   /**
+   * Return the coordinate associated with the center of the perimeter formed
+   * from a list of points.
+   *
+   * @param {geo.geoPosition[]} coor An array of coordinates.
+   * @returns {geo.geoPosition|undefined} The position for the center, or
+   *    `undefined` if no such position exists.
+   */
+  centerFromPerimeter: function (coor) {
+    var position, p0, p1, w, sumw, i;
+    if (!coor || !coor.length) {
+      return;
+    }
+    if (coor.length === 1) {
+      return {x: coor[0].x, y: coor[0].y};
+    }
+    position = {x: 0, y: 0};
+    sumw = 0;
+    p0 = coor[coor.length - 1];
+    for (i = 0; i < coor.length; i += 1) {
+      p1 = p0;
+      p0 = coor[i];
+      w = Math.sqrt(Math.pow(p1.x - p0.x, 2) + Math.pow(p1.y - p0.y, 2));
+      position.x += (p0.x + p1.x) * w;
+      position.y += (p0.y + p1.y) * w;
+      sumw += 2 * w;
+    }
+    position.x /= sumw;
+    position.y /= sumw;
+    // return a copy of p0 if all points are the same
+    return sumw ? position : {x: p0.x, y: p0.y};
+  },
+
+  /**
    * Escape any character in a string that has a code point >= 127.
    *
    * @param {string} text The string to escape.

--- a/src/util/index.js
+++ b/src/util/index.js
@@ -747,7 +747,10 @@ var util = module.exports = {
 
   /**
    * Return the coordinate associated with the center of the perimeter formed
-   * from a list of points.
+   * from a list of points.  This averages all of the vertices in the perimeter
+   * weighted by the line length on either side of each point.  Functionally,
+   * this is the same as the average of all the points of the lines of the
+   * perimeter.
    *
    * @param {geo.geoPosition[]} coor An array of coordinates.
    * @returns {geo.geoPosition|undefined} The position for the center, or

--- a/tests/cases/annotation.js
+++ b/tests/cases/annotation.js
@@ -257,7 +257,9 @@ describe('geo.annotation', function () {
       ann._coordinates = function () {
         return [{x: 1, y: 2}, {x: 3, y: 5}, {x: 8, y: 11}];
       };
-      expect(ann._labelPosition()).toEqual({x: 4, y: 6});
+      var pos = ann._labelPosition();
+      expect(pos.x).toBeCloseTo(4.447);
+      expect(pos.y).toBeCloseTo(6.539);
     });
     it('labelRecord', function () {
       var ann = geo.annotation.annotation('test', {

--- a/tests/cases/util.js
+++ b/tests/cases/util.js
@@ -32,4 +32,17 @@ describe('geo.util', function () {
     expect(({}) instanceof iframeWindow.Object).toBe(false);
     iframe.remove();
   });
+
+  it('centerFromPerimter', function () {
+    expect(util.centerFromPerimeter()).toBe(undefined);
+    expect(util.centerFromPerimeter([])).toBe(undefined);
+    expect(util.centerFromPerimeter([{x: 1, y: 1}])).toEqual({x: 1, y: 1});
+    expect(util.centerFromPerimeter([{x: 1, y: 1}, {x: 1, y: 1}])).toEqual({x: 1, y: 1});
+    expect(util.centerFromPerimeter([
+        {x: 1, y: 1}, {x: 3, y: 1}, {x: 3, y: 3}, {x: 1, y: 3}
+    ])).toEqual({x: 2, y: 2});
+    expect(util.centerFromPerimeter([
+        {x: 1, y: 1}, {x: 3, y: 1}, {x: 5, y: 1}, {x: 5, y: 3}, {x: 1, y: 3}
+    ])).toEqual({x: 3, y: 2});
+  });
 });


### PR DESCRIPTION
When a polygon has many points near each other in one area and few along the opposite part of the perimeter, this produces a nicer center.