### PR TITLE
Improve resolving optional dependencies.

### DIFF
--- a/src/choroplethFeature.js
+++ b/src/choroplethFeature.js
@@ -40,7 +40,7 @@ var choroplethFeature = function (arg) {
   /**
    * @private
    */
-  var d3 = require('d3'),
+  var d3 = require('./d3/d3Renderer').d3,
       m_this = this,
       s_init = this._init,
       m_choropleth = $.extend({},

--- a/src/d3/d3Renderer.js
+++ b/src/d3/d3Renderer.js
@@ -21,7 +21,7 @@ var renderer = require('../renderer');
 var d3Renderer = function (arg) {
   'use strict';
 
-  var d3 = require('d3');
+  var d3 = d3Renderer.d3;
   var object = require('./object');
   var util = require('../util');
   var geo_event = require('../event');
@@ -676,11 +676,12 @@ registerRenderer('d3', d3Renderer);
    * @returns {boolean} true if available.
    */
   d3Renderer.supported = function () {
-    if (!__webpack_modules__[require.resolveWeak('d3')]) {  // eslint-disable-line
-      return false;
-    }
-    var d3 = require('d3');
-    return d3 !== undefined;
+    delete d3Renderer.d3;
+    // webpack expects optional dependencies to be wrapped in a try-catch
+    try {
+      d3Renderer.d3 = require('d3');
+    } catch (_error) {}
+    return d3Renderer.d3 !== undefined;
   };
 
   /**
@@ -692,6 +693,8 @@ registerRenderer('d3', d3Renderer);
   d3Renderer.fallback = function () {
     return null;
   };
+
+  d3Renderer.supported();  // cache reference to d3 if it is available
 })();
 
 module.exports = d3Renderer;

--- a/src/d3/lineFeature.js
+++ b/src/d3/lineFeature.js
@@ -16,7 +16,7 @@ var d3_lineFeature = function (arg) {
     return new d3_lineFeature(arg);
   }
 
-  var d3 = require('d3');
+  var d3 = require('./d3Renderer').d3;
   var object = require('./object');
   var timestamp = require('../timestamp');
   var util = require('../util');

--- a/src/d3/pathFeature.js
+++ b/src/d3/pathFeature.js
@@ -17,7 +17,7 @@ var d3_pathFeature = function (arg) {
   }
 
   var $ = require('jquery');
-  var d3 = require('d3');
+  var d3 = require('./d3Renderer').d3;
   var object = require('./object');
   var timestamp = require('../timestamp');
 

--- a/src/d3/quadFeature.js
+++ b/src/d3/quadFeature.js
@@ -17,7 +17,7 @@ var d3_quadFeature = function (arg) {
   }
 
   var $ = require('jquery');
-  var d3 = require('d3');
+  var d3 = require('./d3Renderer').d3;
   var object = require('./object');
 
   quadFeature.call(this, arg);

--- a/src/d3/vectorFeature.js
+++ b/src/d3/vectorFeature.js
@@ -18,7 +18,7 @@ var d3_vectorFeature = function (arg) {
 
   var object = require('./object');
   var timestamp = require('../timestamp');
-  var d3 = require('d3');
+  var d3 = require('./d3Renderer').d3;
 
   arg = arg || {};
   vectorFeature.call(this, arg);

--- a/src/mapInteractor.js
+++ b/src/mapInteractor.js
@@ -703,12 +703,14 @@ var mapInteractor = function (args) {
     }
     $node.toggleClass('highlight-focus',
       !!(m_boundKeys && m_boundKeys.length && m_options.keyboard.focusHighlight));
-
     // bind touch events
     if ((m_this.hasTouchSupport() || m_options.alwaysTouch) &&
-        (usedInputs.pan || usedInputs.rotate) &&
-        __webpack_modules__[require.resolveWeak('hammerjs')]) { // eslint-disable-line
-      var Hammer = require('hammerjs');
+        (usedInputs.pan || usedInputs.rotate)) {
+      // webpack expects optional dependencies to be wrapped in a try-catch
+      var Hammer;
+      try {
+        Hammer = require('hammerjs');
+      } catch (_error) {}
       if (Hammer !== undefined) {
         var recog = [],
             touchEvents = ['hammer.input'];

--- a/src/ui/colorLegendWidget.js
+++ b/src/ui/colorLegendWidget.js
@@ -1,4 +1,4 @@
-var d3 = require('d3');
+var d3 = require('../d3/d3Renderer').d3;
 var domWidget = require('./domWidget');
 var inherit = require('../inherit');
 var registerWidget = require('../registry').registerWidget;

--- a/src/ui/legendWidget.js
+++ b/src/ui/legendWidget.js
@@ -16,7 +16,7 @@ var legendWidget = function (arg) {
   }
   svgWidget.call(this, arg);
 
-  var d3 = require('d3');
+  var d3 = require('../d3/d3Renderer').d3;
   var geo_event = require('../event');
 
   /** @private */

--- a/src/ui/sliderWidget.js
+++ b/src/ui/sliderWidget.js
@@ -16,7 +16,7 @@ var sliderWidget = function (arg) {
   }
   svgWidget.call(this, arg);
 
-  var d3 = require('d3');
+  var d3 = require('../d3/d3Renderer').d3;
   var geo_event = require('../event');
 
   var m_this = this,

--- a/tests/cases/mapInteractor.js
+++ b/tests/cases/mapInteractor.js
@@ -1857,6 +1857,7 @@ describe('Optional Dependencies', function () {
   it('test missing Hammer library', function () {
     var old = __webpack_modules__[require.resolveWeak('hammerjs')];  // eslint-disable-line
     __webpack_modules__[require.resolveWeak('hammerjs')] = null;  // eslint-disable-line
+    delete __webpack_require__.c[require.resolveWeak('hammerjs')];  // eslint-disable-line
     var map = geo.map({node: '#mapNode1'}),
         interactor = map.interactor();
 
@@ -1871,5 +1872,6 @@ describe('Optional Dependencies', function () {
       'panend', {touch: true, center: {x: 40, y: 20}});
     expect(map.center().x).toBeCloseTo(0);
     __webpack_modules__[require.resolveWeak('hammerjs')] = old;  // eslint-disable-line
+    delete __webpack_require__.c[require.resolveWeak('hammerjs')];  // eslint-disable-line
   });
 });

--- a/tests/cases/renderers.js
+++ b/tests/cases/renderers.js
@@ -73,8 +73,10 @@ describe('renderers', function () {
 
       var oldd3 = __webpack_modules__[require.resolveWeak('d3')];  // eslint-disable-line
       __webpack_modules__[require.resolveWeak('d3')] = null;  // eslint-disable-line
+      delete __webpack_require__.c[require.resolveWeak('d3')];  // eslint-disable-line
       expect(geo.checkRenderer('d3')).toBe(null);
       __webpack_modules__[require.resolveWeak('d3')] = oldd3;  // eslint-disable-line
+      delete __webpack_require__.c[require.resolveWeak('d3')];  // eslint-disable-line
       expect(geo.checkRenderer('d3')).toBe('d3');
 
       mockVGLRenderer(false);


### PR DESCRIPTION
webpack makes any dependency that is not in a try-catch block a required dependency.  Adjust code to be in conformance with this.  All require statements for `d3` and `hammerjs` are now guarded.  Most `d3` references are now via `d3Renderer.d3` to avoid having to have conditionals in every file.