### PR TITLE
Avoid making an "untagged" tag when deploying.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -101,6 +101,3 @@ deploy:
     skip-cleanup: true
     on:
       tag: true
-      # We could emit artifacts on all branches rather than just master
-      branch: master
-      # all_branches: true


### PR DESCRIPTION
When merging to master, travis is generating an "untagged-<hash>" tag.  I think this might avoid that.