### PR TITLE
Move annotation definitions to typedefs.

### DIFF
--- a/jsdoc.conf.json
+++ b/jsdoc.conf.json
@@ -4,6 +4,7 @@
   },
   "plugins": [
     "jsdoc/plugins/events",
+    "jsdoc/plugins/typedef_augments",
     "node_modules/jsdoc-autoprivate/autoprivate.js",
     "plugins/markdown"
   ],

--- a/jsdoc/plugins/typedef_augments.js
+++ b/jsdoc/plugins/typedef_augments.js
@@ -1,0 +1,69 @@
+/**
+ * Define a jsdoc plugin to update typedefs that use augments.
+ */
+exports.handlers = {
+  /**
+   * Modify typedefs that use augments (extends).  Add the base typedef's
+   * properties to the augmented typedefs.
+   */
+  parseComplete: function (e) {
+    var typedefs = {},
+        augmentedTypedefs = {},
+        numAugmented = 0;
+    /* Make a dictionary of all known typedefs and a dictionary of augmented
+     * typedefs */
+    e.doclets.forEach(function (doclet) {
+      if (doclet.kind === 'typedef') {
+        typedefs[doclet.longname] = doclet;
+        if (doclet.augments && doclet.augments.length) {
+          augmentedTypedefs[doclet.longname] = doclet;
+        }
+      }
+    });
+    while (Object.keys(augmentedTypedefs).length !== numAugmented) {
+      numAugmented = Object.keys(augmentedTypedefs).length;
+      Object.keys(augmentedTypedefs).forEach(function (name) {
+        var doclet = augmentedTypedefs[name];
+        /* If this typedef is augmented by an augmented typedef, skip it for
+         * now.  Ignore self references */
+        if (doclet.augments.some(function (augmentName) {
+          return augmentName !== name && augmentedTypedefs[augmentName];
+        })) {
+          return;
+        }
+        /* Ensure we have properties */
+        doclet.properties = doclet.properties || [];
+        /* Make a dictionary so we don't clobber known properties. */
+        var properties = {};
+        doclet.properties.forEach(function (prop) {
+          properties[prop.name] = prop;
+        });
+        /* For each augment base, add its properties if we don't already have
+         * them.  If the typedef augments two other typedefs that each have a
+         * property of the same name, the last listed will be shown (done by
+         * reversing the augments list). */
+        doclet.augments.slice().reverse().forEach(function (augmentName) {
+          if (augmentName !== name && typedefs[augmentName] && typedefs[augmentName].properties) {
+            typedefs[augmentName].properties.forEach(function (prop) {
+              if (!properties[prop.name]) {
+                /* Make a copy so we don't mutate the original property. */
+                prop = Object.assign(prop);
+                /* Add a value that a rendering template could use to show that
+                 * the property was inherted from a parent.  Since that in turn
+                 * could have been inherited, preserve a known value. */
+                prop.inherited = prop.inherited || augmentName;
+                /* Add the property to the typedef and to the list of known
+                 * properties. */
+                doclet.properties.push(prop);
+                properties[prop.name] = prop;
+              }
+            });
+          }
+        });
+        /* We've finished processing this typedef, so remove it from the
+         * augmented list. */
+        delete augmentedTypedefs[name];
+      });
+    }
+  }
+};

--- a/src/annotation.js
+++ b/src/annotation.js
@@ -67,6 +67,21 @@ var defaultEditHandleStyle = {
 var editHandleFeatureLevel = 3;
 
 /**
+ * General annotation specification.
+ *
+ * @typedef {object} geo.annotation.spec
+ * @property {string} [name] A name for the annotation.  This defaults to the
+ *    type with a unique ID suffixed to it.
+ * @property {geo.annotationLayer} [layer] A reference to the controlling
+ *    layer.  This is used for coordinate transforms.
+ * @property {string} [state] Initial annotation state.  One of the
+ *    {@link geo.annotation.state} values.
+ * @property {boolean|string[]} [showLabel=true] `true` to show the annotation
+ *    label on annotations in done or edit states.  Alternately, a list of
+ *    states in which to show the label.  Falsy to not show the label.
+ */
+
+/**
  * Base annotation class.
  *
  * @class
@@ -74,16 +89,7 @@ var editHandleFeatureLevel = 3;
  * @param {string} type The type of annotation.  These should be registered
  *    with {@link geo.registerAnnotation} and can be listed with
  *    {@link geo.listAnnotations}.
- * @param {object?} [args] Individual annotations have additional options.
- * @param {string} [args.name] A name for the annotation.  This defaults to
- *    the type with a unique ID suffixed to it.
- * @param {geo.annotationLayer} [arg.layer] A reference to the controlling
- *    layer.  This is used for coordinate transforms.
- * @param {string} [args.state] Initial annotation state.  One of the
- *    {@link geo.annotation.state} values.
- * @param {boolean|string[]} [args.showLabel=true] `true` to show the
- *    annotation label on annotations in done or edit states.  Alternately, a
- *    list of states in which to show the label.  Falsy to not show the label.
+ * @param {geo.annotation.spec?} [args] Options for the annotation.
  * @returns {geo.annotation}
  */
 var annotation = function (type, args) {
@@ -1068,6 +1074,23 @@ var annotation = function (type, args) {
 };
 
 /**
+ * Rectangle annotation specification.
+ *
+ * @typedef {geo.annotation.spec} geo.rectangleAnnotation.spec
+ * @property {geo.geoPosition[]} [corners] A list of four corners in map gcs
+ *    coordinates.  These must be in order around the perimeter of the
+ *    rectangle (in either direction).
+ * @property {geo.geoPosition[]} [coordinates] An alternate name for `corners`.
+ * @property {object} [style] The style to apply to a finished rectangle.  This
+ *    uses styles for polygons, including `fill`, `fillColor`, `fillOpacity`,
+ *    `stroke`, `strokeWidth`, `strokeColor`, and `strokeOpacity`.
+ * @property {object} [editStyle] The style to apply to a rectangle in edit
+ *    mode.  This uses styles for polygons and lines, including `fill`,
+ *    `fillColor`, `fillOpacity`, `stroke`, `strokeWidth`, `strokeColor`, and
+ *    `strokeOpacity`.
+ */
+
+/**
  * Rectangle annotation class.
  *
  * Rectangles are always rendered as polygons.  This could be changed -- if no
@@ -1078,27 +1101,7 @@ var annotation = function (type, args) {
  * @alias geo.rectangleAnnotation
  * @extends geo.annotation
  *
- * @param {object?} [args] Options for the annotation.
- * @param {string} [args.name] A name for the annotation.  This defaults to
- *    the type with a unique ID suffixed to it.
- * @param {string} [args.state] initial annotation state.  One of the
- *    annotation.state values.
- * @param {boolean|string[]} [args.showLabel=true] `true` to show the
- *    annotation label on annotations in done or edit states.  Alternately, a
- *    list of states in which to show the label.  Falsy to not show the label.
- * @param {geo.geoPosition[]} [args.corners] A list of four corners in map
- *    gcs coordinates.  These must be in order around the perimeter of the
- *    rectangle (in either direction).
- * @param {geo.geoPosition[]} [args.coordinates] An alternate name for
- *    `args.corners`.
- * @param {object} [args.style] The style to apply to a finished rectangle.
- *    This uses styles for polygons, including `fill`, `fillColor`,
- *    `fillOpacity`, `stroke`, `strokeWidth`, `strokeColor`, and
- *    `strokeOpacity`.
- * @param {object} [args.editStyle] The style to apply to a rectangle in edit
- *    mode.  This uses styles for polygons and lines, including `fill`,
- *    `fillColor`, `fillOpacity`, `stroke`, `strokeWidth`, `strokeColor`, and
- *    `strokeOpacity`.
+ * @param {geo.rectangleAnnotation.spec?} [args] Options for the annotation.
  */
 var rectangleAnnotation = function (args) {
   'use strict';
@@ -1457,6 +1460,24 @@ rectangleRequiredFeatures[polygonFeature.capabilities.feature] = true;
 registerAnnotation('rectangle', rectangleAnnotation, rectangleRequiredFeatures);
 
 /**
+ * Polygon annotation specification.
+ *
+ * @typedef {geo.annotation.spec} geo.polygonAnnotation.spec
+ * @property {geo.geoPosition[]} [vertices] A list of vertices in map gcs
+ *    coordinates.  These must be in order around the perimeter of the polygon
+ *    (in either direction).
+ * @property {geo.geoPosition[]} [coordinates] An alternate name for
+ *    `vertices`.
+ * @property {object} [style] The style to apply to a finished polygon.  This
+ *    uses styles for polygons, including `fill`, `fillColor`, `fillOpacity`,
+ *    `stroke`, `strokeWidth`, `strokeColor`, and `strokeOpacity`.
+ * @property {object} [editStyle] The style to apply to a polygon in edit mode.
+ *    This uses styles for polygons and lines, including `fill`, `fillColor`,
+ *    `fillOpacity`, `stroke`, `strokeWidth`, `strokeColor`, and
+ *    `strokeOpacity`.
+ */
+
+/**
  * Polygon annotation class
  *
  * When complete, polygons are rendered as polygons.  During creation they are
@@ -1466,27 +1487,7 @@ registerAnnotation('rectangle', rectangleAnnotation, rectangleRequiredFeatures);
  * @alias geo.polygonAnnotation
  * @extends geo.annotation
  *
- * @param {object?} [args] Options for the annotation.
- * @param {string} [args.name] A name for the annotation.  This defaults to
- *    the type with a unique ID suffixed to it.
- * @param {string} [args.state] initial annotation state.  One of the
- *    annotation.state values.
- * @param {boolean|string[]} [args.showLabel=true] `true` to show the
- *    annotation label on annotations in done or edit states.  Alternately, a
- *    list of states in which to show the label.  Falsy to not show the label.
- * @param {geo.geoPosition[]} [args.vertices] A list of vertices in map gcs
- *    coordinates.  These must be in order around the perimeter of the
- *    polygon (in either direction).
- * @param {geo.geoPosition[]} [args.coordinates] An alternate name for
- *    `args.vertices`.
- * @param {object} [args.style] The style to apply to a finished polygon.
- *    This uses styles for polygons, including `fill`, `fillColor`,
- *    `fillOpacity`, `stroke`, `strokeWidth`, `strokeColor`, and
- *    `strokeOpacity`.
- * @param {object} [args.editStyle] The style to apply to a polygon in edit
- *    mode.  This uses styles for polygons and lines, including `fill`,
- *    `fillColor`, `fillOpacity`, `stroke`, `strokeWidth`, `strokeColor`, and
- *    `strokeOpacity`.
+ * @param {geo.polygonAnnotation.spec?} [args] Options for the annotation.
  */
 var polygonAnnotation = function (args) {
   'use strict';
@@ -1724,31 +1725,29 @@ polygonRequiredFeatures[lineFeature.capabilities.basic] = [annotationState.creat
 registerAnnotation('polygon', polygonAnnotation, polygonRequiredFeatures);
 
 /**
+ * Line annotation specification.
+ *
+ * @typedef {geo.annotation.spec} geo.lineAnnotation.spec
+ * @property {geo.geoPosition[]} [vertices] A list of vertices in map gcs
+ *    coordinates.
+ * @property {geo.geoPosition[]} [coordinates] An alternate name for
+ *    `vertices`.
+ * @property {object} [style] The style to apply to a finished line.  This uses
+ *    styles for lines, including `strokeWidth`, `strokeColor`,
+ *    `strokeOpacity`, `strokeOffset`, `closed`, `lineCap`, and `lineJoin`.
+ * @property {object} [editStyle] The style to apply to a line in edit mode.
+ *    This uses styles for lines, including `strokeWidth`, `strokeColor`,
+ *    `strokeOpacity`, `strokeOffset`, `closed`, `lineCap`, and `lineJoin`.
+ */
+
+/**
  * Line annotation class.
  *
  * @class
  * @alias geo.lineAnnotation
  * @extends geo.annotation
  *
- * @param {object?} [args] Options for the annotation.
- * @param {string} [args.name] A name for the annotation.  This defaults to
- *    the type with a unique ID suffixed to it.
- * @param {string} [args.state] initial annotation state.  One of the
- *    annotation.state values.
- * @param {boolean|string[]} [args.showLabel=true] `true` to show the
- *    annotation label on annotations in done or edit states.  Alternately, a
- *    list of states in which to show the label.  Falsy to not show the label.
- * @param {geo.geoPosition[]} [args.vertices] A list of vertices in map gcs
- *    coordinates.
- * @param {geo.geoPosition[]} [args.coordinates] An alternate name for
- *    `args.corners`.
- * @param {object} [args.style] The style to apply to a finished line.
- *    This uses styles for lines, including `strokeWidth`, `strokeColor`,
- *    `strokeOpacity`, `strokeOffset`, `closed`, `lineCap`, and `lineJoin`.
- * @param {object} [args.editStyle] The style to apply to a line in edit
- *    mode.  This uses styles for lines, including `strokeWidth`,
- *    `strokeColor`, `strokeOpacity`, `strokeOffset`, `closed`, `lineCap`,
- *    and `lineJoin`.
+ * @param {geo.lineAnnotation.spec?} [args] Options for the annotation.
  */
 var lineAnnotation = function (args) {
   'use strict';
@@ -2111,33 +2110,30 @@ lineRequiredFeatures[lineFeature.capabilities.basic] = [annotationState.create];
 registerAnnotation('line', lineAnnotation, lineRequiredFeatures);
 
 /**
+ * Point annotation specification.
+ *
+ * @typedef {geo.annotation.spec} geo.pointAnnotation.spec
+ * @property {geo.geoPosition} [position] A coordinate in map gcs coordinates.
+ * @property {geo.geoPosition[]} [coordinates] An array with one coordinate to
+ *    use in place of `position`.
+ * @property {object} [style] The style to apply to a finished point.  This
+ *    uses styles for points, including `radius`, `fill`, `fillColor`,
+ *    `fillOpacity`, `stroke`, `strokeWidth`, `strokeColor`, `strokeOpacity`,
+ *    and `scaled`.  If `scaled` is `false`, the point is not scaled with zoom
+ *    level.  If it is `true`, the radius is based on the zoom level at first
+ *    instantiation.  Otherwise, if it is a number, the radius is used at that
+ *    zoom level.
+ * @property {object} [editStyle] The style to apply to a point in edit mode.
+ */
+
+/**
  * Point annotation class.
  *
  * @class
- * @alias geo.poinyAnnotation
+ * @alias geo.pointAnnotation
  * @extends geo.annotation
  *
- * @param {object?} [args] Options for the annotation.
- * @param {string} [args.name] A name for the annotation.  This defaults to
- *    the type with a unique ID suffixed to it.
- * @param {string} [args.state] initial annotation state.  One of the
- *    annotation.state values.
- * @param {boolean|string[]} [args.showLabel=true] `true` to show the
- *    annotation label on annotations in done or edit states.  Alternately, a
- *    list of states in which to show the label.  Falsy to not show the label.
- * @param {geo.geoPosition} [args.position] A coordinate in map gcs
- *    coordinates.
- * @param {geo.geoPosition[]} [args.coordinates] An array with one coordinate
- *  to use in place of `args.position`.
- * @param {object} [args.style] The style to apply to a finished point.
- *    This uses styles for points, including `radius`, `fill`, `fillColor`,
- *    `fillOpacity`, `stroke`, `strokeWidth`, `strokeColor`, `strokeOpacity`,
- *    and `scaled`.  If `scaled` is `false`, the point is not scaled with
- *    zoom level.  If it is `true`, the radius is based on the zoom level at
- *    first instantiation.  Otherwise, if it is a number, the radius is used
- *    at that zoom level.
- * @param {object} [args.editStyle] The style to apply to a point in edit
- *    mode.
+ * @param {geo.pointAnnotation.spec?} [args] Options for the annotation.
  */
 var pointAnnotation = function (args) {
   'use strict';

--- a/src/annotation.js
+++ b/src/annotation.js
@@ -1074,9 +1074,10 @@ var annotation = function (type, args) {
 };
 
 /**
- * Rectangle annotation specification.
+ * Rectangle annotation specification.  Extends {@link geo.annotation.spec}.
  *
- * @typedef {geo.annotation.spec} geo.rectangleAnnotation.spec
+ * @typedef {object} geo.rectangleAnnotation.spec
+ * @extends geo.annotation.spec
  * @property {geo.geoPosition[]} [corners] A list of four corners in map gcs
  *    coordinates.  These must be in order around the perimeter of the
  *    rectangle (in either direction).
@@ -1460,9 +1461,10 @@ rectangleRequiredFeatures[polygonFeature.capabilities.feature] = true;
 registerAnnotation('rectangle', rectangleAnnotation, rectangleRequiredFeatures);
 
 /**
- * Polygon annotation specification.
+ * Polygon annotation specification.  Extends {@link geo.annotation.spec}.
  *
- * @typedef {geo.annotation.spec} geo.polygonAnnotation.spec
+ * @typedef {object} geo.polygonAnnotation.spec
+ * @extends geo.annotation.spec
  * @property {geo.geoPosition[]} [vertices] A list of vertices in map gcs
  *    coordinates.  These must be in order around the perimeter of the polygon
  *    (in either direction).
@@ -1725,9 +1727,10 @@ polygonRequiredFeatures[lineFeature.capabilities.basic] = [annotationState.creat
 registerAnnotation('polygon', polygonAnnotation, polygonRequiredFeatures);
 
 /**
- * Line annotation specification.
+ * Line annotation specification.  Extends {@link geo.annotation.spec}.
  *
- * @typedef {geo.annotation.spec} geo.lineAnnotation.spec
+ * @typedef {object} geo.lineAnnotation.spec
+ * @extends geo.annotation.spec
  * @property {geo.geoPosition[]} [vertices] A list of vertices in map gcs
  *    coordinates.
  * @property {geo.geoPosition[]} [coordinates] An alternate name for
@@ -2110,9 +2113,10 @@ lineRequiredFeatures[lineFeature.capabilities.basic] = [annotationState.create];
 registerAnnotation('line', lineAnnotation, lineRequiredFeatures);
 
 /**
- * Point annotation specification.
+ * Point annotation specification.  Extends {@link geo.annotation.spec}.
  *
- * @typedef {geo.annotation.spec} geo.pointAnnotation.spec
+ * @typedef {object} geo.pointAnnotation.spec
+ * @extends geo.annotation.spec
  * @property {geo.geoPosition} [position] A coordinate in map gcs coordinates.
  * @property {geo.geoPosition[]} [coordinates] An array with one coordinate to
  *    use in place of `position`.


### PR DESCRIPTION
This makes the documentation cleaner and reduces redundancy.