### PR TITLE
Display-gcs conversion functions can now handle arrays of points.

### DIFF
--- a/src/camera.js
+++ b/src/camera.js
@@ -517,7 +517,7 @@
       point = this.worldToDisplay4(
         [point.x, point.y, z, w]
       );
-      return {x: point[0], y: point[1], z: point[2]};
+      return {x: point[0], y: point[1]};
     };
 
     /**

--- a/src/map.js
+++ b/src/map.js
@@ -715,12 +715,16 @@ var map = function (arg) {
   /**
    * Convert from gcs coordinates to map world coordinates.
    *
-   * @param {geo.geoPosition} c The input coordinate to convert.
+   * @param {geo.geoPosition|geo.geoPosition[]} c The input coordinate to
+   *    convert.
    * @param {string|geo.transform|null} [gcs] Input gcs.  `undefined` to use
    *    the interface gcs, `null` to use the map gcs, or any other transform.
-   * @returns {geo.worldPosition} World space coordinates.
+   * @returns {geo.worldPosition|geo.worldPosition[]} World space coordinates.
    */
   this.gcsToWorld = function (c, gcs) {
+    if (Array.isArray(c)) {
+      return c.map(function (pt) { return m_this.gcsToWorld(pt, gcs); });
+    }
     gcs = (gcs === null ? m_gcs : (gcs === undefined ? m_ingcs : gcs));
     if (gcs !== m_gcs) {
       c = transform.transformCoordinates(gcs, m_gcs, c);
@@ -739,12 +743,16 @@ var map = function (arg) {
   /**
    * Convert from map world coordinates to gcs coordinates.
    *
-   * @param {geo.worldPosition} c The input coordinate to convert.
+   * @param {geo.worldPosition|geo.worldPosition[]} c The input coordinate to
+   *    convert.
    * @param {string|geo.transform|null} [gcs] output gcs.  `undefined` to use
    *    the interface gcs, `null` to use the map gcs, or any other transform.
-   * @returns {geo.geoPosition} GCS space coordinates.
+   * @returns {geo.geoPosition|geo.geoPosition[]} GCS space coordinates.
    */
   this.worldToGcs = function (c, gcs) {
+    if (Array.isArray(c)) {
+      return c.map(function (pt) { return m_this.worldToGcs(pt, gcs); });
+    }
     if (m_origin.x || m_origin.y || m_origin.z) {
       c = transform.affineInverse(
         {origin: m_origin},
@@ -764,10 +772,12 @@ var map = function (arg) {
    * Convert from gcs coordinates to display coordinates.  This is identical to
    * calling `gcsToWorld` and then `worldToDisplay`.
    *
-   * @param {geo.geoPosition} c The input coordinate to convert.
+   * @param {geo.geoPosition|geo.geoPosition[]} c The input coordinate to
+   *    convert.
    * @param {string|geo.transform|null} [gcs] Input gcs.  `undefined` to use
    *    the interface gcs, `null` to use the map gcs, or any other transform.
-   * @returns {geo.screenPosition} Display space coordinates.
+   * @returns {geo.screenPosition|geo.screenPosition[]} Display space
+   *    coordinates.
    */
   this.gcsToDisplay = function (c, gcs) {
     c = m_this.gcsToWorld(c, gcs);
@@ -778,10 +788,15 @@ var map = function (arg) {
    * Convert from world coordinates to display coordinates using the attached
    * camera.
    *
-   * @param {geo.worldPosition} c The input coordinate to convert.
-   * @returns {geo.screenPosition} Display space coordinates.
+   * @param {geo.worldPosition|geo.worldPosition[]} c The input coordinate to
+   *    convert.
+   * @returns {geo.screenPosition|geo.screenPosition[]} Display space
+   *    coordinates.
    */
   this.worldToDisplay = function (c) {
+    if (Array.isArray(c)) {
+      return c.map(function (pt) { return m_camera.worldToDisplay(pt); });
+    }
     return m_camera.worldToDisplay(c);
   };
 
@@ -789,10 +804,11 @@ var map = function (arg) {
    * Convert from display to gcs coordinates.  This is identical to calling
    * `displayToWorld` and then `worldToGcs`.
    *
-   * @param {geo.screenPosition} c The input display coordinate to convert.
+   * @param {geo.screenPosition|geo.screenPosition[]} c The input display
+   *    coordinate to convert.
    * @param {string|geo.transform|null} [gcs] Output gcs.  `undefined` to use
    *    the interface gcs, `null` to use the map gcs, or any other transform.
-   * @returns {geo.geoPosition} GCS space coordinates.
+   * @returns {geo.geoPosition|geoPosition[]} GCS space coordinates.
    */
   this.displayToGcs = function (c, gcs) {
     c = m_this.displayToWorld(c); // done via camera
@@ -803,10 +819,14 @@ var map = function (arg) {
    * Convert from display coordinates to world coordinates using the attached
    * camera.
    *
-   * @param {geo.screenPosition} c The input coordinate to convert.
-   * @returns {geo.worldPosition} World space coordinates.
+   * @param {geo.screenPosition|geo.screenPosition[]} c The input coordinate to
+   *    convert.
+   * @returns {geo.worldPosition|geo.worldPosition[]} World space coordinates.
    */
   this.displayToWorld = function (c) {
+    if (Array.isArray(c)) {
+      return c.map(function (pt) { return m_camera.displayToWorld(pt); });
+    }
     return m_camera.displayToWorld(c);
   };
 

--- a/tests/cases/map.js
+++ b/tests/cases/map.js
@@ -683,7 +683,36 @@ describe('geo.core.map', function () {
       expect(m.layers().length).toBe(0);
       expect(m2.layers().length).toBe(1);
     });
-
+    it('displayToGcs', function () {
+      var m = createMap(), result;
+      expect(closeToEqual(m.displayToGcs({x: 10, y: 20}), {x: -27.25, y: 13.92, z: 0})).toBe(true);
+      expect(closeToEqual(m.displayToGcs({x: 200, y: 100}), {x: -10.55, y: 7.01, z: 0})).toBe(true);
+      expect(closeToEqual(m.displayToGcs({x: 10, y: 20}, 'EPSG:3857'), {x: -3033021, y: 1565430, z: 0}, 0)).toBe(true);
+      expect(closeToEqual(m.displayToGcs({x: 200, y: 100}, 'EPSG:3857'), {x: -1174073, y: 782715, z: 0}, 0)).toBe(true);
+      result = m.displayToGcs([{x: 10, y: 20}, {x: 200, y: 100}]);
+      expect(closeToEqual(result[0], {x: -27.25, y: 13.92, z: 0})).toBe(true);
+      expect(closeToEqual(result[1], {x: -10.55, y: 7.01, z: 0})).toBe(true);
+      result = m.displayToGcs([{x: 10, y: 20}, {x: 200, y: 100}], 'EPSG:3857');
+      expect(closeToEqual(result[0], {x: -3033021, y: 1565430, z: 0}, 0)).toBe(true);
+      expect(closeToEqual(result[1], {x: -1174073, y: 782715, z: 0}, 0)).toBe(true);
+      m.bounds({left: -80, top: 50, right: -40, bottom: 40});
+      expect(closeToEqual(m.displayToGcs({x: 10, y: 20}), {x: -79.38, y: 51.83, z: 0})).toBe(true);
+    });
+    it('gcsToDisplay', function () {
+      var m = createMap(), result;
+      expect(closeToEqual(m.gcsToDisplay({x: -27.25, y: 13.92}), {x: 10, y: 20}, 1)).toBe(true);
+      expect(closeToEqual(m.gcsToDisplay({x: -10.55, y: 7.01}), {x: 200, y: 100}, 1)).toBe(true);
+      expect(closeToEqual(m.gcsToDisplay({x: -3033021, y: 1565430}, 'EPSG:3857'), {x: 10, y: 20})).toBe(true);
+      expect(closeToEqual(m.gcsToDisplay({x: -1174073, y: 782715}, 'EPSG:3857'), {x: 200, y: 100})).toBe(true);
+      result = m.gcsToDisplay([{x: -27.25, y: 13.92}, {x: -10.55, y: 7.01}]);
+      expect(closeToEqual(result[0], {x: 10, y: 20}, 1)).toBe(true);
+      expect(closeToEqual(result[1], {x: 200, y: 100}, 1)).toBe(true);
+      result = m.gcsToDisplay([{x: -3033021, y: 1565430}, {x: -1174073, y: 782715}], 'EPSG:3857');
+      expect(closeToEqual(result[0], {x: 10, y: 20})).toBe(true);
+      expect(closeToEqual(result[1], {x: 200, y: 100})).toBe(true);
+      m.bounds({left: -80, top: 50, right: -40, bottom: 40});
+      expect(closeToEqual(m.gcsToDisplay({x: -79.375, y: 51.83}), {x: 10, y: 20}, 1)).toBe(true);
+    });
   });
   describe('screenshot', function () {
     var m, layer1, layer2, l1, l2;


### PR DESCRIPTION
Allow `map.gcsToDisplay` and `map.displayToGcs` to work on arrays of points in addition to single points.

`camera.worldToDisplay` no longer returns a z value, since it was a meaningless value (z is not used as part of the input).