### PR TITLE
Catch errors in animation frame callbacks

### DIFF
--- a/src/map.js
+++ b/src/map.js
@@ -1803,7 +1803,11 @@ var map = function (arg) {
 
     /* The first entry is the reference to the window.requestAnimationFrame. */
     for (var i = 1; i < queue.length; i += 1) {
-      queue[i].apply(this, arguments);
+      try {
+        queue[i].apply(this, arguments);
+      } catch (err) {
+        console.error(err);
+      }
     }
   }
 


### PR DESCRIPTION
Errors in user provided animation frame callbacks caused all future
callbacks in the same animation frame to not run.  This catches any
errors and prints them to `console.error`.