### PR TITLE
Fix reporting coverage when using babel.

### DIFF
--- a/karma-base.js
+++ b/karma-base.js
@@ -1,4 +1,4 @@
-var webpack_config = require('./webpack.config');
+var webpack_config = require('./webpack.base.config');
 var url = require('url');
 var fs = require('fs');
 var path = require('path');

--- a/karma-cov.conf.js
+++ b/karma-cov.conf.js
@@ -1,8 +1,6 @@
 // Defines a test server for running jasmine unit tests
 // with coverage support.
 
-var path = require('path');
-
 /**
  * Return URL friendly browser string
  */
@@ -40,11 +38,11 @@ module.exports = function (config) {
       {type: 'text'}
     ]
   };
-  karma_config.webpack.module.rules.unshift({
-    test: /\.js$/,
-    include: path.resolve('src/'),
-    exclude: path.resolve('src/polyfills.js'),
-    use: ['istanbul-instrumenter-loader']
+  /* Alter our first webpack module rule which should just apply to src/*.js
+   * files. */
+  karma_config.webpack.module.rules[0].use.push({
+    loader: 'istanbul-instrumenter-loader',
+    options: {esModules: true}
   });
 
   config.set(karma_config);

--- a/webpack.base.config.js
+++ b/webpack.base.config.js
@@ -75,12 +75,32 @@ module.exports = {
   */
   module: {
     rules: [{
+      /* The first rule only includes src/*.js so that it can conveniently be
+       * modified for istanbul instrumentation */
+      test: /\.js$/,
+      include: path.resolve('src'),
+      exclude: path.resolve('src/polyfills.js'),
+      use: [{
+        loader: 'babel-loader',
+        options: {
+          presets: [[
+            'env', {
+              targets: {
+                browsers: ['defaults'],
+                uglify: true
+              },
+              useBuiltIns: 'usage'
+            }
+          ]],
+          cacheDirectory: true
+        }
+      }]
+    }, {
       test: /\.js$/,
       include: [
-        path.resolve(__dirname, 'src'),
-        path.resolve(__dirname, 'tests'),
-        path.resolve(__dirname, 'examples'),
-        path.resolve(__dirname, 'tutorials')
+        path.resolve('tests'),
+        path.resolve('examples'),
+        path.resolve('tutorials')
       ],
       use: [{
         loader: 'babel-loader',


### PR DESCRIPTION
If the istanbul-instrumenter-loader is added in a separate rule from the babel-loader, the line numbers reported by coverage are wrong.

Compare, for instance, these codecov reports:
- [Before PR #900](https://codecov.io/gh/OpenGeoscience/geojs/src/65c41328b40db49c4b32f53766b9bbb31cdfbf40/src/object.js)
- [After PR #900 and before this change](https://codecov.io/gh/OpenGeoscience/geojs/src/1ec38a43b06510cdeb951fd6ffc039a352c16fb9/src/object.js)
- [With this PR](https://codecov.io/gh/OpenGeoscience/geojs/src/68872838e4aefd4c0d851cd78451842defb4ffe3/src/object.js)
  