### PR TITLE
Proj4 doesn't include some projections by default.  Include them.

### DIFF
--- a/examples/reprojection/main.js
+++ b/examples/reprojection/main.js
@@ -114,7 +114,7 @@ $(function () {
       node: '#map',
       center: {x: 0, y: 0},
       zoom: 2.5,
-      gcs: gcsTable[gcs],
+      gcs: gcsTable[gcs] || gcs,
       unitsPerPixel: (range[1].x - range[0].x) / 256,
       clampBoundsX: false,
       clampBoundsY: false,
@@ -131,7 +131,7 @@ $(function () {
       gcs: 'EPSG:3857',
       attribution: $('#url-list [value="' + $('#layer-url').val() + '"]').attr(
           'credit'),
-      minLevel: 4,
+      minLevel: query.minLevel ? parseInt(query.minLevel, 10) : 4,
       keepLower: true,
       wrapX: false,
       wrapY: false

--- a/src/transform.js
+++ b/src/transform.js
@@ -1,4 +1,9 @@
 var proj4 = require('proj4');
+/* These projections exist in proj4 but aren't included by default. */
+proj4.Proj.projections.add(require('proj4/projections/equi'));
+proj4.Proj.projections.add(require('proj4/projections/gauss'));
+proj4.Proj.projections.add(require('proj4/projections/gstmerc'));
+proj4.Proj.projections.add(require('proj4/projections/ortho'));
 var util = require('./util');
 
 /**
@@ -613,5 +618,8 @@ transform.vincentyDistance = function (pt1, pt2, gcs, baseGcs, ellipsoid, maxIte
     alpha2: Math.atan2(cosU1 * Math.sin(lambda), -sinU1 * cosU2 + cosU1 * sinU2 * Math.cos(lambda))
   };
 };
+
+/* Expose proj4 to make it easier to debug */
+transform.proj4 = proj4;
 
 module.exports = transform;


### PR DESCRIPTION
This allows something like this to work:

http://opengeoscience.github.io/geojs/examples/reprojection/?gcs=%2Bproj%3Dortho%20%2Ba%3D6370997%20%2Bb%3D6370997%20%2Blat_0%3D42%20%2Blon_0%3D-72%20%2Bno_defs%20%2Bunits%3Dm%20%2Bx_0%3D0%20%2By_0%3D0&minLevel=5