### PR TITLE
Expose registries.

### DIFF
--- a/src/annotationLayer.js
+++ b/src/annotationLayer.js
@@ -1012,8 +1012,8 @@ var annotationLayer = function (args) {
       return m_this;
     }
     if (!m_labelFeature) {
-      var renderer = registry.rendererForFeatures(['text']);
-      if (renderer !== m_this.renderer().api()) {
+      if (!(registry.registries.features[m_this.rendererName()] || {}).text) {
+        var renderer = registry.rendererForFeatures(['text']);
         m_labelLayer = registry.createLayer('feature', m_this.map(), {renderer: renderer});
         m_this.addChild(m_labelLayer);
         m_labelLayer._update();

--- a/src/registry.js
+++ b/src/registry.js
@@ -459,4 +459,15 @@ util.rendererForAnnotations = function (annotationList) {
   return util.rendererForFeatures(util.featuresForAnnotations(annotationList));
 };
 
+/* Expose the various registries so that the can be examined to see what
+ * things are registered. */
+util.registries = {
+  annotations: annotations,
+  features: features,
+  featureCapabilities: featureCapabilities,
+  fileReaders: fileReaders,
+  layers: layers,
+  renderers: renderers
+};
+
 module.exports = util;

--- a/tests/cases/registry.js
+++ b/tests/cases/registry.js
@@ -25,5 +25,10 @@ describe('geo.registry', function () {
       expect(geo.rendererForFeatures(['point'])).toBe('d3');
       restoreVGLRenderer();
     });
+    it('expose registries', function () {
+      expect(geo.registries.unknown).toBe(undefined);
+      expect(geo.registries.annotations).not.toBe(undefined);
+      expect(geo.registries.features).not.toBe(undefined);
+    });
   });
 });


### PR DESCRIPTION
This, or some other way, is needed to that if a feature is available in multiple renderers, so that a compound feature doesn't have to invoke a secondary renderer if the current renderer is sufficient (see the change for the annotationLayer, for instance).

This also has the virtue that the `geo.registries` entry can be inspected to discover available features, layers, etc.