### PR TITLE
Use a background color to indicate the target in jsdoc.

### DIFF
--- a/jsdoc/template/style.css
+++ b/jsdoc/template/style.css
@@ -16,3 +16,6 @@
   border-top: 3px double #e1e1e1;
   padding-top: 20px;
 }    
+:target {
+  background-color: #ff8;
+}


### PR DESCRIPTION
This makes it easier to identify a selected section when it ends up not being at the top of the display.