### PR TITLE
Add an API Docs link to the top bar of the website.

### DIFF
--- a/website/themes/agency/layout/layout.ejs
+++ b/website/themes/agency/layout/layout.ejs
@@ -89,6 +89,9 @@
                         <a href="<%- page_url("examples") %>">Examples</a>
                     </li>
                     <li>
+                        <a href="<%- page_url("apidocs") %>">API Docs</a>
+                    </li>
+                    <li>
                         <a href="https://github.com/OpenGeoscience/geojs">GitHub</a>
                     </li>
                 </ul>


### PR DESCRIPTION
This makes it easier to get to the API Docs from tutorials and examples.

![image](https://user-images.githubusercontent.com/8781639/44797332-f0db5300-ab7c-11e8-9a9f-1a5891c180c2.png)
