### PR TITLE
Warn on trying to create an unsupported feature.

### DIFF
--- a/src/featureLayer.js
+++ b/src/featureLayer.js
@@ -45,6 +45,8 @@ var featureLayer = function (arg) {
       featureName, m_this, m_this.renderer(), arg);
     if (newFeature) {
       this.addFeature(newFeature);
+    } else {
+      console.warn('Layer renderer (' + m_this.rendererName() + ') does not support feature type "' + featureName + '"');
     }
     return newFeature;
   };

--- a/src/jsonReader.js
+++ b/src/jsonReader.js
@@ -216,15 +216,16 @@ var jsonReader = function (arg) {
   this.read = function (file, done, progress) {
 
     function _done(object) {
-      var features, allFeatures = [], points, lines, polygons;
+      var features, allFeatures = [], points, lines, polygons, feature;
 
       features = m_this._featureArray(object);
 
       // process points
       points = features.filter(function (f) { return f.geometry.type === 'Point'; });
       if (points.length) {
-        allFeatures.push(
-          m_this.layer().createFeature('point')
+        feature = m_this.layer().createFeature('point');
+        if (feature) {
+          feature
             .data(points)
             .position(function (d) {
               return m_this._position(d.geometry.coordinates);
@@ -238,15 +239,17 @@ var jsonReader = function (arg) {
               strokeWidth: m_this._style('strokeWidth', 1),
               strokeOpacity: m_this._style('strokeOpacity', 1),
               radius: m_this._style('radius', 8)
-            })
-        );
+            });
+          allFeatures.push(feature);
+        }
       }
 
       // process lines
       lines = features.filter(function (f) { return f.geometry.type === 'LineString'; });
       if (lines.length) {
-        allFeatures.push(
-          m_this.layer().createFeature('line')
+        feature = m_this.layer().createFeature('line');
+        if (feature) {
+          feature
             .data(lines)
             .line(function (d) {
               return d.geometry.coordinates;
@@ -260,15 +263,17 @@ var jsonReader = function (arg) {
               lineCap: m_this._style('lineCap', 'butt', lines),
               lineJoin: m_this._style('lineCap', 'miter', lines),
               closed: m_this._style('closed', false, lines)
-            })
-        );
+            });
+          allFeatures.push(feature);
+        }
       }
 
       // process polygons
       polygons = features.filter(function (f) { return f.geometry.type === 'Polygon'; });
       if (polygons.length) {
-        allFeatures.push(
-          m_this.layer().createFeature('polygon')
+        feature = m_this.layer().createFeature('polygon');
+        if (feature) {
+          feature
             .data(polygons)
             .polygon(function (d, i) {
               return {
@@ -285,8 +290,9 @@ var jsonReader = function (arg) {
               strokeColor: m_this._style('strokeColor', '#999999', polygons, convertColor),
               strokeWidth: m_this._style('strokeWidth', 2, polygons),
               strokeOpacity: m_this._style('strokeOpacity', 1, polygons)
-            })
-        );
+            });
+          allFeatures.push(feature);
+        }
       }
       if (done) {
         done(allFeatures);

--- a/tests/cases/feature.js
+++ b/tests/cases/feature.js
@@ -33,7 +33,7 @@ describe('geo.feature', function () {
 
       feat = geo.feature.create(layer, {type: 'no_feature'});
       expect(feat).toBeNull();
-      expect(console.warn.calledOnce).toBe(true);
+      expect(console.warn.called).toBe(true);
       expect(console.warn.calledWith(
         'Could not create feature type "no_feature"')).toBe(true);
       console.warn.reset();


### PR DESCRIPTION
When a feature is requested that a layer doesn't support, issue a warning.  Don't fail in the geojson reader when this occurs.