### PR TITLE
Revert docco to 0.7.0.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1575,9 +1575,9 @@
       "dev": true
     },
     "docco": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/docco/-/docco-0.8.0.tgz",
-      "integrity": "sha512-QcWBDnnGaT+rgC0wqynznXv0/4hd6nAFdWNs2fN4FvkH2yAnCYVeRU7GIZXNCeUQ955Lufq+TmZcSXiBa1cGQQ==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/docco/-/docco-0.7.0.tgz",
+      "integrity": "sha1-1gblqZDLoFLKHhgDqcWH7O48XDg=",
       "dev": true,
       "requires": {
         "commander": "2.15.1",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "codemirror": "^5.15.2",
     "colorbrewer": "^1.0.0",
     "css-loader": "^0.28.11",
-    "docco": "^0.8.0",
+    "docco": "^0.7.0",
     "earcut": "^2.1.1",
     "eslint": "^2.10.2",
     "eslint-config-semistandard": "^6.0.2",


### PR DESCRIPTION
Upgrading to docco 0.8.0 (done as part of PR #812) changes how the build source documents are placed in the examples.  Reverting fixes this.  It might be worth eventually changing the build process to work with the newer version, but revert for now.