### PR TITLE
Avoid making an "untagged" tag when deploying.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -100,4 +100,7 @@ deploy:
       - dist/built/geo.ext.min.js
     skip-cleanup: true
     on:
-      tag: true
+      tags: true
+      # We could emit artifacts on all branches rather than just master
+      branch: master
+      # all_branches: true


### PR DESCRIPTION
The travis key is 'tags' not 'tag'.