### PR TITLE
Reduce webpack output when run with karma.

### DIFF
--- a/karma-base.js
+++ b/karma-base.js
@@ -304,6 +304,9 @@ module.exports = function (config) {
       },
       resolve: webpack_config.resolve,
       plugins: webpack_config.exposed_plugins
+    },
+    webpackMiddleware: {
+      stats: 'errors-only'
     }
   };
   newConfig.preprocessors[test_case] = ['webpack', 'sourcemap'];


### PR DESCRIPTION
This makes running single tests easier to look at.  For instance, when I run `GEOJS_TEST_CASE=tests/cases/annotation.js npx karma start --single-run`, I no longer see a few hundred lines of webpack successful build information.