### PR TITLE
Improve Javascript error logging when Hammer.js lookup fails

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -47,7 +47,10 @@ module.exports = {
       root: 'Hammer',
       commonjs: 'hammerjs',
       commonjs2: 'hammerjs',
-      amd: 'hammerjs'
+      amd: 'hammerjs',
+      // Since GeoJS's libraryTarget is "umd", defining this (undocumented) external library type
+      // will allow Webpack to create a better error message if a "hammerjs" import fails
+      umd: 'hammerjs'
     }
   },
   plugins: [


### PR DESCRIPTION
The code supporting this is at: https://github.com/webpack/webpack/blob/v1.15.0/lib/ExternalModule.js#L63