### PR TITLE
Improve the screenshot by dereferencing CSS urls.

### DIFF
--- a/src/map.js
+++ b/src/map.js
@@ -1688,7 +1688,7 @@ var map = function (arg) {
           drawLayerImageToContext(context, opacity, canvasElem, canvasElem[0]);
         });
       });
-      if (layer.node().children().not('canvas').length) {
+      if (layer.node().children().not('canvas').length || !layer.node().children().length) {
         defer = defer.then(function () {
           return util.htmlToImage(layer.node(), 1).done(function (img) {
             drawLayerImageToContext(context, 1, $([]), img);

--- a/tests/cases/map.js
+++ b/tests/cases/map.js
@@ -6,6 +6,7 @@ describe('geo.core.map', function () {
   var $ = require('jquery');
   var geo = require('../test-utils').geo;
   var createMap = require('../test-utils').createMap;
+  var isPhantomJS = require('../test-utils').isPhantomJS;
   var closeToEqual = require('../test-utils').closeToEqual;
   var mockAnimationFrame = require('../test-utils').mockAnimationFrame;
   var stepAnimationFrame = require('../test-utils').stepAnimationFrame;
@@ -763,7 +764,7 @@ describe('geo.core.map', function () {
         done();
       });
     });
-    it('jpegi via single parameter', function (done) {
+    it('jpeg via single parameter', function (done) {
       m.screenshot({type: 'image/jpeg'}).then(function (result) {
         expect(result).toEqual(ss.jpeg);
         done();
@@ -814,6 +815,21 @@ describe('geo.core.map', function () {
         expect(result).not.toEqual(ss.nobackground);
         done();
       });
+    });
+    it('layer background', function (done) {
+      // this test won't work in PhantomJS.
+      if (!isPhantomJS()) {
+        var layer3 = m.createLayer('ui');
+        layer3.node().css('background-image', 'url(/data/tilefancy.png)');
+        m.screenshot().then(function (result) {
+          expect(result).not.toEqual(ss.basic);
+          expect(result).not.toEqual(ss.nobackground);
+          m.deleteLayer(layer3);
+          done();
+        });
+      } else {
+        done();
+      }
     });
     it('layers in a different order', function (done) {
       m.screenshot([layer2, layer1]).then(function (result) {

--- a/tests/cases/map.js
+++ b/tests/cases/map.js
@@ -830,7 +830,24 @@ describe('geo.core.map', function () {
       } else {
         done();
       }
-    });
+    }, 10000);
+    it('layer css background', function (done) {
+      // this test won't work in PhantomJS.
+      if (!isPhantomJS()) {
+        geo.jQuery('head').append('<link rel="stylesheet" href="/testdata/test.css" type="text/css"/>');
+        var layer3 = m.createLayer('ui');
+        layer3.node().addClass('image-background');
+        layer3.opacity(0.5);
+        m.screenshot().then(function (result) {
+          expect(result).not.toEqual(ss.basic);
+          expect(result).not.toEqual(ss.nobackground);
+          m.deleteLayer(layer3);
+          done();
+        });
+      } else {
+        done();
+      }
+    }, 10000);
     it('layers in a different order', function (done) {
       m.screenshot([layer2, layer1]).then(function (result) {
         // the order doesn't matter

--- a/tests/data/test.css
+++ b/tests/data/test.css
@@ -1,0 +1,3 @@
+.image-background {
+  background-image: url('white.jpg');
+}

--- a/tests/test-utils.js
+++ b/tests/test-utils.js
@@ -304,3 +304,13 @@ module.exports.createMap = function (opts, css) {
   opts.node = node;
   return geo.map(opts);
 };
+
+/**
+ * Return true if the browser is probably PhantomJS.
+ *
+ * @returns {boolean}
+ */
+module.exports.isPhantomJS = function () {
+  // PhantomJS doesn't have Math.log10, but Chrome and Firefox do
+  return !Math.log10;
+};


### PR DESCRIPTION
If CSS included a URL resource, such as for a font or background image, it was not being dereferenced, which would lead to it not rendering as expected on the screenshot.