### PR TITLE
Add an option to the tutorial editors to keep history in the browser.

### DIFF
--- a/examples/common/utils.js
+++ b/examples/common/utils.js
@@ -19,9 +19,11 @@ var exampleUtils = {
    * location and history.  This will also remove undefined values from the
    * set properites of params.
    *
-   * @param {object} params: the query parameters as a dictionary.
+   * @param {object} params The query parameters as a dictionary.
+   * @param {boolean} [updateHistory] If true, update the browser history.  If
+   *    falsy, replace the history state.
    */
-  setQuery: function (params) {
+  setQuery: function (params, updateHistory) {
     $.each(params, function (key, value) {
       if (value === undefined) {
         delete params[key];
@@ -29,7 +31,11 @@ var exampleUtils = {
     });
     var newurl = window.location.protocol + '//' + window.location.host +
         window.location.pathname + '?' + $.param(params);
-    window.history.replaceState(params, '', newurl);
+    if (updateHistory) {
+      window.history.pushState(params, '', newurl);
+    } else {
+      window.history.replaceState(params, '', newurl);
+    }
   }
 };
 

--- a/tutorials/common/tutorials.js
+++ b/tutorials/common/tutorials.js
@@ -272,7 +272,7 @@ function start_keeper(alwaysKeep) {
   if (keep) {
     $(document).on('geojs-tutorial-run', '.codeblock', function () {
       var newQuery = {};
-      if (query.keep && (alwaysKeep !== true || query.keep === 'history')) {
+      if (query.keep && alwaysKeep !== true) {
         newQuery.keep = query.keep;
       }
       $('.codeblock').each(function () {
@@ -291,18 +291,16 @@ function start_keeper(alwaysKeep) {
         }
       });
       if (!inPop) {
-        utils.setQuery(newQuery, keep === 'history');
+        utils.setQuery(newQuery, true);
       }
     });
   }
-  if (keep === 'history') {
-    window.addEventListener('popstate', function (evt) {
-      inPop = true;
-      fill_codeblocks(utils.getQuery());
-      run_tutorial();
-      inPop = false;
-    }, false);
-  }
+  window.addEventListener('popstate', function (evt) {
+    inPop = true;
+    fill_codeblocks(utils.getQuery());
+    run_tutorial();
+    inPop = false;
+  }, false);
 }
 
 /**


### PR DESCRIPTION
If `keep=history` is in the tutorial's url, in addition to add the source code to the window's location, the back button will return to the previously source code of the tutorial.

I'm finding this is handy when using the editor to try out experimental code, as those experiments are in the browser's history.  However, this has been left as an option that has to be explicitly enabled, as if you make many small edits, the history is very long and tedious without a good indicator of when something significant or interesting occurred.