### PR TITLE
Ensure that GL polygons are built once before their strokes.

### DIFF
--- a/src/gl/polygonFeature.js
+++ b/src/gl/polygonFeature.js
@@ -38,6 +38,7 @@ var gl_polygonFeature = function (arg) {
       m_geometry,
       s_init = this._init,
       s_update = this._update,
+      m_builtOnce,
       m_updateAnimFrameRef;
 
   function createVertexShader() {
@@ -325,6 +326,7 @@ var gl_polygonFeature = function (arg) {
 
     if (!m_this.renderer().contextRenderer().hasActor(m_actor)) {
       m_this.renderer().contextRenderer().addActor(m_actor);
+      m_builtOnce = true;
     }
     m_this.buildTime().modified();
   };
@@ -332,10 +334,12 @@ var gl_polygonFeature = function (arg) {
   /**
    * Update.
    *
-   * @override
+   * @param {object} [opts] Update options.
+   * @param {boolean} [opts.mayDelay] If truthy, wait until the next animation
+   *    frame for the update.
    */
   this._update = function (opts) {
-    if (opts && opts.mayDelay) {
+    if (opts && opts.mayDelay && m_builtOnce) {
       m_updateAnimFrameRef = m_this.layer().map().scheduleAnimationFrame(m_this._update);
       return;
     }


### PR DESCRIPTION
When we build a webgl polygon we attach two vgl actors, one for the polygon and one for the stroke (lines).  Whichever actor gets attached first is drawn first.  We always want to draw the fill before the stroke, but for efficiency it can be deferred an animation frame when there are updates.  The first time this is rendered, don't allow such a delay.  This change ensures that the fill actor is added before the stroke actor.