### PR TITLE
Test layer.js.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@
 - Removed the dependency on the vgl module for the `object` and `timestamp` classes (#918)
 - CSS color names are obtained from an npm package rather than being defined in the util module (#936)
 
+### Bug Fixes
+- Fixed some minor issues with layers (#949)
+
 ## Version 0.18.1
 
 ### Bug Fixes

--- a/src/annotationLayer.js
+++ b/src/annotationLayer.js
@@ -9,6 +9,34 @@ var Mousetrap = require('mousetrap');
 var textFeature = require('./textFeature');
 
 /**
+ * Object specification for an annotation layer.
+ *
+ * @typedef {geo.layer.spec} geo.annotationLayer.spec
+ * @extends {geo.layer.spec}
+ * @property {number} [dblClickTime=300] The delay in milliseconds that is
+ *   treated as a double-click when working with annotations.
+ * @property {number} [adjacentPointProximity=5] The minimum distance in
+ *   display coordinates (pixels) between two adjacent points when creating a
+ *   polygon or line.  A value of 0 requires an exact match.
+ * @property {number} [continuousPointProximity=5] The minimum distance in
+ *   display coordinates (pixels) between two adjacent points when dragging
+ *   to create an annotation.  `false` disables continuous drawing mode.
+ * @property {number} [continuousPointColinearity=1.0deg] The minimum angle
+ *   between a series of three points when dragging to not interpret them as
+ *   colinear.  Only applies if `continuousPointProximity` is not `false`.
+ * @property {number} [finalPointProximity=10] The maximum distance in display
+ *   coordinates (pixels) between the starting point and the mouse coordinates
+ *   to signal closing a polygon.  A value of 0 requires an exact match.  A
+ *   negative value disables closing a polygon by clicking on the start point.
+ * @property {boolean} [showLabels=true] Truthy to show feature labels that are
+ *   allowed by the associated feature to be shown.
+ * @property {boolean} [clickToEdit=false] Truthy to allow clicking an
+ *   annotation to place it in edit mode.
+ * @property {geo.textFeature.styleSpec} [defaultLabelStyle] Default styles for
+ *   labels.
+ */
+
+/**
  * @typedef {object} geo.annotationLayer.labelRecord
  * @property {string} text The text of the label
  * @property {geo.geoPosition} position The position of the label in map gcs
@@ -26,41 +54,19 @@ var textFeature = require('./textFeature');
  * @class
  * @alias geo.annotationLayer
  * @extends geo.featureLayer
- * @param {object} [args] Layer options.
- * @param {number} [args.dblClickTime=300] The delay in milliseconds that is
- *    treated as a double-click when working with annotations.
- * @param {number} [args.adjacentPointProximity=5] The minimum distance in
- *    display coordinates (pixels) between two adjacent points when creating a
- *    polygon or line.  A value of 0 requires an exact match.
- * @param {number} [args.continuousPointProximity=5] The minimum distance in
- *    display coordinates (pixels) between two adjacent points when dragging
- *    to create an annotation.  `false` disables continuous drawing mode.
- * @param {number} [args.continuousPointColinearity=1.0deg] The minimum
- *    angle between a series of three points when dragging to not interpret
- *    them as colinear.  Only applies if `continuousPointProximity` is not
- *    `false`.
- * @param {number} [args.finalPointProximity=10] The maximum distance in
- *    display coordinates (pixels) between the starting point and the mouse
- *    coordinates to signal closing a polygon.  A value of 0 requires an exact
- *    match.  A negative value disables closing a polygon by clicking on the
- *    start point.
- * @param {boolean} [args.showLabels=true] Truthy to show feature labels that
- *    are allowed by the associated feature to be shown.
- * @param {boolean} [args.clickToEdit=false] Truthy to allow clicking an
- *    annotation to place it in edit mode.
- * @param {object} [args.defaultLabelStyle] Default styles for labels.
+ * @param {geo.annotationLayer.spec} [arg] Specification for the new layer.
  * @returns {geo.annotationLayer}
  * @fires geo.event.annotation.state
  * @fires geo.event.annotation.coordinates
  * @fires geo.event.annotation.edit_action
  * @fires geo.event.annotation.select_edit_handle
  */
-var annotationLayer = function (args) {
+var annotationLayer = function (arg) {
   'use strict';
   if (!(this instanceof annotationLayer)) {
-    return new annotationLayer(args);
+    return new annotationLayer(arg);
   }
-  featureLayer.call(this, args);
+  featureLayer.call(this, arg);
 
   var mapInteractor = require('./mapInteractor');
   var timestamp = require('./timestamp');
@@ -130,7 +136,7 @@ var annotationLayer = function (args) {
     finalPointProximity: 10,  // in pixels, 0 is exact
     showLabels: true,
     clickToEdit: false
-  }, args);
+  }, arg);
 
   /**
    * Process an action event.  If we are in rectangle-creation mode, this

--- a/src/canvas/canvasRenderer.js
+++ b/src/canvas/canvasRenderer.js
@@ -61,7 +61,7 @@ var canvasRenderer = function (arg) {
 
     s_init.call(m_this);
 
-    var canvas = $(document.createElement('canvas'));
+    var canvas = arg.canvas || $(document.createElement('canvas'));
     m_this.context2d = canvas[0].getContext('2d');
 
     canvas.addClass('canvas-canvas');
@@ -113,7 +113,7 @@ var canvasRenderer = function (arg) {
     var layer = m_this.layer(),
         map = layer.map(),
         mapSize = map.size(),
-        features = layer.features(),
+        features = layer.features ? layer.features() : [],
         i;
 
     for (i = 0; i < features.length; i += 1) {

--- a/src/d3/d3Renderer.js
+++ b/src/d3/d3Renderer.js
@@ -380,7 +380,7 @@ var d3Renderer = function (arg) {
           .attr('mode', 'normal');
 
       if (!arg.widget) {
-        canvas = m_svg.append('g');
+        canvas = arg.canvas || m_svg.append('g');
       }
 
       shadow = m_defs.append('filter')

--- a/src/featureLayer.js
+++ b/src/featureLayer.js
@@ -10,7 +10,7 @@ var registry = require('./registry');
  * @class
  * @alias geo.featureLayer
  * @extends geo.layer
- * @param {object} arg Options for the new layer.
+ * @param {geo.layer.spec} [arg] Specification for the new layer.
  * @returns {geo.featureLayer}
  */
 var featureLayer = function (arg) {

--- a/src/gl/vglRenderer.js
+++ b/src/gl/vglRenderer.js
@@ -89,7 +89,7 @@ var vglRenderer = function (arg) {
 
     s_init.call(m_this);
 
-    var canvas = $(document.createElement('canvas'));
+    var canvas = arg.canvas || $(document.createElement('canvas'));
     canvas.addClass('webgl-canvas');
     $(m_this.layer().node().get(0)).append(canvas);
 

--- a/src/osmLayer.js
+++ b/src/osmLayer.js
@@ -5,6 +5,15 @@ var registry = require('./registry');
 var quadFeature = require('./quadFeature');
 
 /**
+ * Object specification for an OSM layer.
+ *
+ * @typedef {geo.tileLayer.spec} geo.osmLayer.spec
+ * @extends {geo.tileLayer.spec}
+ * @property {number} [mapOpacity] If specified, and `opacity` is not
+ *   specified, use this as the layer opacity.
+ */
+
+/**
  * Create a new instance of osmLayer.  This is a {@link geo.tileLayer} with
  * an OSM url and attribution defaults and with the tiles centered on the
  * origin.
@@ -13,9 +22,7 @@ var quadFeature = require('./quadFeature');
  * @alias geo.osmLayer
  * @extends geo.tileLayer
  *
- * @param {object} arg
- * @param {number} [arg.mapOpacity] If specified, and `arg.opacity` is not
- *    specified, use this as the layer opacity.
+ * @param {geo.osmLayer.spec} [arg] Specification for the layer.
  */
 var osmLayer = function (arg) {
 

--- a/src/ui/uiLayer.js
+++ b/src/ui/uiLayer.js
@@ -8,7 +8,7 @@ var layer = require('../layer');
  * @class
  * @alias geo.gui.uiLayer
  * @extends {geo.layer}
- * @param {object} [arg] Options for the layer.
+ * @param {geo.layer.spec} [arg] Specification for the new layer.
  * @returns {geo.gui.uiLayer}
  */
 var uiLayer = function (arg) {

--- a/tests/cases/layer.js
+++ b/tests/cases/layer.js
@@ -1,0 +1,252 @@
+// Test geo.layer
+
+var geo = require('../test-utils').geo;
+var createMap = require('../test-utils').createMap;
+
+describe('geo.layer', function () {
+  'use strict';
+
+  beforeEach(function () {
+    sinon.stub(console, 'log', function () {});
+  });
+  afterEach(function () {
+    console.log.restore();
+  });
+
+  describe('create', function () {
+    it('create function', function () {
+      var map, layer;
+
+      map = createMap();
+      layer = geo.layer({map: map});
+      expect(layer instanceof geo.layer).toBe(true);
+      expect(layer.initialized()).toBe(false);
+
+      expect(function () {
+        geo.layer({});
+      }).toThrow(new Error('Layers must be initialized on a map.'));
+    });
+    it('direct create', function () {
+      var map, layer, warn;
+
+      map = createMap();
+      layer = geo.layer.create(map, {renderer: 'canvas'});
+      expect(layer instanceof geo.layer).toBe(true);
+      expect(layer.initialized()).toBe(true);
+      expect(layer.children().length).toBe(0);
+
+      layer = geo.layer.create(map, {renderer: 'd3', features: [{type: 'point'}]});
+      expect(layer instanceof geo.layer).toBe(true);
+      expect(layer.initialized()).toBe(true);
+      expect(layer.children().length).toBe(1);
+
+      warn = sinon.stub(console, 'warn', function () {});
+      layer = geo.layer.create(map, {renderer: 'notarenderer'});
+      expect(warn.calledOnce).toBe(true);
+      console.warn.restore();
+
+      warn = sinon.stub(console, 'warn', function () {});
+      layer = geo.layer.create(map, {type: 'notalayertype', renderer: 'canvas'});
+      expect(warn.calledOnce).toBe(true);
+      console.warn.restore();
+    });
+  });
+  describe('Check private class methods', function () {
+    var map, layer;
+    it('_init', function () {
+      map = createMap();
+      layer = geo.layer({map: map});
+      expect(layer.initialized()).toBe(false);
+      layer._init();
+      expect(layer.initialized()).toBe(true);
+      layer._init();
+      expect(layer.initialized()).toBe(true);
+    });
+    it('_init with events', function () {
+      var count = 0;
+
+      layer = geo.layer({map: map});
+      map.addChild(layer);
+      layer._update = function () { count += 1; };
+      layer._init();
+      map.size({width: 600});
+      map.pan({x: 0, y: 1});
+      map.rotation(1);
+      map.zoom(1);
+      expect(count).toBe(7);  // sie, rotation, zoom also trigger pan
+      map.removeChild(layer);
+    });
+    it('_init without events', function () {
+      var count = 0;
+
+      layer = geo.layer({map: map});
+      map.addChild(layer);
+      layer._update = function () { count += 1; };
+      layer._init(true);
+      map.size({width: 640});
+      map.pan({x: 0, y: 1});
+      map.rotation(1);
+      map.zoom(1);
+      expect(count).toBe(0);
+      map.removeChild(layer);
+    });
+    it('_exit', function () {
+      layer = geo.layer({map: map});
+      layer._init();
+      expect(layer.renderer()).not.toBe(null);
+      layer._exit();
+      expect(layer.renderer()).toBe(null);
+    });
+    it('_update', function () {
+      layer = geo.layer({map: map});
+      expect(layer._update()).toBe(layer);
+    });
+  });
+  describe('Check class (non-instance) methods', function () {
+    it('newLayerId', function () {
+      var id = geo.layer.newLayerId();
+      expect(geo.layer.newLayerId()).toBeGreaterThan(id);
+    });
+  });
+  describe('Check public class methods', function () {
+    var map, layer;
+    it('active', function () {
+      map = createMap();
+      layer = geo.layer({map: map});
+      expect(layer.active()).toBe(true);
+      expect(layer.active(false)).toBe(layer);
+      expect(layer.active()).toBe(false);
+      expect(layer.active(true)).toBe(layer);
+      expect(layer.active()).toBe(true);
+      layer = geo.layer({map: map, active: false});
+      expect(layer.active()).toBe(false);
+      expect(layer.active(true)).toBe(layer);
+      expect(layer.active()).toBe(true);
+    });
+    it('attribution', function () {
+      expect(layer.attribution()).toBe(null);
+      layer = geo.layer({map: map, attribution: 'attribution1'});
+      expect(layer.attribution()).toBe('attribution1');
+      expect(layer.attribution('attribution2')).toBe(layer);
+      expect(layer.attribution()).toBe('attribution2');
+    });
+    it('canvas', function () {
+      layer = geo.layer({map: map});
+      expect(layer.canvas()).toBe(null);
+      layer._init();
+      expect(layer.canvas()).not.toBe(null);
+      expect(layer.canvas()).toBe(layer.renderer().canvas());
+      var canvas = layer.canvas();
+      var layer2 = geo.layer({map: map, canvas: canvas});
+      layer2._init();
+      expect(layer2.canvas()).toEqual(layer.canvas());
+      var layer3 = geo.layer({map: map});
+      layer2._init();
+      expect(layer3.canvas()).not.toEqual(layer.canvas());
+    });
+    it('dataTime', function () {
+      expect(layer.dataTime() instanceof geo.timestamp).toBe(true);
+    });
+    it('fromLocal', function () {
+      expect(layer.fromLocal('abc')).toBe('abc');
+    });
+    it('height', function () {
+      expect(layer.height()).toBe(map.node().height());
+    });
+    it('id', function () {
+      var id;
+
+      expect(layer.id()).toBeGreaterThan(0);
+      id = layer.id();
+      layer = geo.layer({map: map, id: 1});
+      expect(layer.id()).toBe(1);
+      expect(layer.id(5)).toBe(layer);
+      expect(layer.id()).toBe(5);
+      expect(layer.id(null)).toBe(layer);
+      expect(layer.id()).toBeGreaterThan(id);
+    });
+    it('initialized', function () {
+      layer = geo.layer({map: map});
+      expect(layer.initialized()).toBe(false);
+      layer._init();
+      expect(layer.initialized()).toBe(true);
+      expect(layer.initialized(false)).toBe(layer);
+      expect(layer.initialized()).toBe(false);
+    });
+    it('map', function () {
+      expect(layer.map()).toBe(map);
+    });
+    it('name', function () {
+      expect(layer.name()).toBe('');
+      layer = geo.layer({map: map, name: 'name1'});
+      expect(layer.name()).toBe('name1');
+      expect(layer.name('name2')).toBe(layer);
+      expect(layer.name()).toBe('name2');
+    });
+    it('node', function () {
+      expect(layer.node().attr('id')).toBe(layer.name());
+    });
+    it('opacity', function () {
+      expect(layer.opacity()).toBe(1);
+      layer = geo.layer({map: map, opacity: 0.5});
+      expect(layer.opacity()).toBe(0.5);
+      expect(layer.opacity(0.75)).toBe(layer);
+      expect(layer.opacity()).toBe(0.75);
+    });
+    it('renderer', function () {
+      layer = geo.layer({map: map});
+      expect(layer.renderer()).toBe(null);
+      layer._init();
+      expect(layer.renderer() instanceof geo.renderer).toBe(true);
+      var renderer = layer.renderer();
+      var layer2 = geo.layer({map: map, renderer: renderer});
+      layer2._init();
+      expect(layer2.renderer()).toEqual(layer.renderer());
+      var layer3 = geo.layer({map: map});
+      layer2._init();
+      expect(layer3.renderer()).not.toEqual(layer.renderer());
+    });
+    it('rendererName', function () {
+      layer = geo.layer({map: map, renderer: 'canvas'});
+      expect(layer.rendererName()).toBe('canvas');
+    });
+    it('selectionAPI', function () {
+      expect(layer.selectionAPI()).toBe(true);
+      expect(layer.selectionAPI(false)).toBe(layer);
+      expect(layer.selectionAPI()).toBe(false);
+      expect(layer.selectionAPI(true)).toBe(layer);
+      expect(layer.selectionAPI()).toBe(true);
+      layer = geo.layer({map: map, selectionAPI: false});
+      expect(layer.selectionAPI()).toBe(false);
+      expect(layer.selectionAPI(true)).toBe(layer);
+      expect(layer.selectionAPI()).toBe(true);
+    });
+    it('sticky', function () {
+      expect(layer.sticky()).toBe(true);
+      layer = geo.layer({map: map, sticky: false});
+      expect(layer.sticky()).toBe(false);
+    });
+    it('toLocal', function () {
+      expect(layer.toLocal('abc')).toBe('abc');
+    });
+    it('updateTime', function () {
+      expect(layer.updateTime() instanceof geo.timestamp).toBe(true);
+    });
+    it('visible', function () {
+      expect(layer.visible()).toBe(true);
+      expect(layer.visible(false)).toBe(layer);
+      expect(layer.visible()).toBe(false);
+      expect(layer.visible(true)).toBe(layer);
+      expect(layer.visible()).toBe(true);
+      layer = geo.layer({map: map, visible: false});
+      expect(layer.visible()).toBe(false);
+      expect(layer.visible(true)).toBe(layer);
+      expect(layer.visible()).toBe(true);
+    });
+    it('width', function () {
+      expect(layer.width()).toBe(map.node().width());
+    });
+    /* zIndex, moveUp, moveDown, moveToTop, and moveToBottom tested in
+     * layerReorder.js */
+  });
+});


### PR DESCRIPTION
Move the layer specification to a typedef for better documentation.  Make sure all layer types use typedefs.

Fix issues with the layer id function.

Ensures that canvas and renderer can actually be specified when creating a layer.  This allows layers to share a renderer or a canvas.  For the webgl renderer, sharing a canvas results in flashing, as each layer completely redraws the canvas.  When sharing a renderer, there is no proper support for opacity (probably not for visibility) or z-order, but this is a first step to implementing #942.

Removed some unused code.