### PR TITLE
When doing a pointSearch on polygons, include strokes.

### DIFF
--- a/src/polygonFeature.js
+++ b/src/polygonFeature.js
@@ -219,7 +219,7 @@ var polygonFeature = function (arg) {
    *    `found`: a list of quads that contain the specified coordinate.
    */
   this.pointSearch = function (coordinate) {
-    var found = [], indices = [], data = m_this.data(),
+    var found = [], indices = [], irecord = {}, data = m_this.data(),
         map = m_this.layer().map(),
         pt = transform.transformCoordinates(map.ingcs(), m_this.gcs(), coordinate);
     m_coordinates.forEach(function (coord, i) {
@@ -231,9 +231,20 @@ var polygonFeature = function (arg) {
       );
       if (inside) {
         indices.push(i);
+        irecord[i] = true;
         found.push(data[i]);
       }
     });
+    if (m_lineFeature) {
+      var lineFound = m_lineFeature.pointSearch(coordinate);
+      lineFound.found.forEach(function (lineData) {
+        if (lineData.length && lineData[0].length === 4 && !irecord[lineData[0][3]]) {
+          indices.push(lineData[0][3]);
+          irecord[lineData[0][3]] = true;
+          found.push(data[lineData[0][3]]);
+        }
+      });
+    }
     return {
       index: indices,
       found: found

--- a/tests/cases/polygonFeature.js
+++ b/tests/cases/polygonFeature.js
@@ -146,9 +146,10 @@ describe('geo.polygonFeature', function () {
   describe('Public utility methods', function () {
     describe('pointSearch', function () {
       it('basic usage', function () {
+        mockVGLRenderer();
         var map, layer, polygon, data, pt;
         map = createMap();
-        layer = map.createLayer('feature', {renderer: null});
+        layer = map.createLayer('feature', {renderer: 'vgl'});
         polygon = geo.polygonFeature({layer: layer});
         polygon._init();
         data = testPolygons;
@@ -174,6 +175,12 @@ describe('geo.polygonFeature', function () {
         pt = polygon.pointSearch({x: 60, y: 13});
         expect(pt.index).toEqual([]);
         expect(pt.found.length).toBe(0);
+
+        // enable stroke and test very close, but outside, of an edge
+        polygon.style({stroke: true, strokeWidth: 20});
+        pt = polygon.pointSearch({x: 5, y: 2.499});
+        expect(pt.index).toEqual([0]);
+        restoreVGLRenderer();
       });
     });
   });


### PR DESCRIPTION
Prior to this, only the interior of the polygon was considered.