### PR TITLE
Overallocate geomBuffer.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Coordinate transforms on flat arrays are now faster (#939)
 - `convertColor` is memoized to speed up repeated calls (#936)
 - All features have a `featureType` property (#931)
+- When changing geometry sizes, buffers are reallocated less (#941)
 
 ### Changes
 - Removed the dependency on the vgl module for the `object` and `timestamp` classes (#918)

--- a/src/util/common.js
+++ b/src/util/common.js
@@ -368,14 +368,10 @@ var util = {
     }
     /* If we need to allocate a new buffer (smaller or larger), and we have an
      * existing, non-zero-length buffer, allocate a larger than needed buffer.
-     * Add an extra factor of allocateLarger, but if a power-of-two is between
-     * the specified size and the larger permitted size, perfer the power-of-
-     * two. */
+     * Add an extra factor of allocateLarger. */
     var allocate = len;
     if (data instanceof Float32Array && data.length && len && allocateLarger > 0) {
-      allocate = Math.min(
-        Math.floor((allocateLarger + 1) * len),
-        Math.pow(2, Math.ceil(Math.log(len) / Math.log(2))));
+      allocate = Math.floor((allocateLarger + 1) * len);
     }
     data = new Float32Array(allocate);
     src.setData(data);


### PR DESCRIPTION
When reusing an existing buffer for webGL, permit it to be larger than strictly necessary.  If reallocating an existing buffer, allocate some extra space.  For dynamic data sets, this avoids reallocating buffers on every geometry update, substantially reducing garbage collection.

In one examples with ~35,000 lines containing a total of ~1,000,000 vertices where the number of vertices changes periodically, this reduced geometry update time by ~200 ms.