### PR TITLE
Fix text alignment for the scale.

### DIFF
--- a/src/ui/scaleWidget.js
+++ b/src/ui/scaleWidget.js
@@ -237,7 +237,7 @@ var scaleWidget = function (arg) {
           x: width / 2,
           y: sw * 2,
           'text-anchor': 'middle',
-          'alignment-baseline': 'hanging'
+          'dominant-baseline': 'hanging'
         });
         break;
       case 'top':
@@ -246,7 +246,7 @@ var scaleWidget = function (arg) {
           x: width / 2,
           y: height - sw * 2,
           'text-anchor': 'middle',
-          'alignment-baseline': 'baseline'
+          'dominant-baseline': 'alphabetic'
         });
         break;
       case 'left':
@@ -255,7 +255,7 @@ var scaleWidget = function (arg) {
           x: width - sw * 2,
           y: height / 2,
           'text-anchor': 'end',
-          'alignment-baseline': 'middle'
+          'dominant-baseline': 'middle'
         });
         break;
       case 'right':
@@ -264,7 +264,7 @@ var scaleWidget = function (arg) {
           x: sw * 2,
           y: height / 2,
           'text-anchor': 'start',
-          'alignment-baseline': 'middle'
+          'dominant-baseline': 'middle'
         });
         break;
     }


### PR DESCRIPTION
For svg text elements, `alignment-baseline` is not a valid property (though Chrome honors it).  One must use `dominant-baseline` instead.

This fixes a rendering bug in Firefox.  Before:
![image](https://user-images.githubusercontent.com/8781639/40545729-d651ee40-5ffa-11e8-923d-3d15203e224a.png)
After:
![image](https://user-images.githubusercontent.com/8781639/40545744-e52e765e-5ffa-11e8-87ca-90572b37c637.png)

