### PR TITLE
Fix website example template.

### DIFF
--- a/website/themes/agency/layout/example.ejs
+++ b/website/themes/agency/layout/example.ejs
@@ -7,9 +7,6 @@ no_footer: true
 <link rel="stylesheet" href="<%- url_for("css/example.css") %>">
 <script type="text/javascript" src="../bundle.js" charset="UTF-8"></script>
 <div class="page example">
-    <% for(js of page.exampleJs) { %>
-        <script type="text/javascript" src="<%- js %>"></script>
-    <% } %>
     <% for(css of page.exampleCss) { %>
         <link rel="stylesheet" href="<%- css %>">
     <% } %>
@@ -52,3 +49,6 @@ no_footer: true
         </div>
     </div>
 </div>
+<% for(js of page.exampleJs) { %>
+    <script type="text/javascript" src="<%- js %>"></script>
+<% } %>


### PR DESCRIPTION
Commit 9581d4f allows exampels to not have to wrap javascript inside a function.  That commit updated the common/index.pug but not the companion website template.