### PR TITLE
Add an idle property to objects.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,12 @@
 
 ## Unreleased
 
+### Features
+- Added an idle property to objects (#894)
+
 ### Changes
 
 - Changed build process: optional dependencies are now included in the bundle by default (#890)
-
 
 ## Version 0.17.0
 

--- a/src/object.js
+++ b/src/object.js
@@ -23,8 +23,9 @@ var object = function () {
       m_promiseCount = 0;
 
   /**
-   * Bind a handler that will be called once when all internal promises are
-   * resolved.
+   * Bind a handler that will be called one time when all internal promises are
+   * resolved.  If there are no outstanding promises, this is invoked
+   * synchronously.
    *
    * @param {function} handler A function taking no arguments.
    * @returns {this}
@@ -37,6 +38,20 @@ var object = function () {
     }
     return m_this;
   };
+
+  /**
+   * Getter for the idle state.  Read only.
+   *
+   * @property {boolean} idle `true` if the object is idle (`onIdle` would call
+   *    a handler immediately).
+   * @name geo.object#idle
+   */
+  Object.defineProperty(this, 'idle', {
+    get: function () {
+      return !m_promiseCount;
+    },
+    configurable: true
+  });
 
   /**
    * Add a new promise object preventing idle event handlers from being called

--- a/tests/cases/deferred.js
+++ b/tests/cases/deferred.js
@@ -8,6 +8,7 @@ describe('Testing onIdle event handling', function () {
     it('no deferred', function () {
       var obj = geo.object(), called = false;
 
+      expect(obj.idle).toBe(true);
       obj.onIdle(function () {
         called = true;
       });
@@ -19,10 +20,12 @@ describe('Testing onIdle event handling', function () {
       var obj = geo.object(), defer = $.Deferred();
 
       obj.addPromise(defer);
+      expect(obj.idle).toBe(false);
       window.setTimeout(function () {
         var called = false;
         defer.resolve();
 
+        expect(obj.idle).toBe(true);
         obj.onIdle(function () {
           called = true;
         });


### PR DESCRIPTION
For any object that inherits from geo.object, the `idle` property is true if `onIdle` would call a handler immediately.