### PR TITLE
Allow modifying the camera view property.

### DIFF
--- a/src/camera.js
+++ b/src/camera.js
@@ -159,7 +159,8 @@ var camera = function (spec) {
     set: function (view) {
       mat4.copy(this._view, view);
       this._update();
-    }
+    },
+    configurable: true
   });
 
   /**


### PR DESCRIPTION
This facilitates overriding the camera view.  Although this allows changing an internal property, it doesn't cause any direct issue and makes development easier.