### PR TITLE
Ensure that all point position calls pass the data index.

### DIFF
--- a/src/pointFeature.js
+++ b/src/pointFeature.js
@@ -148,7 +148,7 @@ var pointFeature = function (arg) {
     } else {
       var isFunc = util.isFunction(val);
       m_this.style('position', function (d, i) {
-        if (d.__cluster) {
+        if (d !== null && d !== undefined && d.__cluster) {
           return d;
         } else if (isFunc) {
           return val(d, i);
@@ -181,7 +181,7 @@ var pointFeature = function (arg) {
 
     // create an array of positions in geo coordinates
     pts = m_this.data().map(function (d, i) {
-      var pt = position(d);
+      var pt = position(d, i);
 
       // store the maximum point radius
       m_maxRadius = Math.max(
@@ -275,7 +275,7 @@ var pointFeature = function (arg) {
         idx = [];
     // TODO: use the range tree
     m_this.data().forEach(function (d, i) {
-      var p = pos(d);
+      var p = pos(d, i);
       if (p.x >= lowerLeft.x &&
           p.x <= upperRight.x &&
           p.y >= lowerLeft.y &&

--- a/tests/cases/pointFeature.js
+++ b/tests/cases/pointFeature.js
@@ -53,6 +53,9 @@ describe('geo.pointFeature', function () {
       point = geo.pointFeature({layer: layer, position: pos});
       point._init({position: pos});
       expect(point.position()('a')).toEqual(pos);
+      // with null data
+      point.position(function (d, i) { return i; });
+      expect(point.position()(null, 2)).toBe(2);
     });
 
     it('data', function () {


### PR DESCRIPTION
We want position to be a function that takes `(data, dataIndex)`, but in several places we were only calling it with `(data)`.  Also, data entries don't have to be objects, so guard against that -- you can set a point feature with data just equal to `{length: <number of points>}`, and then generate the positions purely based on the index.