### PR TITLE
Update website build process.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,6 +51,8 @@ install:
   # travis moved to "npm ci", but that fails with canvas-prebuilt as it tries
   # to install it before node-pre-gyp
   - npm install
+  # Install for the website build
+  - npm run setup-website
 
 before_script:
   - export DISPLAY=:99.0
@@ -63,6 +65,8 @@ script:
   - mkdir _build
   - ctest -S cmake/travis_build.cmake -VV || true
   - if [ -f _build/test_failed ] ; then false ; fi
+  # Build the website to ensure that it will pass
+  - npm run build-website
 
 after_failure:
   # Upload test results.  First make them smaller with optipng.
@@ -79,3 +83,11 @@ env:
   global:
     - secure: JYWs3zJV09uAb7CvX32pADRYTH2XqSGvImNEI6zVFxJxs9r0JsGgyOTz4PPBgs3dv1OjVBXqxu4GD2ZBKeo0Ax13ZnBNVR/BacupBtIwXbxp/FG2lr+WBzE0YnEBhAF/mW5DEkNBWJyLSiBlxYA5QFAAHYwb/GOADl+Z9Qi2FIU=
     - secure: on13Ka+3jkLDCXxqzxuT+CY4sPM0Zxfbe9M2F3LE0yhN2ww5vaBKdbTrzEWa0TOlBkM2qQUPAFybjHXfHeRyKpZDlsssjogH8YO5qx4zFRP5ZB9ny39QAqBsfZTuXt2WmOTLEcXkByYXVH8my/8ZqZqofSeBZsZdeauzoLbr0R0=
+
+deploy:
+  - provider: pages
+    local-dir: website/public
+    github-token: $GITHUB_TOKEN
+    skip-cleanup: true
+    on:
+      branch: master

--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "docs": "jsdoc --pedantic -d dist/apidocs -r src -c jsdoc.conf.json",
     "website": "cd website && npx hexo server",
     "setup-website": "cd website && npm install",
-    "build-website": "npm run build && cp -a dist/built/. website/source/built && npm run build-website-examples && npm run build-website-tutorials && npm run docs && cp -ar dist/data/. website/source/data && cp -ar dist/apidocs/. website/source/apidocs && cd website && npm install && rm -f db.json && npx hexo generate"
+    "build-website": "npm run build && cp -a dist/built/. website/source/built && npm run build-website-examples && npm run build-website-tutorials && npm run docs && cd dist && find data \\( -name tiles -o -name base-images -o -name '*-hash-stamp' -o -name '*.tgz' \\) -prune -o \\( -print0 \\) | cpio -pmdL0 ../website/source && cp -ar apidocs/. ../website/source/apidocs && cd ../website && npm install && rm -f db.json && npx hexo generate"
   },
   "keywords": [
     "map",

--- a/website/package.json
+++ b/website/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "hexo": {
-    "version": "3.4.4"
+    "version": "3.7.1"
   },
   "dependencies": {
     "hexo": "^3.4.4",


### PR DESCRIPTION
Auto-deploy the gh-pages branch when merged to master.

This changes how data is copying into the website build process to avoid copying proxy and test data and to dereference symlinks.