### PR TITLE
Optimize coordinate transforms on flat arrays.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Feature selection API is now enabled automatically if any event handlers are bounds to the feature (#921)
 
 ### Improvements
+- Coordinate transforms on flat arrays are now faster (#939)
 - `convertColor` is memoized to speed up repeated calls (#936)
 - All features have a `featureType` property (#931)
 


### PR DESCRIPTION
This is commonly done (for instance in generating glLineFeature).  As a crude metric, this reduces time by about a third.  For instance, transforming ~100,000 line vertices went from around 60 ms to 40 ms.