### PR TITLE
Add a selectionAPI='auto' mode for features.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Features
+- Feature selection API is now enabled automatically if any event handlers are bounds to the feature (#921)
+
 ### Changes
 - Removed the dependency on the vgl module for the `object` and `timestamp` classes (#918)
 

--- a/tests/cases/feature.js
+++ b/tests/cases/feature.js
@@ -59,6 +59,7 @@ describe('geo.feature', function () {
       feat = geo.feature({layer: layer});
       expect(feat.style('opacity')).toBe(1);
       expect(feat.selectionAPI()).toBe(false);
+      expect(feat.selectionAPI(undefined, true)).toBe('auto');
     });
     it('_exit', function () {
       feat = geo.feature({layer: layer});
@@ -338,6 +339,8 @@ describe('geo.feature', function () {
       expect(feat.style('data')).toEqual([1]);
     });
     it('selectionAPI', function () {
+      var bindSpy, unbindSpy;
+
       expect(feat.selectionAPI()).toBe(false);
       feat = geo.feature({layer: layer, renderer: layer.renderer(), selectionAPI: true});
       expect(feat.selectionAPI()).toBe(true);
@@ -362,6 +365,25 @@ describe('geo.feature', function () {
       expect(feat.selectionAPI()).toBe(false);
       expect(feat.selectionAPI(true, true)).toBe(feat);
       expect(feat.selectionAPI()).toBe(true);
+
+      // auto will change the selection mode depending on bound events
+      bindSpy = sinon.spy(feat, '_bindMouseHandlers');
+      unbindSpy = sinon.spy(feat, '_unbindMouseHandlers');
+      expect(feat.selectionAPI('auto')).toBe(feat);
+      expect(feat.selectionAPI()).toBe(false);
+      expect(feat.selectionAPI(undefined, true)).toBe('auto');
+      expect(bindSpy.callCount).toBe(1);
+      expect(unbindSpy.callCount).toBe(1);
+      feat.geoOn(geo.event.feature.mouseover, function () {});
+      expect(feat.selectionAPI()).toBe(true);
+      expect(feat.selectionAPI(undefined, true)).toBe('auto');
+      expect(bindSpy.callCount).toBe(2);
+      expect(unbindSpy.callCount).toBe(2);
+      feat.geoOff(geo.event.feature.mouseover);
+      expect(feat.selectionAPI()).toBe(false);
+      expect(feat.selectionAPI(undefined, true)).toBe('auto');
+      expect(bindSpy.callCount).toBe(2);
+      expect(unbindSpy.callCount).toBe(3);
     });
     it('ready', function () {
       feat = geo.feature({layer: layer});


### PR DESCRIPTION
This is the new default.  If any feature event is bound on the feature, the selectionAPI is enabled.  Binding and unbinding feature events will update the selection.  The selectionAPI can still be a boolean to directly control the behavior.

This resolves #871.