### PR TITLE
Enable Color Legend example

### DIFF
--- a/examples/color-legend/example.json
+++ b/examples/color-legend/example.json
@@ -4,5 +4,5 @@
   "about": {
     "text": "This example shows how to create a discrete or continous color legends."
   },
-  "disabled": true
+  "disabled": false
 }


### PR DESCRIPTION
Enable the color legend example to be shown on the examples page because I think it has value to show the example and also one of the tutorials is using the legend.