### PR TITLE
Fix an issue with key handling.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Bug Fixes
+- Fixed an issue with the annotation key handler (#923)
+
 ## Version 0.18.0
 
 ### Features

--- a/src/annotationLayer.js
+++ b/src/annotationLayer.js
@@ -77,7 +77,8 @@ var annotationLayer = function (args) {
       m_annotations = [],
       m_features = [],
       m_labelFeature,
-      m_labelLayer;
+      m_labelLayer,
+      m_keyHandler;
 
   var geojsonStyleProperties = {
     'closed': {dataType: 'boolean', keys: ['closed', 'close']},
@@ -519,10 +520,13 @@ var annotationLayer = function (args) {
           mapNode = m_this.map().node(), oldMode = m_mode;
       m_mode = arg;
       mapNode.toggleClass('annotation-input', !!(m_mode && m_mode !== m_this.modes.edit));
+      if (!m_keyHandler) {
+        m_keyHandler = Mousetrap(mapNode[0]);
+      }
       if (m_mode) {
-        Mousetrap(mapNode[0]).bind('esc', function () { m_this.mode(null); });
+        m_keyHandler.bind('esc', function () { m_this.mode(null); });
       } else {
-        Mousetrap(mapNode[0]).unbind('esc');
+        m_keyHandler.unbind('esc');
       }
       if (m_this.currentAnnotation) {
         switch (m_this.currentAnnotation.state()) {
@@ -1150,6 +1154,9 @@ var annotationLayer = function (args) {
    * @returns {this} The current layer.
    */
   this._exit = function () {
+    if (m_keyHandler) {
+      m_keyHandler.reset();
+    }
     m_this._removeLabelFeature();
     // Call super class exit
     s_exit.call(m_this);


### PR DESCRIPTION
Mousetrap generates a new instance of its key handler when called on an element (not retrieving an existing instance).  This means that we were binding the escape key multiple times which let to problems when it was used.