### PR TITLE
Don't modify geojson object coordinates.

### DIFF
--- a/src/annotationLayer.js
+++ b/src/annotationLayer.js
@@ -674,13 +674,16 @@ var annotationLayer = function (args) {
           if (!position || position.length < 2) {
             return;
           }
+          // make a copy of the position array to avoid mutating the original.
+          position = position.slice();
           break;
         case 'polygon':
           position = feature.polygon()(data, data_idx);
           if (!position || !position.outer || position.outer.length < 3) {
             return;
           }
-          position = position.outer;
+          // make a copy of the position array to avoid mutating the original.
+          position = position.outer.slice();
           if (position[position.length - 1][0] === position[0][0] &&
               position[position.length - 1][1] === position[0][1]) {
             position.splice(position.length - 1, 1);

--- a/tests/cases/annotationLayer.js
+++ b/tests/cases/annotationLayer.js
@@ -674,6 +674,8 @@ describe('geo.annotationLayer', function () {
         }
       };
       expect(layer.geojson(lineString)).toBe(1);
+      // expect that the original coordinates are still in place
+      expect(lineString.geometry.coordinates[1][0]).toBe(-73.79);
       lineString.properties.annotationType = 'polygon';
       expect(layer.geojson(lineString)).toBe(2);
       var sample = {
@@ -729,6 +731,8 @@ describe('geo.annotationLayer', function () {
         }]
       };
       expect(layer.geojson(sample)).toBe(5);
+      // expect that the original coordinates are still in place
+      expect(sample.features[1].geometry.coordinates[0][6][0]).toBe(-118.915853);
       var badpoly = {
         type: 'Feature',
         geometry: {


### PR DESCRIPTION
If a geojson object is passed to the annotation layer, the coordinates used for polygon and line features referenced the arrays from the geojson object.  These arrays could be modified.  For polygons, this
could remove a last point that duplicated a first point.  For both lines and polygons, points are normalized to have x, y, z properties instead of being stored in an array.  If the same geojson object was passed to the annotation layer a second time, the polygon would always remove the last point, even if it was not a duplicate of the first point because the `[0]` and `[1]` properties of the points matched (as they no longer exist, having been replaced with `x` and `y`).

This, instead, creates a new array for coordinates for polygons and lines.  Although this uses more memory, it avoids the reuse problem.

Resolves #847.