### PR TITLE
Pin the Chrome version for testing.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ node_js:
 addons:
   firefox: latest  # version 55.0 - 57.x have an issue with screenshots.
   # firefox: 54.0.1
+  # Chrome 68 breaks headless gl testing, so this is replaced later
   chrome: stable
   apt:
     packages:
@@ -41,6 +42,10 @@ before_install:
   - npm install -g npm@latest
   # Prune the npm packages.  If this fails for any reason, just remove them all
   - npm prune || rm -r node_modules
+  # Get a specific version of Chrome
+  - curl -L -C - https://www.slimjet.com/chrome/download-chrome.php?file=lnx%2Fchrome64_67.0.3396.79.deb -o "${HOME}/cache/chrome64_67.0.3396.79.deb"
+  - sudo dpkg -i "${HOME}/cache/chrome64_67.0.3396.79.deb"
+  - google-chrome --version
 
 install:
   # travis moved to "npm ci", but that fails with canvas-prebuilt as it tries


### PR DESCRIPTION
Chrome 68 breaks headless gl tests and drastically slows down headed tests using osmesa or swiftshader.  Rather than work around this by making headless gl tests headed and adding more delay to tests, pin to version 67 for now.