### PR TITLE
When tiles have overlap, rendering cropped tiles could throw an error.

### DIFF
--- a/src/canvas/quadFeature.js
+++ b/src/canvas/quadFeature.js
@@ -174,8 +174,11 @@ var canvas_quadFeature = function (arg) {
         if (!quad.crop) {
           context2d.drawImage(src, 0, 0);
         } else {
-          context2d.drawImage(src, 0, 0, quad.crop.x, quad.crop.y, 0, 0,
-                              quad.crop.x, quad.crop.y);
+          var cropx = Math.min(src.w, quad.crop.x),
+              cropy = Math.min(src.h, quad.crop.y);
+          if (cropx > 0 && cropy > 0) {
+            context2d.drawImage(src, 0, 0, cropx, cropy, 0, 0, cropx, cropy);
+          }
         }
       });
     });


### PR DESCRIPTION
This happened on IE11.  I don't know if it happens on Edge.  By ensuring we don't ask to crop to a size larger than the image, it works properly.

You can see the issue if you look at the deepzoom Mars example on IE11.