### PR TITLE
Allow changing the feature.mouseover order.

### DIFF
--- a/src/event.js
+++ b/src/event.js
@@ -324,10 +324,10 @@ geo_event.feature = {
    */
   mouseover:  'geo_feature_mouseover',
   /**
-   * The event contains the `feature`, the `previous` record of data elements
-   * that were under the mouse, and `over`, the new record of data elements that
-   * are unrder the mouse.
-   * @event geo.event.feature.mouseover.order
+   * The event contains the `feature`, the `mouse` record, the `previous`
+   * record of data elements that were under the mouse, and `over`, the new
+   * record of data elements that are unrder the mouse.
+   * @event geo.event.feature.mouseover_order
   */
   mouseover_order: 'geo_feature_mouseover_order',
   /**
@@ -350,6 +350,12 @@ geo_event.feature = {
    * @event geo.event.feature.mouseclick
    */
   mouseclick: 'geo_feature_mouseclick',
+  /**
+   * The event contains the `feature`, the `mouse` record, and `over`, the
+   * record of data elements that are unrder the mouse.
+   * @event geo.event.feature.mouseclick_order
+  */
+  mouseclick_order: 'geo_feature_mouseclick_order',
   /**
    * The event is the feature version of {@link geo.event.brushend}.
    * @event geo.event.feature.brushend

--- a/src/event.js
+++ b/src/event.js
@@ -324,6 +324,13 @@ geo_event.feature = {
    */
   mouseover:  'geo_feature_mouseover',
   /**
+   * The event contains the `feature`, the `previous` record of data elements
+   * that were under the mouse, and `over`, the new record of data elements that
+   * are unrder the mouse.
+   * @event geo.event.feature.mouseover.order
+  */
+  mouseover_order: 'geo_feature_mouseover_order',
+  /**
    * The event is the feature version of {@link geo.event.mouseout}.
    * @event geo.event.feature.mouseout
    */

--- a/src/feature.js
+++ b/src/feature.js
@@ -211,7 +211,7 @@ var feature = function (arg) {
 
     // if we are over more than one item, trigger an event that is allowed to
     // reorder the values in evt.over.index.  Event handlers don't have to
-    // maintain evt.over.data.  Handlers should not modify evt.over.extra or
+    // maintain evt.over.found.  Handlers should not modify evt.over.extra or
     // evt.previous.
     if (over.index.length > 1) {
       m_this.geoTrigger(geo_event.feature.mouseover_order, {
@@ -326,6 +326,16 @@ var feature = function (arg) {
         over = m_this.pointSearch(mouse.geo),
         extra = over.extra || {};
 
+    // if we are over more than one item, trigger an event that is allowed to
+    // reorder the values in evt.over.index.  Event handlers don't have to
+    // maintain evt.over.found.  Handlers should not modify evt.over.extra.
+    if (over.index.length > 1) {
+      m_this.geoTrigger(geo_event.feature.mouseclick_order, {
+        feature: this,
+        mouse: mouse,
+        over: over
+      });
+    }
     mouse.buttonsDown = evt.buttonsDown;
     feature.eventID += 1;
     over.index.forEach(function (i, idx) {

--- a/src/feature.js
+++ b/src/feature.js
@@ -206,7 +206,22 @@ var feature = function (arg) {
     if (!m_selectedFeatures.length && !over.index.length) {
       return;
     }
+
     extra = over.extra || {};
+
+    // if we are over more than one item, trigger an event that is allowed to
+    // reorder the values in evt.over.index.  Event handlers don't have to
+    // maintain evt.over.data.  Handlers should not modify evt.over.extra or
+    // evt.previous.
+    if (over.index.length > 1) {
+      m_this.geoTrigger(geo_event.feature.mouseover_order, {
+        feature: this,
+        mouse: mouse,
+        previous: m_selectedFeatures,
+        over: over
+      });
+    }
+
     // Get the index of the element that was previously on top
     if (m_selectedFeatures.length) {
       lastTop = m_selectedFeatures[m_selectedFeatures.length - 1];
@@ -731,6 +746,25 @@ var feature = function (arg) {
       this._bindMouseHandlers();
     }
     return this;
+  };
+
+  /**
+   * If the selectionAPI is on, then setting
+   * `this.geoOn(geo.event.feature.mouseover_order, this.mouseOverOrderHighestIndex)`
+   * will make it so that the mouseon events prefer the highest index feature.
+   *
+   * @param {geo.event} evt The event; this should be triggered from
+   *    `geo.event.feature.mouseover_order`.
+   */
+  this.mouseOverOrderHighestIndex = function (evt) {
+    // sort the found indices.  The last one is the one "on top".
+    evt.over.index.sort();
+    // this isn't necessary, but ensures that other event handlers have
+    // consistent information
+    var data = evt.feature.data();
+    evt.over.index.forEach(function (di, idx) {
+      evt.over.found[idx] = data[di];
+    });
   };
 
   /**

--- a/tests/cases/feature.js
+++ b/tests/cases/feature.js
@@ -254,6 +254,12 @@ describe('geo.feature', function () {
       feat.updateStyleFromArray('radius', [11, 12, 13, 14], true);
       expect(count).toBe(1);
     });
+    it('mouseOverOrderHighestIndex', function () {
+      var evt = {over: {index: [3, 4, 2], found: []}, feature: feat};
+      expect(feat.mouseOverOrderHighestIndex(evt)).toBe(undefined);
+      expect(evt.over.index).toEqual([2, 3, 4]);
+      expect(evt.over.found.length).toBe(3);
+    });
   });
   describe('Check class accessors', function () {
     var map, layer, feat;

--- a/tests/cases/feature.js
+++ b/tests/cases/feature.js
@@ -90,6 +90,11 @@ describe('geo.feature', function () {
       feat.geoOn(geo.event.feature.brushend, function (evt) { events.brushend = evt; });
       map.interactor().simulateEvent('mousemove', {map: {x: 20, y: 20}});
       expect(events.mouseover.index).toBe(1);
+      points.index = [1, 2];
+      map.interactor().simulateEvent('mousedown', {map: {x: 20, y: 20}, button: 'left'});
+      map.interactor().simulateEvent('mouseup', {map: {x: 20, y: 20}, button: 'left'});
+      expect(events.mouseclick.index).toBe(2);
+      expect(events.mouseclick.top).toBe(true);
     });
     it('_unbindMouseHandlers', function () {
       feat._unbindMouseHandlers();


### PR DESCRIPTION
Add an event that allows changing the selection order for feature.mouseover.  Also, add two common handlers for such ordering.

Specifically, the `geo.event.feature.mouseover_order` event is triggered if the mouse is located on multiple elements of a feature.  The `feature.mouseOverOrderHighestIndex` function will always sort these so that the highest index element is on top.  The `polygonFeature.mouseOverOrderClosestBorder` function will sort polygons so that they are sorted based on how far the mouse is from their borders, with the closest on top.  Note that, as always, the mouse must be within the polygon for it to be considered.