### PR TITLE
Fix testing with Chrome 65.

### DIFF
--- a/tests/gl-cases/glLines.js
+++ b/tests/gl-cases/glLines.js
@@ -140,7 +140,9 @@ describe('glLines', function () {
 
     myMap.draw();
 
-    imageTest.imageTest('glLinesOpts', null, 0.0015, done, myMap.onIdle, 0, 2);
+    // maximum error is 0.0030 because of a change in Chrome 65.  When new
+    // versions are released, see if this can be moved back to 0.0015
+    imageTest.imageTest('glLinesOpts', null, 0.0030, done, myMap.onIdle, 0, 2);
 
   }, 10000);
 });

--- a/tests/gl-cases/glPolygons.js
+++ b/tests/gl-cases/glPolygons.js
@@ -2446,7 +2446,9 @@ describe('glPolygons', function () {
       layer: layer
     }).read(JSON.stringify(data), function () {
       myMap.draw();
-      imageTest.imageTest('glMultiPolygons', null, 0.0015, done, myMap.onIdle, 0, 2);
+      // maximum error is 0.0030 because of a change in Chrome 65.  When new
+      // versions are released, see if this can be moved back to 0.0015
+      imageTest.imageTest('glMultiPolygons', null, 0.0030, done, myMap.onIdle, 0, 2);
     });
   });
 

--- a/tests/headed-cases/lines.js
+++ b/tests/headed-cases/lines.js
@@ -15,7 +15,9 @@ describe('lines example', function () {
   it('more lines', function (done) {
     base$ = $('iframe#map')[0].contentWindow.jQuery;
     base$('#lines').val(100000).trigger('change');
-    imageTest.imageTest('exampleLines100k', '#map', 0.0015, done, null, 0, 2, '#map.ready[segments="100000"]');
+    // maximum error is 0.0030 because of a change in Chrome 65.  When new
+    // versions are released, see if this can be moved back to 0.0015
+    imageTest.imageTest('exampleLines100k', '#map', 0.0030, done, null, 0, 2, '#map.ready[segments="100000"]');
   }, 10000);
   it('thin preset', function (done) {
     base$('button.preset').eq(1).trigger('click');


### PR DESCRIPTION
Chrome 65 was released 2018-3-6.  With it, some vertices appear odd in GL rendered lines, but only on the headless GL or xvfb tests.  This doesn't affect how the tests are rendered in Chrome 65 on a desktop, so it is likely some sort of Chrome-65-with-mesa issue.  This is not a mesa issue, since it was not updated.

Since this is just a testing artifact, rather than change the baselines, relax the strictness of the image comparison.  Note that if travis allowed pinning to a specific version of Chrome, I'd recommend pinning to version 64 until Chrome fixes their issue.