### PR TITLE
In jsdoc, mark inherited members as such.

### DIFF
--- a/jsdoc/template/members.tmpl
+++ b/jsdoc/template/members.tmpl
@@ -1,0 +1,39 @@
+<?js
+var data = obj;
+var self = this;
+var typeSignature = '';
+
+if (data.type && data.type.names) {
+    data.type.names.forEach(function (name) {
+        typeSignature += '<span class="type-signature type ' + name.toLowerCase() + '">' + self.linkto(name, self.htmlsafe(name)) + '</span> ';
+    });
+}
+?>
+<dt>
+    <div class="nameContainer">
+        <h4 class="name" id="<?js= id ?>">
+            <?js if (data.inherited || data.inherits) { ?>
+                <span class="inherited"><?js= this.linkto(data.inherits, 'inherited') ?></span>
+            <?js } ?>
+            <?js= data.attribs + (data.scope === 'static' ? longname : name)  + typeSignature ?>
+        </h4>
+    </div>
+    
+    <?js if (data.summary) { ?>
+    <p class="summary"><?js= summary ?></p>
+    <?js } ?>
+</dt>
+<dd>
+    <?js if (data.description) { ?>
+    <div class="description">
+        <?js= data.description ?>
+    </div>
+    <?js } ?>
+    
+    <?js= this.partial('details.tmpl', data) ?>
+    
+    <?js if (data.examples && examples.length) { ?>
+        <h5>Example<?js= examples.length > 1? 's':'' ?></h5>
+        <?js= this.partial('examples.tmpl', examples) ?>
+    <?js } ?>
+</dd>

--- a/jsdoc/template/publish.js
+++ b/jsdoc/template/publish.js
@@ -10,10 +10,12 @@ var fse = require('fs-extra');
 
 fse.copySync('node_modules/jaguarjs-jsdoc/tmpl', 'jsdoc/template/tmpl');
 fse.copySync('node_modules/jaguarjs-jsdoc/static', 'jsdoc/template/static');
-fse.copySync('jsdoc/template/container.tmpl', 'jsdoc/template/tmpl/container.tmpl');
-fse.copySync('jsdoc/template/mainpage.tmpl', 'jsdoc/template/tmpl/mainpage.tmpl');
-fse.copySync('jsdoc/template/navigation.tmpl', 'jsdoc/template/tmpl/navigation.tmpl');
-fse.copySync('jsdoc/template/properties.tmpl', 'jsdoc/template/tmpl/properties.tmpl');
+
+Object.values(fse.readdirSync('jsdoc/template')).forEach(file => {
+  if (file.endsWith('.tmpl')) {
+    fse.copySync('jsdoc/template/' + file, 'jsdoc/template/tmpl/' + file);
+  }
+});
 fse.appendFileSync('jsdoc/template/static/styles/jaguar.css', fse.readFileSync('jsdoc/template/style.css').toString());
 
 /* Also get the git sha, if possible */
@@ -35,7 +37,6 @@ var template = require('jsdoc/template'),
     htmlsafe = helper.htmlsafe,
     linkto = helper.linkto,
     resolveAuthorLinks = helper.resolveAuthorLinks,
-    scopeToPunc = helper.scopeToPunc,
     hasOwnProp = Object.prototype.hasOwnProperty,
     data,
     view,


### PR DESCRIPTION
I noticed, for instance, that `idle` member wasn't listed as inherited.