### PR TITLE
Expose matrix and vector classes in the camera object.

### DIFF
--- a/src/camera.js
+++ b/src/camera.js
@@ -1,6 +1,8 @@
 var inherit = require('./inherit');
 var object = require('./object');
 var util = require('./util');
+var mat3 = require('gl-mat3');
+var vec3 = require('gl-vec3');
 var mat4 = require('gl-mat4');
 var vec4 = require('gl-vec4');
 
@@ -913,6 +915,12 @@ camera.css = function (t) {
       }).join(',') +
     ')';
 };
+
+// expose the vector and matrix functions for convenience
+camera.vec3 = vec3;
+camera.mat3 = mat3;
+camera.vec4 = vec4;
+camera.mat4 = mat4;
 
 inherit(camera, object);
 module.exports = camera;

--- a/tests/cases/camera.js
+++ b/tests/cases/camera.js
@@ -371,9 +371,6 @@ describe('geo.camera', function () {
     }
 
     function assert_position(position) {
-      if (!closeToEqual(get_node_position(), position, 2)) { //DWM::
-        console.log('assert_position', get_node_position(), position); //DWM::
-      } //DWM::
       expect(closeToEqual(get_node_position(), position, 2)).toBe(true);
     }
 


### PR DESCRIPTION
This makes it easier for consuming applications to perform matrix math, instead of having to include the matrix libraries separately.

This also removes some debug code from a test.