### PR TITLE
Use the latest version of Firefox in CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,8 @@ node_js:
   - 4
 
 addons:
-  # firefox: latest  # version 55.0 has an issue.
-  firefox: 54.0.1
+  firefox: latest  # version 55.0 - 57.x have an issue with screenshots.
+  # firefox: 54.0.1
   chrome: stable
   apt:
     packages:


### PR DESCRIPTION
Firefox versions 55.0 - 57.x had a bug that caused them to fail to take screenshots that included img elements (https://bugzilla.mozilla.org/show_bug.cgi?id=1409992).  Now that this has been fixed, resume testing with the latest Firefox.