### PR TITLE
Reduced use of the vgl module.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Changes
+- Removed the dependency on the vgl module for the `object` and `timestamp` classes (#918)
+
 ## Version 0.18.1
 
 ### Bug Fixes

--- a/examples/animation/main.js
+++ b/examples/animation/main.js
@@ -198,7 +198,7 @@ $(function () {
   function animation_frame() {
     var datalen = animationState.order.length,
         styles = animationState.styleArrays,
-        curTime = new Date().getTime(), genTime, updateTime,
+        curTime = Date.now(), genTime, updateTime,
         position, i, idx, p;
     timeRecords.frames.push(curTime);
     animationState.raf = null;
@@ -284,9 +284,9 @@ $(function () {
         updateStyles[key] = styles[key];
       }
     });
-    genTime = new Date().getTime();
+    genTime = Date.now();
     pointFeature.updateStyleFromArray(updateStyles, null, true);
-    updateTime = new Date().getTime();
+    updateTime = Date.now();
     timeRecords.generate.push(genTime - curTime);
     timeRecords.update.push(updateTime - genTime);
     show_framerate();
@@ -325,7 +325,7 @@ $(function () {
     if (animationState.position === undefined || animationState.position === null) {
       animationState.position = 0;
     }
-    animationState.startTime = new Date().getTime() - animationState.duration * animationState.position;
+    animationState.startTime = Date.now() - animationState.duration * animationState.position;
     if (!animationState.styleArrays || datalen !== animationState.order.length) {
       animationState.order = new Array(datalen);
       if (!animationState.orderedData) {

--- a/src/annotationLayer.js
+++ b/src/annotationLayer.js
@@ -908,7 +908,7 @@ var annotationLayer = function (args) {
    * @returns {this} The current layer.
    */
   this._update = function () {
-    if (m_this.getMTime() > m_buildTime.getMTime()) {
+    if (m_this.timestamp() > m_buildTime.timestamp()) {
       var labels = m_this.options('showLabels') ? [] : null,
           editable = m_this.options('clickToEdit') || m_this.mode() === m_this.modes.edit;
       /* Interally, we have a set of feature levels (to provide z-index

--- a/src/canvas/heatmapFeature.js
+++ b/src/canvas/heatmapFeature.js
@@ -297,7 +297,7 @@ var canvas_heatmapFeature = function (arg) {
    */
   this._renderOnCanvas = function (context2d, map) {
 
-    if (m_renderTime.getMTime() < m_this.buildTime().getMTime()) {
+    if (m_renderTime.timestamp() < m_this.buildTime().timestamp()) {
       var data = m_this.data() || [],
           radius = m_this.style('radius') + m_this.style('blurRadius'),
           binned = m_this.binned(),
@@ -375,8 +375,8 @@ var canvas_heatmapFeature = function (arg) {
    */
   this._update = function () {
     s_update.call(m_this);
-    if (m_this.buildTime().getMTime() <= m_this.dataTime().getMTime() ||
-        m_this.updateTime().getMTime() < m_this.getMTime()) {
+    if (m_this.buildTime().timestamp() <= m_this.dataTime().timestamp() ||
+        m_this.updateTime().timestamp() < m_this.timestamp()) {
       m_this._build();
     }
     m_this.updateTime().modified();

--- a/src/canvas/quadFeature.js
+++ b/src/canvas/quadFeature.js
@@ -224,8 +224,8 @@ var canvas_quadFeature = function (arg) {
    */
   this._update = function () {
     s_update.call(m_this);
-    if (m_this.buildTime().getMTime() <= m_this.dataTime().getMTime() ||
-        m_this.updateTime().getMTime() < m_this.getMTime()) {
+    if (m_this.buildTime().timestamp() <= m_this.dataTime().timestamp() ||
+        m_this.updateTime().timestamp() < m_this.timestamp()) {
       m_this._build();
     }
 

--- a/src/d3/lineFeature.js
+++ b/src/d3/lineFeature.js
@@ -121,7 +121,7 @@ var d3_lineFeature = function (arg) {
   this._update = function () {
     s_update.call(m_this);
 
-    if (m_this.getMTime() >= m_buildTime.getMTime()) {
+    if (m_this.timestamp() >= m_buildTime.timestamp()) {
       m_this._build();
     }
 

--- a/src/d3/pathFeature.js
+++ b/src/d3/pathFeature.js
@@ -104,7 +104,7 @@ var d3_pathFeature = function (arg) {
   this._update = function () {
     s_update.call(m_this);
 
-    if (m_this.dataTime().getMTime() >= m_buildTime.getMTime()) {
+    if (m_this.dataTime().timestamp() >= m_buildTime.timestamp()) {
       m_this._build();
     }
 

--- a/src/d3/pointFeature.js
+++ b/src/d3/pointFeature.js
@@ -96,7 +96,7 @@ var d3_pointFeature = function (arg) {
   this._update = function () {
     s_update.call(m_this);
 
-    if (m_this.getMTime() >= m_buildTime.getMTime()) {
+    if (m_this.timestamp() >= m_buildTime.timestamp()) {
       m_this._build();
     }
 

--- a/src/d3/quadFeature.js
+++ b/src/d3/quadFeature.js
@@ -196,8 +196,8 @@ var d3_quadFeature = function (arg) {
    */
   this._update = function () {
     s_update.call(m_this);
-    if (m_this.buildTime().getMTime() <= m_this.dataTime().getMTime() ||
-        m_this.buildTime().getMTime() < m_this.getMTime()) {
+    if (m_this.buildTime().timestamp() <= m_this.dataTime().timestamp() ||
+        m_this.buildTime().timestamp() < m_this.timestamp()) {
       m_this._build();
     }
     return m_this;

--- a/src/d3/vectorFeature.js
+++ b/src/d3/vectorFeature.js
@@ -252,7 +252,7 @@ var d3_vectorFeature = function (arg) {
   this._update = function () {
     s_update.call(m_this);
 
-    if (m_this.getMTime() >= m_buildTime.getMTime()) {
+    if (m_this.timestamp() >= m_buildTime.timestamp()) {
       m_this._build();
     } else {
       updateMarkers(

--- a/src/featureLayer.js
+++ b/src/featureLayer.js
@@ -200,7 +200,7 @@ var featureLayer = function (arg) {
     // Call base class update
     s_update.call(m_this, request);
 
-    if (m_this.dataTime().getMTime() > m_this.updateTime().getMTime()) {
+    if (m_this.dataTime().timestamp() > m_this.updateTime().timestamp()) {
       for (i = 0; i < m_features.length; i += 1) {
         m_features[i].renderer(m_this.renderer());
       }

--- a/src/gl/choroplethFeature.js
+++ b/src/gl/choroplethFeature.js
@@ -71,8 +71,8 @@ var gl_choroplethFeature = function (arg) {
    */
   this._update = function () {
     s_update.call(m_this);
-    if (m_this.dataTime().getMTime() >= m_this.buildTime().getMTime() ||
-        m_this.updateTime().getMTime() <= m_this.getMTime()) {
+    if (m_this.dataTime().timestamp() >= m_this.buildTime().timestamp() ||
+        m_this.updateTime().timestamp() <= m_this.timestamp()) {
       m_this._wipePolygons();
       m_this._build();
     }

--- a/src/gl/contourFeature.js
+++ b/src/gl/contourFeature.js
@@ -263,8 +263,8 @@ var gl_contourFeature = function (arg) {
   this._update = function () {
     s_update.call(m_this);
 
-    if (m_this.dataTime().getMTime() >= m_this.buildTime().getMTime() ||
-        m_this.updateTime().getMTime() <= m_this.getMTime()) {
+    if (m_this.dataTime().timestamp() >= m_this.buildTime().timestamp() ||
+        m_this.updateTime().timestamp() <= m_this.timestamp()) {
       m_this._build();
     }
 

--- a/src/gl/lineFeature.js
+++ b/src/gl/lineFeature.js
@@ -754,7 +754,7 @@ var gl_lineFeature = function (arg) {
    * @returns {this}
    */
   this._build = function () {
-    createGLLines(m_this.dataTime().getMTime() < m_this.buildTime().getMTime() && m_geometry);
+    createGLLines(m_this.dataTime().timestamp() < m_this.buildTime().timestamp() && m_geometry);
 
     if (!m_this.renderer().contextRenderer().hasActor(m_actor)) {
       m_this.renderer().contextRenderer().addActor(m_actor);
@@ -771,8 +771,8 @@ var gl_lineFeature = function (arg) {
   this._update = function () {
     s_update.call(m_this);
 
-    if (m_this.dataTime().getMTime() >= m_this.buildTime().getMTime() ||
-        m_this.updateTime().getMTime() <= m_this.getMTime()) {
+    if (m_this.dataTime().timestamp() >= m_this.buildTime().timestamp() ||
+        m_this.updateTime().timestamp() <= m_this.timestamp()) {
       m_this._build();
     }
 

--- a/src/gl/pointFeature.js
+++ b/src/gl/pointFeature.js
@@ -621,8 +621,8 @@ var gl_pointFeature = function (arg) {
 
     // For now build if the data or style changes. In the future we may
     // we able to partially update the data using dynamic gl buffers.
-    if (m_this.dataTime().getMTime() >= m_this.buildTime().getMTime() ||
-        m_this.updateTime().getMTime() < m_this.getMTime()) {
+    if (m_this.dataTime().timestamp() >= m_this.buildTime().timestamp() ||
+        m_this.updateTime().timestamp() < m_this.timestamp()) {
       m_this._build();
     }
 

--- a/src/gl/polygonFeature.js
+++ b/src/gl/polygonFeature.js
@@ -322,7 +322,7 @@ var gl_polygonFeature = function (arg) {
    * @override
    */
   this._build = function () {
-    createGLPolygons(m_this.dataTime().getMTime() < m_this.buildTime().getMTime() && m_geometry);
+    createGLPolygons(m_this.dataTime().timestamp() < m_this.buildTime().timestamp() && m_geometry);
 
     if (!m_this.renderer().contextRenderer().hasActor(m_actor)) {
       m_this.renderer().contextRenderer().addActor(m_actor);
@@ -352,8 +352,8 @@ var gl_polygonFeature = function (arg) {
     }
     s_update.call(m_this);
 
-    if (m_this.dataTime().getMTime() >= m_this.buildTime().getMTime() ||
-        m_this.updateTime().getMTime() <= m_this.getMTime()) {
+    if (m_this.dataTime().timestamp() >= m_this.buildTime().timestamp() ||
+        m_this.updateTime().timestamp() <= m_this.timestamp()) {
       m_this._build();
     }
 

--- a/src/gl/quadFeature.js
+++ b/src/gl/quadFeature.js
@@ -1,6 +1,7 @@
 var inherit = require('../inherit');
 var registerFeature = require('../registry').registerFeature;
 var quadFeature = require('../quadFeature');
+var timestamp = require('../timestamp');
 
 /**
  * Create a new instance of class quadFeature.
@@ -31,8 +32,8 @@ var gl_quadFeature = function (arg) {
       m_modelViewUniform,
       m_actor_image, m_actor_color, m_glBuffers = {}, m_imgposbuf,
       m_clrposbuf, m_clrModelViewUniform,
-      m_glCompileTimestamp = vgl.timestamp(),
-      m_glColorCompileTimestamp = vgl.timestamp(),
+      m_glCompileTimestamp = timestamp(),
+      m_glColorCompileTimestamp = timestamp(),
       m_quads;
   var fragmentShaderImageSource = [
     'varying highp vec2 iTextureCoord;',
@@ -145,6 +146,29 @@ var gl_quadFeature = function (arg) {
   }
 
   /**
+   * Get a vgl mapper, mark dynamicDraw, augment the timestamp and the render
+   * function.
+   *
+   * @private
+   * @param {function} renderFunc Our own render function.
+   * @returns {vgl.mapper} a vgl mapper object.
+   */
+  function getVGLMapper(renderFunc) {
+    var mapper = new vgl.mapper({dynamicDraw: true});
+    mapper.s_modified = mapper.modified;
+    mapper.g_timestamp = timestamp();
+    mapper.timestamp = mapper.g_timestamp.timestamp;
+    mapper.modified = function () {
+      mapper.s_modified();
+      mapper.g_timestamp.modified();
+      return mapper;
+    };
+    mapper.s_render = mapper.render;
+    mapper.render = renderFunc;
+    return mapper;
+  }
+
+  /**
    * Build this feature.
    */
   this._build = function () {
@@ -157,7 +181,7 @@ var gl_quadFeature = function (arg) {
     /* Create an actor to render image quads */
     if (m_quads.imgQuads.length && !m_actor_image) {
       m_this.visible(false);
-      mapper = new vgl.mapper({dynamicDraw: true});
+      mapper = getVGLMapper(m_this._renderImageQuads);
       m_actor_image = new vgl.actor();
       /* This is similar to vgl.utils.createTextureMaterial */
       m_actor_image.setMapper(mapper);
@@ -193,16 +217,13 @@ var gl_quadFeature = function (arg) {
 
       mapper.setGeometryData(geom);
       m_actor_image.setMaterial(mat);
-
-      mapper.s_render = mapper.render;
-      mapper.render = m_this._renderImageQuads;
       m_this.renderer().contextRenderer().addActor(m_actor_image);
       m_this.visible(true);
     }
     /* Create an actor to render color quads */
     if (m_quads.clrQuads.length && !m_actor_color) {
       m_this.visible(false);
-      mapper = new vgl.mapper({dynamicDraw: true});
+      mapper = getVGLMapper(m_this._renderColorQuads);
       m_actor_color = new vgl.actor();
       /* This is similar to vgl.utils.createTextureMaterial */
       m_actor_color.setMapper(mapper);
@@ -231,8 +252,6 @@ var gl_quadFeature = function (arg) {
       mapper.setGeometryData(geom);
       m_actor_color.setMaterial(mat);
 
-      mapper.s_render = mapper.render;
-      mapper.render = m_this._renderColorQuads;
       m_this.renderer().contextRenderer().addActor(m_actor_color);
       m_this.visible(true);
     }
@@ -277,8 +296,8 @@ var gl_quadFeature = function (arg) {
       return;
     }
     var mapper = this;
-    if (mapper.getMTime() > m_glColorCompileTimestamp.getMTime() ||
-        m_this.dataTime().getMTime() > m_glColorCompileTimestamp.getMTime() ||
+    if (mapper.timestamp() > m_glColorCompileTimestamp.timestamp() ||
+        m_this.dataTime().timestamp() > m_glColorCompileTimestamp.timestamp() ||
         renderState.m_contextChanged || !m_clrposbuf ||
         m_quads.clrQuads.length * 12 > m_clrposbuf.length) {
       setupColorDrawObjects(renderState);
@@ -324,8 +343,8 @@ var gl_quadFeature = function (arg) {
       return;
     }
     var mapper = this;
-    if (mapper.getMTime() > m_glCompileTimestamp.getMTime() ||
-        m_this.dataTime().getMTime() > m_glCompileTimestamp.getMTime() ||
+    if (mapper.timestamp() > m_glCompileTimestamp.timestamp() ||
+        m_this.dataTime().timestamp() > m_glCompileTimestamp.timestamp() ||
         renderState.m_contextChanged || !m_imgposbuf ||
         m_quads.imgQuads.length * 12 > m_imgposbuf.length) {
       setupDrawObjects(renderState);
@@ -371,8 +390,8 @@ var gl_quadFeature = function (arg) {
    */
   this._update = function () {
     s_update.call(m_this);
-    if (m_this.buildTime().getMTime() <= m_this.dataTime().getMTime() ||
-        m_this.updateTime().getMTime() < m_this.getMTime()) {
+    if (m_this.buildTime().timestamp() <= m_this.dataTime().timestamp() ||
+        m_this.updateTime().timestamp() < m_this.timestamp()) {
       m_this._build();
     }
     if (m_actor_color) {

--- a/src/isolineFeature.js
+++ b/src/isolineFeature.js
@@ -536,7 +536,7 @@ var isolineFeature = function (arg) {
    * @returns {this}
    */
   this.labelPositions = function () {
-    if (m_this.dataTime().getMTime() >= m_this.buildTime().getMTime()) {
+    if (m_this.dataTime().timestamp() >= m_this.buildTime().timestamp()) {
       m_this._build();
     }
     m_lastLabelPositions = null;
@@ -756,8 +756,8 @@ var isolineFeature = function (arg) {
   this._update = function () {
     s_update.call(m_this);
 
-    if (m_this.dataTime().getMTime() >= m_this.buildTime().getMTime() ||
-        m_this.updateTime().getMTime() <= m_this.getMTime()) {
+    if (m_this.dataTime().timestamp() >= m_this.buildTime().timestamp() ||
+        m_this.updateTime().timestamp() <= m_this.timestamp()) {
       m_this._build();
     }
     m_this.updateTime().modified();

--- a/src/lineFeature.js
+++ b/src/lineFeature.js
@@ -142,8 +142,8 @@ var lineFeature = function (arg) {
    * @returns {object} The point search information record.
    */
   this._updatePointSearchInfo = function () {
-    if (m_pointSearchTime.getMTime() >= m_this.dataTime().getMTime() &&
-        m_pointSearchTime.getMTime() >= m_this.getMTime()) {
+    if (m_pointSearchTime.timestamp() >= m_this.dataTime().timestamp() &&
+        m_pointSearchTime.timestamp() >= m_this.timestamp()) {
       return m_pointSearchInfo;
     }
     m_pointSearchTime.modified();

--- a/src/map.js
+++ b/src/map.js
@@ -1,5 +1,4 @@
 var $ = require('jquery');
-var vgl = require('vgl');
 var inherit = require('./inherit');
 var sceneObject = require('./sceneObject');
 
@@ -1097,10 +1096,10 @@ var map = function (arg) {
 
     // Transform zoom level into z-coordinate and inverse.
     function zoom2z(z) {
-      return vgl.zoomToHeight(z + 1, m_width, m_height) * units;
+      return Math.pow(2, -(z + 1)) * units * m_height;
     }
     function z2zoom(z) {
-      return vgl.heightToZoom(z / units, m_width, m_height) - 1;
+      return -Math.log2(z / units / m_height) - 1;
     }
 
     var defaultOpts = {

--- a/src/object.js
+++ b/src/object.js
@@ -1,12 +1,12 @@
-var vgl = require('vgl');
 var inherit = require('./inherit');
+var timestamp = require('./timestamp');
 
 /**
  * Create a new instance of class object.
  *
  * @class
  * @alias geo.object
- * @extends vgl.object
+ * @extends geo.timestamp
  * @returns {geo.object}
  */
 var object = function () {
@@ -211,10 +211,11 @@ var object = function () {
     m_this.geoOff();
   };
 
-  vgl.object.call(this);
+  timestamp.call(this);
+  this.modified();
 
   return this;
 };
 
-inherit(object, vgl.object);
+inherit(object, timestamp);
 module.exports = object;

--- a/src/pixelmapFeature.js
+++ b/src/pixelmapFeature.js
@@ -352,8 +352,8 @@ var pixelmapFeature = function (arg) {
    */
   this._update = function () {
     s_update.call(m_this);
-    if (m_this.buildTime().getMTime() <= m_this.dataTime().getMTime() ||
-        m_this.updateTime().getMTime() < m_this.getMTime()) {
+    if (m_this.buildTime().timestamp() <= m_this.dataTime().timestamp() ||
+        m_this.updateTime().timestamp() < m_this.timestamp()) {
       m_this._build();
     }
 

--- a/src/pointFeature.js
+++ b/src/pointFeature.js
@@ -226,7 +226,7 @@ var pointFeature = function (arg) {
    * data changes.
    */
   this._updateRangeTree = function () {
-    if (m_rangeTreeTime.getMTime() >= m_this.dataTime().getMTime()) {
+    if (m_rangeTreeTime.timestamp() >= m_this.dataTime().timestamp()) {
       return;
     }
     var pts, position,

--- a/src/timestamp.js
+++ b/src/timestamp.js
@@ -1,12 +1,11 @@
-var vgl = require('vgl');
-var inherit = require('./inherit');
+var m_globalTimestamp = 0;
 
 /**
- * Create a new instance of class timestamp.
+ * Create a new instance of class timestamp.  The timestamp is a globally
+ * unique integer that monotonically increases.
  *
  * @class
  * @alias geo.timestamp
- * @extends vgl.timestamp
  * @returns {geo.timestamp}
  */
 var timestamp = function () {
@@ -14,8 +13,35 @@ var timestamp = function () {
   if (!(this instanceof timestamp)) {
     return new timestamp();
   }
-  vgl.timestamp.call(this);
+
+  var m_this = this,
+      m_timestamp = 0;
+
+  /**
+   * Update the timestamp to the next global timestamp value.
+   *
+   * @returns {this}
+   */
+  this.modified = function () {
+    m_globalTimestamp += 1;
+    m_timestamp = m_globalTimestamp;
+    return m_this;
+  };
+
+  /**
+   * Get time.
+   *
+   * @returns {number} The timestamp.  This is 0 if the timestamp has never
+   *    been modified.
+   */
+  this.timestamp = function () {
+    return m_timestamp;
+  };
+
+  // Also refer to `timestamp` under an alternate name
+  this.getMTime = this.timestamp;
+
+  return this;
 };
 
-inherit(timestamp, vgl.timestamp);
 module.exports = timestamp;

--- a/tests/cases/annotation.js
+++ b/tests/cases/annotation.js
@@ -56,7 +56,7 @@ describe('geo.annotation', function () {
       mouse: {mapgcs: map.displayToGcs(end, null)},
       state: {origin: {mapgcs: map.displayToGcs(start, null)}},
       buttonsDown: {},
-      time: new Date().getTime()
+      time: Date.now()
     };
   }
 
@@ -246,9 +246,9 @@ describe('geo.annotation', function () {
     });
     it('modified', function () {
       var ann = geo.annotation.annotation('test', {layer: layer});
-      var buildTime = layer.getMTime();
+      var buildTime = layer.timestamp();
       ann.modified();
-      expect(layer.getMTime()).toBeGreaterThan(buildTime);
+      expect(layer.timestamp()).toBeGreaterThan(buildTime);
     });
     it('draw', function () {
       var oldDraw = layer.draw, drawCalled = 0;
@@ -738,7 +738,7 @@ describe('geo.annotation', function () {
         annotations: ['rectangle']
       });
       var ann = geo.annotation.rectangleAnnotation({layer: layer});
-      var time = new Date().getTime();
+      var time = Date.now();
       expect(ann.mouseClick({
         buttonsDown: {left: true},
         time: time,
@@ -987,7 +987,7 @@ describe('geo.annotation', function () {
         annotations: ['polygon']
       });
       var ann = geo.annotation.polygonAnnotation({layer: layer});
-      var time = new Date().getTime();
+      var time = Date.now();
       expect(ann.mouseClick({
         buttonsDown: {left: true},
         time: time,
@@ -1219,7 +1219,7 @@ describe('geo.annotation', function () {
         annotations: ['line']
       });
       var ann = geo.annotation.lineAnnotation({layer: layer});
-      var time = new Date().getTime();
+      var time = Date.now();
       expect(ann.mouseClick({
         buttonsDown: {left: true},
         time: time,

--- a/tests/cases/annotationLayer.js
+++ b/tests/cases/annotationLayer.js
@@ -414,7 +414,7 @@ describe('geo.annotationLayer', function () {
       layer.mode('polygon');
       expect(layer.annotations().length).toBe(1);
       expect(layer.annotations()[0].options('vertices').length).toBe(0);
-      var time = new Date().getTime();
+      var time = Date.now();
       layer._handleMouseClick({
         buttonsDown: {left: true},
         time: time,
@@ -561,7 +561,7 @@ describe('geo.annotationLayer', function () {
     it('_handleMouseMove', function () {
       layer.removeAllAnnotations();
       layer.mode('polygon');
-      var time = new Date().getTime();
+      var time = Date.now();
       layer._handleMouseClick({
         buttonsDown: {left: true},
         time: time,
@@ -582,14 +582,14 @@ describe('geo.annotationLayer', function () {
       layer.removeAllAnnotations();
       layer.addAnnotation(point);
       layer._update();
-      var mod = layer.features()[0].getMTime();
+      var mod = layer.features()[0].timestamp();
       layer._handleZoom();
-      expect(layer.features()[0].getMTime()).toBe(mod);
+      expect(layer.features()[0].timestamp()).toBe(mod);
       layer.annotations()[0].options({style: {scaled: true}});
       layer._update();
-      mod = layer.features()[0].getMTime();
+      mod = layer.features()[0].timestamp();
       layer._handleZoom();
-      expect(layer.features()[0].getMTime()).toBeGreaterThan(mod);
+      expect(layer.features()[0].timestamp()).toBeGreaterThan(mod);
     });
     it('_processAction', function () {
       layer.removeAllAnnotations();

--- a/tests/cases/feature.js
+++ b/tests/cases/feature.js
@@ -194,19 +194,19 @@ describe('geo.feature', function () {
     });
     it('visible', function () {
       expect(feat.visible()).toBe(true);
-      var modTime = feat.getMTime();
+      var modTime = feat.timestamp();
       expect(feat.visible(false)).toBe(feat);
       expect(feat.visible()).toBe(false);
-      expect(feat.getMTime()).toBeGreaterThan(modTime);
+      expect(feat.timestamp()).toBeGreaterThan(modTime);
 
       expect(feat.visible(true)).toBe(feat);
       var depFeat = geo.feature({layer: layer, renderer: layer.renderer()});
       feat.dependentFeatures([depFeat]);
-      modTime = depFeat.getMTime();
+      modTime = depFeat.timestamp();
       expect(feat.visible(false)).toBe(feat);
       expect(feat.visible()).toBe(false);
       expect(depFeat.visible()).toBe(false);
-      expect(depFeat.getMTime()).toBeGreaterThan(modTime);
+      expect(depFeat.timestamp()).toBeGreaterThan(modTime);
       feat.dependentFeatures([]);
       expect(feat.visible(true)).toBe(feat);
       expect(depFeat.visible()).toBe(false);

--- a/tests/cases/featureLayer.js
+++ b/tests/cases/featureLayer.js
@@ -161,14 +161,14 @@ describe('geo.featureLayer', function () {
       expect(feat1.draw.calledOnce).toBe(true);
     });
     it('clear', function () {
-      var modTime = layer.getMTime();
+      var modTime = layer.timestamp();
       expect(layer.clear()).toBe(layer);
       expect(layer.features().length).toBe(0);
-      expect(layer.getMTime()).toBeGreaterThan(modTime);
-      modTime = layer.getMTime();
+      expect(layer.timestamp()).toBeGreaterThan(modTime);
+      modTime = layer.timestamp();
       expect(layer.clear()).toBe(layer);
       expect(layer.features().length).toBe(0);
-      expect(layer.getMTime()).toBe(modTime);
+      expect(layer.timestamp()).toBe(modTime);
     });
   });
 });

--- a/tests/cases/heatmap.js
+++ b/tests/cases/heatmap.js
@@ -44,7 +44,7 @@ describe('canvas heatmap', function () {
         .style('blurRadius', 15);
 
       map.draw();
-      stepAnimationFrame(new Date().getTime());
+      stepAnimationFrame(Date.now());
       expect(layer.children().length).toBe(1);
       // leave animation frames mocked for later tests.
     });
@@ -79,21 +79,21 @@ describe('canvas heatmap', function () {
     });
     it('_animatePan', function () {
       map.draw();
-      var buildTime = feature1.buildTime().getMTime();
+      var buildTime = feature1.buildTime().timestamp();
       map.pan({x: 10, y: 0});
-      expect(feature1.buildTime().getMTime()).toBe(buildTime);
+      expect(feature1.buildTime().timestamp()).toBe(buildTime);
       clock.tick(800);
       map.pan({x: 10, y: 0});
-      expect(feature1.buildTime().getMTime()).toBe(buildTime);
+      expect(feature1.buildTime().timestamp()).toBe(buildTime);
       clock.tick(800);
-      expect(feature1.buildTime().getMTime()).toBe(buildTime);
+      expect(feature1.buildTime().timestamp()).toBe(buildTime);
       clock.tick(800);
-      expect(feature1.buildTime().getMTime()).not.toBe(buildTime);
-      buildTime = feature1.buildTime().getMTime();
+      expect(feature1.buildTime().timestamp()).not.toBe(buildTime);
+      buildTime = feature1.buildTime().timestamp();
       map.pan({x: 0, y: 0});
-      expect(feature1.buildTime().getMTime()).toBe(buildTime);
+      expect(feature1.buildTime().timestamp()).toBe(buildTime);
       clock.tick(2000);
-      expect(feature1.buildTime().getMTime()).toBe(buildTime);
+      expect(feature1.buildTime().timestamp()).toBe(buildTime);
     });
     it('radius, blurRadius, and gaussian', function () {
       // animation frames are already mocked
@@ -104,18 +104,18 @@ describe('canvas heatmap', function () {
       expect(feature1._circle.height).toBe(40);
       feature1.style('gaussian', false);
       map.draw();
-      stepAnimationFrame(new Date().getTime());
+      stepAnimationFrame(Date.now());
       expect(feature1._circle.gaussian).toBe(false);
       feature1.style('radius', 10);
       expect(feature1._circle.radius).toBe(5);
       map.draw();
-      stepAnimationFrame(new Date().getTime());
+      stepAnimationFrame(Date.now());
       expect(feature1._circle.radius).toBe(10);
       expect(feature1._circle.width).toBe(50);
       expect(feature1._circle.height).toBe(50);
       feature1.style('blurRadius', 0);
       map.draw();
-      stepAnimationFrame(new Date().getTime());
+      stepAnimationFrame(Date.now());
       expect(feature1._circle.blurRadius).toBe(0);
       expect(feature1._circle.width).toBe(20);
       expect(feature1._circle.height).toBe(20);
@@ -131,19 +131,19 @@ describe('canvas heatmap', function () {
           idx;
       feature1.style({radius: r, blurRadius: 0});
       map.draw();
-      stepAnimationFrame(new Date().getTime());
+      stepAnimationFrame(Date.now());
       expect(feature1._binned).toBe(false);
       feature1.binned(true);
       map.draw();
-      stepAnimationFrame(new Date().getTime());
+      stepAnimationFrame(Date.now());
       expect(feature1._binned).toBe(r / 8);
       feature1.binned(2);
       map.draw();
-      stepAnimationFrame(new Date().getTime());
+      stepAnimationFrame(Date.now());
       expect(feature1._binned).toBe(2);
       feature1.binned(20);
       map.draw();
-      stepAnimationFrame(new Date().getTime());
+      stepAnimationFrame(Date.now());
       expect(feature1._binned).toBe(20);
       for (idx = data.length; idx < numpoints + 1; idx += 1) {
         data.push([
@@ -152,16 +152,16 @@ describe('canvas heatmap', function () {
       feature1.data(data);
       feature1.binned('auto');
       map.draw();
-      stepAnimationFrame(new Date().getTime());
+      stepAnimationFrame(Date.now());
       expect(feature1._binned).toBe(r / 8);
       data.splice(numpoints);
       feature1.data(data);
       map.draw();
-      stepAnimationFrame(new Date().getTime());
+      stepAnimationFrame(Date.now());
       expect(feature1._binned).toBe(false);
       feature1.binned(true);
       map.zoom(10);
-      stepAnimationFrame(new Date().getTime());
+      stepAnimationFrame(Date.now());
       expect(feature1._binned).toBe(r / 8);
     });
     it('Remove a feature from a layer', function () {

--- a/tests/cases/isolineFeature.js
+++ b/tests/cases/isolineFeature.js
@@ -386,16 +386,16 @@ describe('Isoline Feature', function () {
       var isoline = layer.createFeature('isoline', {
         isoline: {elements: squareElements}}).data(vertexList);
       isoline.modified();
-      updateTime = isoline.updateTime().getMTime();
-      buildTime = isoline.buildTime().getMTime();
+      updateTime = isoline.updateTime().timestamp();
+      buildTime = isoline.buildTime().timestamp();
       expect(isoline._update()).toBe(isoline);
-      expect(isoline.updateTime().getMTime()).toBeGreaterThan(updateTime);
-      expect(isoline.buildTime().getMTime()).toBeGreaterThan(buildTime);
-      updateTime = isoline.updateTime().getMTime();
-      buildTime = isoline.buildTime().getMTime();
+      expect(isoline.updateTime().timestamp()).toBeGreaterThan(updateTime);
+      expect(isoline.buildTime().timestamp()).toBeGreaterThan(buildTime);
+      updateTime = isoline.updateTime().timestamp();
+      buildTime = isoline.buildTime().timestamp();
       expect(isoline._update()).toBe(isoline);
-      expect(isoline.updateTime().getMTime()).toBeGreaterThan(updateTime);
-      expect(isoline.buildTime().getMTime()).toBe(buildTime);
+      expect(isoline.updateTime().timestamp()).toBeGreaterThan(updateTime);
+      expect(isoline.buildTime().timestamp()).toBe(buildTime);
     });
     it('_updateLabelPositions', function () {
       var isoline = layer.createFeature('isoline', {

--- a/tests/cases/map.js
+++ b/tests/cases/map.js
@@ -228,7 +228,7 @@ describe('geo.core.map', function () {
       var error = sinon.stub(console, 'error', function () {}),
           m = createMap(),
           called = 0,
-          start = new Date().getTime();
+          start = Date.now();
       m.scheduleAnimationFrame(function () { throw new Error('fail'); });
       m.scheduleAnimationFrame(function () { called += 1; });
       stepAnimationFrame(start);
@@ -542,7 +542,7 @@ describe('geo.core.map', function () {
       mockAnimationFrame();
       var m = createMap(), start, wasCalled;
       expect(m.transition()).toBe(null);
-      start = new Date().getTime();
+      start = Date.now();
       m.transition({
         center: {x: 10, y: 0},
         zoom: 2,
@@ -650,7 +650,7 @@ describe('geo.core.map', function () {
       expect(m.center().x).toBeCloseTo(0);
       expect(m.center().y).toBeCloseTo(0);
       // test cancel
-      start = new Date().getTime();
+      start = Date.now();
       wasCalled = undefined;
       m.transition({
         center: {x: 10, y: 0},

--- a/tests/cases/mapInteractor.js
+++ b/tests/cases/mapInteractor.js
@@ -1352,7 +1352,7 @@ describe('mapInteractor', function () {
     expect(map.info.panArgs.y).toBe(0);
     interactor.simulateEvent(
       'mouseup', {map: {x: 10, y: 0}, button: 'left'});
-    start = new Date().getTime();
+    start = Date.now();
     stepAnimationFrame(start);
     expect(map.info.pan).toBe(2);
     expect(map.info.panArgs.x).toBeGreaterThan(0.25);
@@ -1412,7 +1412,7 @@ describe('mapInteractor', function () {
     expect(map.info.panArgs.x).toBeCloseTo(1);
     interactor.simulateEvent(
       'mouseup', {map: {x: 200.1, y: 0}, button: 'left'});
-    start = new Date().getTime();
+    start = Date.now();
     stepAnimationFrame(start);
     expect(map.info.pan).toBe(4);
     expect(map.info.panArgs.x).toBeLessThan(0);
@@ -1449,7 +1449,7 @@ describe('mapInteractor', function () {
         'wheel',
         {wheelDelta: {x: 0, y: -20}, wheelMode: 0}
       );
-      start = new Date().getTime();
+      start = Date.now();
       stepAnimationFrame(start);
       expect(map.zoom()).toBe(2);
       stepAnimationFrame(start + 50);
@@ -1469,7 +1469,7 @@ describe('mapInteractor', function () {
         'wheel',
         {wheelDelta: {x: 0, y: -20}, wheelMode: 0}
       );
-      start = new Date().getTime();
+      start = Date.now();
       stepAnimationFrame(start);
       expect(map.zoom()).toBe(2);
       stepAnimationFrame(start + 50);
@@ -1501,7 +1501,7 @@ describe('mapInteractor', function () {
         'wheel',
         {wheelDelta: {x: 0, y: -20}, wheelMode: 0}
       );
-      start = new Date().getTime();
+      start = Date.now();
       stepAnimationFrame(start);
       expect(map.zoom()).toBe(2);
       stepAnimationFrame(start + 50);
@@ -1535,7 +1535,7 @@ describe('mapInteractor', function () {
         'wheel',
         {wheelDelta: {x: 0, y: -20}, wheelMode: 0}
       );
-      start = new Date().getTime();
+      start = Date.now();
       stepAnimationFrame(start);
       expect(map.zoom()).toBe(2);
       stepAnimationFrame(start + 50);

--- a/tests/cases/pixelmapFeature.js
+++ b/tests/cases/pixelmapFeature.js
@@ -146,17 +146,17 @@ describe('geo.pixelmapFeature', function () {
           position: position,
           url: testImageSrc
         });
-        buildTime = pixelmap.buildTime().getMTime();
+        buildTime = pixelmap.buildTime().timestamp();
         pixelmap._build().then(function () {
-          expect(pixelmap.buildTime().getMTime()).toBeGreaterThan(buildTime);
+          expect(pixelmap.buildTime().timestamp()).toBeGreaterThan(buildTime);
           expect(pixelmap.maxIndex()).toBe(6);
           done();
         });
       });
       it('built', function () {
-        buildTime = pixelmap.buildTime().getMTime();
+        buildTime = pixelmap.buildTime().timestamp();
         expect(pixelmap._build()).toBe(pixelmap);
-        expect(pixelmap.buildTime().getMTime()).toBeGreaterThan(buildTime);
+        expect(pixelmap.buildTime().timestamp()).toBeGreaterThan(buildTime);
       });
       it('unloaded image', function (done) {
         var img = new Image(), loaded;
@@ -199,21 +199,21 @@ describe('geo.pixelmapFeature', function () {
           position: position,
           url: testImageSrc
         });
-        buildTime = pixelmap.buildTime().getMTime();
-        updateTime = pixelmap.updateTime().getMTime();
+        buildTime = pixelmap.buildTime().timestamp();
+        updateTime = pixelmap.updateTime().timestamp();
         pixelmap._update().then(function () {
-          expect(pixelmap.buildTime().getMTime()).toBeGreaterThan(buildTime);
-          expect(pixelmap.updateTime().getMTime()).toBeGreaterThan(updateTime);
+          expect(pixelmap.buildTime().timestamp()).toBeGreaterThan(buildTime);
+          expect(pixelmap.updateTime().timestamp()).toBeGreaterThan(updateTime);
           expect(pixelmap.maxIndex()).toBe(6);
           done();
         });
       });
       it('updated', function (done) {
-        buildTime = pixelmap.buildTime().getMTime();
-        updateTime = pixelmap.updateTime().getMTime();
+        buildTime = pixelmap.buildTime().timestamp();
+        updateTime = pixelmap.updateTime().timestamp();
         pixelmap._update().then(function () {
-          expect(pixelmap.buildTime().getMTime()).toBe(buildTime);
-          expect(pixelmap.updateTime().getMTime()).toBeGreaterThan(updateTime);
+          expect(pixelmap.buildTime().timestamp()).toBe(buildTime);
+          expect(pixelmap.updateTime().timestamp()).toBeGreaterThan(updateTime);
           done();
         });
       });
@@ -297,11 +297,11 @@ describe('geo.pixelmapFeature', function () {
       });
       /* Trigger rerendering */
       pixelmap.data(['a', 'b', 'c', 'd', 'e', 'f']);
-      buildTime = pixelmap.buildTime().getMTime();
+      buildTime = pixelmap.buildTime().timestamp();
       logCanvas2D();
       counts = $.extend({}, window._canvasLog.counts);
       map.draw();
-      expect(buildTime).not.toEqual(pixelmap.buildTime().getMTime());
+      expect(buildTime).not.toEqual(pixelmap.buildTime().timestamp());
     });
     waitForIt('next render canvas A', function () {
       return window._canvasLog.counts.clearRect >= (counts.clearRect || 0) + 1 &&

--- a/tests/cases/polygonFeature.js
+++ b/tests/cases/polygonFeature.js
@@ -337,11 +337,11 @@ describe('geo.polygonFeature', function () {
       map = createMap();
       layer = map.createLayer('feature');
       polygons = layer.createFeature('polygon', {style: testStyle, data: testPolygons});
-      buildTime = polygons.buildTime().getMTime();
+      buildTime = polygons.buildTime().timestamp();
       /* Trigger rerendering */
       polygons.data(testPolygons);
       map.draw();
-      expect(buildTime).not.toEqual(polygons.buildTime().getMTime());
+      expect(buildTime).not.toEqual(polygons.buildTime().timestamp());
       glCounts = $.extend({}, vgl.mockCounts());
     });
     waitForIt('next render gl A', function () {
@@ -360,55 +360,55 @@ describe('geo.polygonFeature', function () {
         return 'red';
       });
       glCounts = $.extend({}, vgl.mockCounts());
-      buildTime = polygons.buildTime().getMTime();
+      buildTime = polygons.buildTime().timestamp();
       polygons.draw();
     });
     waitForIt('next render gl B', function () {
       return vgl.mockCounts().bufferData >= (glCounts.bufferData || 0) + 1 &&
-             buildTime !== polygons.buildTime().getMTime();
+             buildTime !== polygons.buildTime().timestamp();
     });
     it('update the style B', function () {
       polygons.style('fillColor', function (d) {
         return '#ff0000';
       });
       glCounts = $.extend({}, vgl.mockCounts());
-      buildTime = polygons.buildTime().getMTime();
+      buildTime = polygons.buildTime().timestamp();
       polygons.draw();
     });
     waitForIt('next render gl C', function () {
       return vgl.mockCounts().bufferData >= (glCounts.bufferData || 0) + 1 &&
-             buildTime !== polygons.buildTime().getMTime();
+             buildTime !== polygons.buildTime().timestamp();
     });
     it('update the style C', function () {
       polygons.style('fill', function (d, i) {
         return i % 2 > 0;
       });
       glCounts = $.extend({}, vgl.mockCounts());
-      buildTime = polygons.buildTime().getMTime();
+      buildTime = polygons.buildTime().timestamp();
       polygons.draw();
     });
     waitForIt('next render gl D', function () {
       return vgl.mockCounts().bufferData >= (glCounts.bufferData || 0) + 1 &&
-             buildTime !== polygons.buildTime().getMTime();
+             buildTime !== polygons.buildTime().timestamp();
     });
     it('poor data', function () {
       polygons.data([undefined, testPolygons[1]]);
       polygons.style('fill', true);
       glCounts = $.extend({}, vgl.mockCounts());
-      buildTime = polygons.buildTime().getMTime();
+      buildTime = polygons.buildTime().timestamp();
       polygons.draw();
     });
     waitForIt('next render gl E', function () {
       return vgl.mockCounts().bufferData >= (glCounts.bufferData || 0) + 1 &&
-             buildTime !== polygons.buildTime().getMTime();
+             buildTime !== polygons.buildTime().timestamp();
     });
     it('_exit', function () {
-      var buildTime = polygons.buildTime().getMTime();
+      var buildTime = polygons.buildTime().timestamp();
       layer.deleteFeature(polygons);
       polygons.data(testPolygons);
       polygons._update();
       map.draw();
-      expect(buildTime).toEqual(polygons.buildTime().getMTime());
+      expect(buildTime).toEqual(polygons.buildTime().timestamp());
       destroyMap();
       restoreVGLRenderer();
     });

--- a/tests/cases/quadFeature.js
+++ b/tests/cases/quadFeature.js
@@ -513,11 +513,11 @@ describe('geo.quadFeature', function () {
       map = createMap();
       layer = map.createLayer('feature');
       quads = layer.createFeature('quad', {style: testStyle, data: testQuads});
-      buildTime = quads.buildTime().getMTime();
+      buildTime = quads.buildTime().timestamp();
       /* Trigger rerendering */
       quads.data(testQuads);
       map.draw();
-      expect(buildTime).not.toEqual(quads.buildTime().getMTime());
+      expect(buildTime).not.toEqual(quads.buildTime().timestamp());
       glCounts = $.extend({}, vgl.mockCounts());
     });
     waitForIt('next render gl A', function () {
@@ -525,10 +525,10 @@ describe('geo.quadFeature', function () {
     });
     it('only img quad', function () {
       glCounts = $.extend({}, vgl.mockCounts());
-      var buildTime = quads.buildTime().getMTime();
+      var buildTime = quads.buildTime().timestamp();
       quads.data([testQuads[0], testQuads[1]]);
       map.draw();
-      expect(buildTime).not.toEqual(quads.buildTime().getMTime());
+      expect(buildTime).not.toEqual(quads.buildTime().timestamp());
     });
     waitForIt('next render gl B', function () {
       return vgl.mockCounts().activeTexture >= glCounts.activeTexture + 2 &&
@@ -537,10 +537,10 @@ describe('geo.quadFeature', function () {
     });
     it('only clr quad', function () {
       glCounts = $.extend({}, vgl.mockCounts());
-      var buildTime = quads.buildTime().getMTime();
+      var buildTime = quads.buildTime().timestamp();
       quads.data([testQuads[8], testQuads[9]]);
       map.draw();
-      expect(buildTime).not.toEqual(quads.buildTime().getMTime());
+      expect(buildTime).not.toEqual(quads.buildTime().timestamp());
     });
     waitForIt('next render gl C', function () {
       return vgl.mockCounts().activeTexture === glCounts.activeTexture &&
@@ -563,11 +563,11 @@ describe('geo.quadFeature', function () {
              vgl.mockCounts().bufferSubData === glCounts.bufferSubData;
     });
     it('_exit', function () {
-      var buildTime = quads.buildTime().getMTime();
+      var buildTime = quads.buildTime().timestamp();
       layer.deleteFeature(quads);
       quads.data(testQuads);
       map.draw();
-      expect(buildTime).toEqual(quads.buildTime().getMTime());
+      expect(buildTime).toEqual(quads.buildTime().timestamp());
       destroyMap();
       restoreVGLRenderer();
     });
@@ -587,22 +587,22 @@ describe('geo.quadFeature', function () {
       map = createMap();
       layer = map.createLayer('feature', {renderer: 'canvas'});
       quads = layer.createFeature('quad', {style: testStyle, data: testQuads});
-      buildTime = quads.buildTime().getMTime();
+      buildTime = quads.buildTime().timestamp();
       /* Trigger rerendering */
       quads.data(testQuads);
       counts = $.extend({}, window._canvasLog.counts);
       map.draw();
-      expect(buildTime).not.toEqual(quads.buildTime().getMTime());
+      expect(buildTime).not.toEqual(quads.buildTime().timestamp());
     });
     waitForIt('next render canvas A', function () {
       return window._canvasLog.counts.clearRect >= (counts.clearRect || 0) + 1;
     });
     it('only img quad', function () {
       counts = $.extend({}, window._canvasLog.counts);
-      var buildTime = quads.buildTime().getMTime();
+      var buildTime = quads.buildTime().timestamp();
       quads.data([testQuads[0], testQuads[1]]);
       map.draw();
-      expect(buildTime).not.toEqual(quads.buildTime().getMTime());
+      expect(buildTime).not.toEqual(quads.buildTime().timestamp());
     });
     waitForIt('next render canvas B', function () {
       return window._canvasLog.counts.drawImage >= counts.drawImage + 2 &&
@@ -656,11 +656,11 @@ describe('geo.quadFeature', function () {
       logCanvas2D(false);  // disable call logging
     });
     it('_exit', function () {
-      var buildTime = quads.buildTime().getMTime();
+      var buildTime = quads.buildTime().timestamp();
       layer.deleteFeature(quads);
       quads.data(testQuads);
       map.draw();
-      expect(buildTime).toEqual(quads.buildTime().getMTime());
+      expect(buildTime).toEqual(quads.buildTime().timestamp());
     });
   });
 
@@ -677,31 +677,31 @@ describe('geo.quadFeature', function () {
       map = createMap();
       layer = map.createLayer('feature', {renderer: 'd3'});
       quads = layer.createFeature('quad', {style: testStyle, data: testQuads});
-      buildTime = quads.buildTime().getMTime();
+      buildTime = quads.buildTime().timestamp();
       /* Trigger rerendering */
       quads.data(testQuads);
       map.draw();
-      expect(buildTime).not.toEqual(quads.buildTime().getMTime());
+      expect(buildTime).not.toEqual(quads.buildTime().timestamp());
       /* Force the quads to render synchronously. */
       layer.renderer()._renderFrame();
       expect($('svg image').length).toBe(11);
       expect($('svg polygon').length).toBe(5);
     });
     it('only img quad', function () {
-      var buildTime = quads.buildTime().getMTime();
+      var buildTime = quads.buildTime().timestamp();
       quads.data([testQuads[0], testQuads[1]]);
       map.draw();
-      expect(buildTime).not.toEqual(quads.buildTime().getMTime());
+      expect(buildTime).not.toEqual(quads.buildTime().timestamp());
       /* Force the quads to render synchronously. */
       layer.renderer()._renderFrame();
       expect($('svg image').length).toBe(2);
       expect($('svg polygon').length).toBe(0);
     });
     it('only clr quad', function () {
-      var buildTime = quads.buildTime().getMTime();
+      var buildTime = quads.buildTime().timestamp();
       quads.data([testQuads[8], testQuads[9]]);
       map.draw();
-      expect(buildTime).not.toEqual(quads.buildTime().getMTime());
+      expect(buildTime).not.toEqual(quads.buildTime().timestamp());
       /* Force the quads to render synchronously. */
       layer.renderer()._renderFrame();
       expect($('svg image').length).toBe(0);
@@ -721,11 +721,11 @@ describe('geo.quadFeature', function () {
       expect($('svg polygon').length).toBe(200);
     });
     it('_exit', function () {
-      var buildTime = quads.buildTime().getMTime();
+      var buildTime = quads.buildTime().timestamp();
       layer.deleteFeature(quads);
       quads.data(testQuads);
       map.draw();
-      expect(buildTime).toEqual(quads.buildTime().getMTime());
+      expect(buildTime).toEqual(quads.buildTime().timestamp());
     });
   });
 });

--- a/tests/cases/timestamp.js
+++ b/tests/cases/timestamp.js
@@ -9,17 +9,17 @@ describe('geo.timestamp', function () {
     t2.modified();
     t3.modified();
 
-    expect(t1.getMTime()).toBe(t1.getMTime());
-    expect(t1.getMTime() < t2.getMTime()).toBe(true);
-    expect(t2.getMTime() < t3.getMTime()).toBe(true);
+    expect(t1.timestamp()).toBe(t1.timestamp());
+    expect(t1.timestamp() < t2.timestamp()).toBe(true);
+    expect(t2.timestamp() < t3.timestamp()).toBe(true);
 
     t2.modified();
     t3.modified();
     t2.modified();
 
-    expect(t2.getMTime()).toBe(t2.getMTime());
-    expect(t1.getMTime() < t2.getMTime()).toBe(true);
-    expect(t3.getMTime() < t2.getMTime()).toBe(true);
-    expect(t1.getMTime() < t3.getMTime()).toBe(true);
+    expect(t2.timestamp()).toBe(t2.timestamp());
+    expect(t1.timestamp() < t2.timestamp()).toBe(true);
+    expect(t3.timestamp() < t2.timestamp()).toBe(true);
+    expect(t1.timestamp() < t3.timestamp()).toBe(true);
   });
 });

--- a/tests/cases/widget.js
+++ b/tests/cases/widget.js
@@ -40,9 +40,9 @@ describe('geo.gui.widget', function () {
       map = createMap();
       layer = map.createLayer('ui');
       widget = geo.gui.widget({layer: layer});
-      modTime = widget.getMTime();
+      modTime = widget.timestamp();
       expect(widget._init()).toBe(widget);
-      expect(widget.getMTime()).toBeGreaterThan(modTime);
+      expect(widget.timestamp()).toBeGreaterThan(modTime);
     });
     it('_exit', function () {
       map = createMap();

--- a/tests/gl-cases/glLinesSpeed.js
+++ b/tests/gl-cases/glLinesSpeed.js
@@ -44,7 +44,7 @@ describe('glLinesSpeed', function () {
       // very minimal test threshold
       expect(totaltime).toBeLessThan(10000);
       /* Test animation time. */
-      starttime = new Date().getTime();
+      starttime = Date.now();
       animationFrame();
       $('#map').append($('<div style="display: none" id="loadResults">')
         .attr('results', totaltime));
@@ -84,7 +84,7 @@ describe('glLinesSpeed', function () {
     }
 
     function loadTest() {
-      starttime = new Date().getTime();
+      starttime = Date.now();
       feature.data(lines)
         .style({
           strokeColor: function (d) {
@@ -95,7 +95,7 @@ describe('glLinesSpeed', function () {
           strokeOpacity: 0.05
         });
       myMap.draw();
-      stoptime = new Date().getTime();
+      stoptime = Date.now();
       times.push(stoptime - starttime);
       if (times.length < 12 && stoptime - firsttime < 10000) {
         window.setTimeout(loadTest, 1);
@@ -119,7 +119,7 @@ describe('glLinesSpeed', function () {
       feature.actors()[0].mapper().updateSourceBuffer('strokeOpacity');
       myMap.draw();
       frames += 1;
-      stoptime = new Date().getTime();
+      stoptime = Date.now();
       animTimes.push(stoptime);
       if (animTimes.length < 2 || (animTimes.length < 201 &&
           stoptime - animTimes[0] < 10000)) {
@@ -147,7 +147,7 @@ describe('glLinesSpeed', function () {
         }
       }
 
-      firsttime = new Date().getTime();
+      firsttime = Date.now();
       loadTest();
     });
   }, 30000);

--- a/tests/gl-cases/glPointsSpeed.js
+++ b/tests/gl-cases/glPointsSpeed.js
@@ -44,7 +44,7 @@ describe('glPointsSpeed', function () {
       // very minimal test threshold
       expect(totaltime).toBeLessThan(10000);
       /* Test animation time. */
-      starttime = new Date().getTime();
+      starttime = Date.now();
       animationFrame();
       $('#map').append($('<div style="display: none" id="loadResults">')
         .attr('results', totaltime));
@@ -85,7 +85,7 @@ describe('glPointsSpeed', function () {
     }
 
     function loadTest() {
-      starttime = new Date().getTime();
+      starttime = Date.now();
       feature.data(points)
         .style({
           fillColor: 'black',
@@ -94,7 +94,7 @@ describe('glPointsSpeed', function () {
           radius: 5
         });
       myMap.draw();
-      stoptime = new Date().getTime();
+      stoptime = Date.now();
       times.push(stoptime - starttime);
       if (times.length < 12 && stoptime - firsttime < 10000) {
         window.setTimeout(loadTest, 1);
@@ -118,7 +118,7 @@ describe('glPointsSpeed', function () {
       feature.actors()[0].mapper().updateSourceBuffer('fillOpacity');
       myMap.draw();
       frames += 1;
-      stoptime = new Date().getTime();
+      stoptime = Date.now();
       animTimes.push(stoptime);
       if (animTimes.length < 2 || (animTimes.length < 201 &&
           stoptime - animTimes[0] < 10000)) {
@@ -142,7 +142,7 @@ describe('glPointsSpeed', function () {
         dy = Math.sin(pass) * 0.2;
       }
 
-      firsttime = new Date().getTime();
+      firsttime = Date.now();
       loadTest();
     });
   }, 30000);

--- a/tests/test-utils.js
+++ b/tests/test-utils.js
@@ -160,7 +160,7 @@ module.exports.unmockAnimationFrame = function () {
  */
 module.exports.stepAnimationFrame = function (time) {
   if (time === undefined) {
-    time = new Date().getTime();
+    time = Date.now();
   }
   var callbacks = animFrameCallbacks, action;
   animFrameCallbacks = [];
@@ -210,7 +210,7 @@ module.exports.mockAnimationFrame = function (mockDate) {
 };
 
 var origDate = window.Date,
-    startDate = (new Date()).getTime();
+    startDate = Date.now();
 
 /**
  * Allow mocking calls to Date so that each new object is slightly after the

--- a/tutorials/video_transport/index.pug
+++ b/tutorials/video_transport/index.pug
@@ -143,7 +143,7 @@ block mainTutorial
         return;
       }
       if (!video.seeking) {
-        var position = reverse.startPosition + ((new Date().getTime()) - reverse.startTime) * 0.001 * rate;
+        var position = reverse.startPosition + (Date.now() - reverse.startTime) * 0.001 * rate;
         // adjust the position so that it is within the video duration
         position = (position % video.duration + video.duration) % video.duration;
         // round to the nearest frame.  We add a small amount to ensure that rounding errors
@@ -169,7 +169,7 @@ block mainTutorial
       // record where the video currently is; we use the animation from loop to
       // calculate which frame should be shown.
       reverse = {
-        startTime: new Date().getTime(),
+        startTime: Date.now(),
         startPosition: video.currentTime
       }
       video.pause();


### PR DESCRIPTION
The `object` and `timestamp` classes were using the vgl module definitions of these as base classes.  This obscured documentation -- the `modified` and `getMTime` methods were not in the geojs code, and therefore did not appear in the jsdocs.  Rather than artificially inject it, this simplifies code to move that functionality to the geojs repo.  This means that only the gl renderer has any dependency on the vgl module (except fir the clustering code, which needs to be refactored in any case).

As part of this, `getMTime` was renamed to the somewhat less obscure `timestamp`.  The old name is still supported, but not in the jsdoc (it wasn't in the jsdoc before, either).

This also converts all uses of `new Date().getTime()` to `Date.now()`.