### PR TITLE
Allow specifying the map's initial maxBounds in a different gcs.

### DIFF
--- a/src/map.js
+++ b/src/map.js
@@ -28,6 +28,8 @@ var sceneObject = require('./sceneObject');
  * @param {number} [arg.maxBounds.right=20037508] The right bound.
  * @param {number} [arg.maxBounds.bottom=-20037508] The bottom bound.
  * @param {number} [arg.maxBounds.top=20037508] The top bound.
+ * @param {number} [arg.maxBounds.gcs=arg.ingcs] The coordinate system for the
+ *   bounds.
  *
  * @param {number} [arg.zoom=4] Initial zoom.
  * @param {object?} [arg.center] Initial map center.
@@ -128,17 +130,17 @@ var map = function (arg) {
    * [0, width] and [0, height] instead. */
   var mcx = ((m_maxBounds.left || 0) + (m_maxBounds.right || 0)) / 2,
       mcy = ((m_maxBounds.bottom || 0) + (m_maxBounds.top || 0)) / 2;
-  m_maxBounds.left = transform.transformCoordinates(m_ingcs, m_gcs, {
+  m_maxBounds.left = transform.transformCoordinates(m_maxBounds.gcs || m_ingcs, m_gcs, {
     x: m_maxBounds.left !== undefined ? m_maxBounds.left : -180, y: mcy
   }).x;
-  m_maxBounds.right = transform.transformCoordinates(m_ingcs, m_gcs, {
+  m_maxBounds.right = transform.transformCoordinates(m_maxBounds.gcs || m_ingcs, m_gcs, {
     x: m_maxBounds.right !== undefined ? m_maxBounds.right : 180, y: mcy
   }).x;
   m_maxBounds.top = (m_maxBounds.top !== undefined ?
-    transform.transformCoordinates(m_ingcs, m_gcs, {
+    transform.transformCoordinates(m_maxBounds.gcs || m_ingcs, m_gcs, {
       x: mcx, y: m_maxBounds.top}).y : m_maxBounds.right);
   m_maxBounds.bottom = (m_maxBounds.bottom !== undefined ?
-    transform.transformCoordinates(m_ingcs, m_gcs, {
+    transform.transformCoordinates(m_maxBounds.gcs || m_ingcs, m_gcs, {
       x: mcx, y: m_maxBounds.bottom}).y : m_maxBounds.left);
   m_unitsPerPixel = (arg.unitsPerPixel || (
     m_maxBounds.right - m_maxBounds.left) / 256);

--- a/tests/cases/map.js
+++ b/tests/cases/map.js
@@ -67,6 +67,8 @@ describe('geo.core.map', function () {
       expect(map.rotation()).toBe(1);
       expect(map.maxBounds().left).toBe(0);
       expect(map.maxBounds().right).toBe(50000);
+      expect(map.maxBounds().top).toBe(0);
+      expect(map.maxBounds().bottom).toBe(40000);
       expect(map.size().width).toBe(640);
       expect(map.zoomRange().max).toEqual(9);
       expect(map.zoomRange().origMin).toEqual(3);
@@ -76,6 +78,14 @@ describe('geo.core.map', function () {
       expect(map.clampBoundsX()).toBe(true);
       expect(map.clampBoundsY()).toBe(false);
       expect(map.clampZoom()).toBe(false);
+      // with gcs specified for maxBounds
+      map = createMap({
+        ingcs: '+proj=longlat +axis=esu',
+        gcs: '+proj=longlat +axis=enu',
+        maxBounds: {left: 0, top: 0, right: 50000, bottom: -40000, gcs: '+proj=longlat +axis=enu'}
+      });
+      expect(map.maxBounds().top).toBe(0);
+      expect(map.maxBounds().bottom).toBe(40000);
     });
   });
 


### PR DESCRIPTION
If the bounds are known in a gcs other than the interface gcs, they had to be converted first.

This change makes it easier to initialize a map with a stereographic projection, where the unitsPerPixel can be specified to determine the scope of the area shown (since it could be infinite).  For example,

```
var gcs = '+proj=stere +lat_0=90 +lat_ts=70 +lon_0=-45 +k=1 +x_0=0 +y_0=0 +a=6378273 +b=6356889.449 +units=m +no_defs'
var unitsPerPixel = 10000
geo.map({
  gcs: gcs, 
  maxBounds: {
    left: -unitsPerPixel * 128, 
    right: unitsPerPixel * 128,
    bottom: -unitsPerPixel * 128,
    top: unitsPerPixel * 128,
    gcs: gcs
  },
   unitsPerPixel: unitsPerPixel
});
```