### PR TITLE
Change the font weight on the example and tutorial pages.

### DIFF
--- a/examples/common/examples.css
+++ b/examples/common/examples.css
@@ -9,6 +9,10 @@ html, body {
   user-select: none;
 }
 
+.jumbotron p {
+  font-weight: normal;
+}
+
 .navbar {
   margin: 0;
 }

--- a/tutorials/common/tutorials.css
+++ b/tutorials/common/tutorials.css
@@ -4,6 +4,10 @@ html, body {
   color: black;
 }
 
+.jumbotron p {
+  font-weight: normal;
+}
+
 .navbar {
   margin: 0;
 }


### PR DESCRIPTION
This doesn't affect the built website, only the locally served examples and tutorials pages.  On the pages that list the examples and tutorials, the informational text at the top was set (via bootswatch) to a light weight which made it hard to read.