### PR TITLE
Fix having tutorials update if text is deleted.

### DIFF
--- a/tutorials/common/tutorials.js
+++ b/tutorials/common/tutorials.js
@@ -192,8 +192,8 @@ function process_block_debounce(selector, debounce) {
     processBlockInfo.lastelem = selector;
     if (!debounce) {
       process_block(selector);
+      return;
     }
-    return;
   }
   processBlockInfo.timer = window.setTimeout(function () {
     process_block(processBlockInfo.lastelem);


### PR DESCRIPTION
Tutorials should rerun whenever the contents change.  Some code designed to perform updates when separate code blocks were edited happened to prevent deleting text from triggering the update.