### PR TITLE
Add links to tutorials and examples in the Get Started area.

### DIFF
--- a/website/source/index.html
+++ b/website/source/index.html
@@ -56,21 +56,31 @@ title: Welcome
                 </div>
             </div>
             <div class="row">
-                <div class="col-md-4 col-md-offset-1 col-sm-12">
-                    <a href="http://geojs.readthedocs.io/en/latest/"><h3><i class="fa fa-book"></i>Documentation</h3></a>
-                    <p class="text-muted">Guides for users and developers, plus how to build and contribute to GeoJS.</p>
-                </div>
-                <div class="col-md-5 col-md-offset-2 col-sm-12">
-                    <a href="download"><h3><i class="fa fa-download"></i>Download</h3></a>
-                    <p class="text-muted">Get a local copy of GeoJS or refer to it via a CDN.</p><p>&nbsp;</p>
-                </div>
-                <div class="col-md-4 col-md-offset-1 col-sm-12">
-                    <a href="apidocs"><h3><i class="fa fa-code"></i>API Docs</h3></a>
-                    <p class="text-muted">Full documentation of the GeoJS API</p>
-                </div>
-                <div class="col-md-5 col-md-offset-2 col-sm-12">
-                    <a href="https://github.com/OpenGeoscience/geojs"><h3><i class="fa fa-github"></i>Github</h3></a>
-                    <p class="text-muted">GeoJS is open source.  Contributions and requests are welcome.</p>
+                <div class="col-md-10 col-md-offset-1">
+                    <div class="col-md-6 col-sm-12">
+                        <a href="tutorials"><h3><i class="fa fa-graduation-cap"></i> Tutorials</h3></a>
+                        <p class="text-muted">How-to lessons ranging from simple to complex.</p>
+                    </div>
+                    <div class="col-md-6 col-sm-12">
+                        <a href="examples"><h3><i class="fa fa-star-o"></i> Examples</h3></a>
+                        <p class="text-muted">Examples, some with real-world data and some just to show off features.</p>
+                    </div>
+                    <div class="col-md-6 col-sm-12">
+                        <a href="http://geojs.readthedocs.io/en/latest/"><h3><i class="fa fa-book"></i> Documentation</h3></a>
+                        <p class="text-muted">Guides for users and developers, plus how to build and contribute to GeoJS.</p>
+                    </div>
+                    <div class="col-md-6 col-sm-12">
+                        <a href="download"><h3><i class="fa fa-download"></i> Download</h3></a>
+                        <p class="text-muted">Get a local copy of GeoJS or refer to it via a CDN.</p><p>&nbsp;</p>
+                    </div>
+                    <div class="col-md-6 col-sm-12">
+                        <a href="apidocs"><h3><i class="fa fa-code"></i> API Docs</h3></a>
+                        <p class="text-muted">Full documentation of the GeoJS API</p>
+                    </div>
+                    <div class="col-md-6 col-sm-12">
+                        <a href="https://github.com/OpenGeoscience/geojs"><h3><i class="fa fa-github"></i> Github</h3></a>
+                        <p class="text-muted">GeoJS is open source.  Contributions and requests are welcome.</p>
+                    </div>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
A user commented that tutorials weren't as easy to find as expected because they were only in the top bar navigation.

This PR goes from this:
![image](https://user-images.githubusercontent.com/8781639/44877241-590b6100-ac71-11e8-97d0-384e5c3aed23.png)
to this:
![image](https://user-images.githubusercontent.com/8781639/44877253-632d5f80-ac71-11e8-9c01-ed968ce7b8bb.png)
