### PR TITLE
Fix some references in the website.

### DIFF
--- a/website/themes/agency/layout/layout.ejs
+++ b/website/themes/agency/layout/layout.ejs
@@ -42,22 +42,22 @@
     <!-- Bootstrap Core JavaScript -->
     <%- js("vendor/bootstrap/js/bootstrap.min.js") %>
     
-    <link rel="apple-touch-icon" sizes="57x57" href="favicon/apple-icon-57x57.png">
-    <link rel="apple-touch-icon" sizes="60x60" href="favicon/apple-icon-60x60.png">
-    <link rel="apple-touch-icon" sizes="72x72" href="favicon/apple-icon-72x72.png">
-    <link rel="apple-touch-icon" sizes="76x76" href="favicon/apple-icon-76x76.png">
-    <link rel="apple-touch-icon" sizes="114x114" href="favicon/apple-icon-114x114.png">
-    <link rel="apple-touch-icon" sizes="120x120" href="favicon/apple-icon-120x120.png">
-    <link rel="apple-touch-icon" sizes="144x144" href="favicon/apple-icon-144x144.png">
-    <link rel="apple-touch-icon" sizes="152x152" href="favicon/apple-icon-152x152.png">
-    <link rel="apple-touch-icon" sizes="180x180" href="favicon/apple-icon-180x180.png">
-    <link rel="icon" type="image/png" sizes="192x192"  href="favicon/android-icon-192x192.png">
-    <link rel="icon" type="image/png" sizes="32x32" href="favicon/favicon-32x32.png">
-    <link rel="icon" type="image/png" sizes="96x96" href="favicon/favicon-96x96.png">
-    <link rel="icon" type="image/png" sizes="16x16" href="favicon/favicon-16x16.png">
-    <link rel="manifest" href="favicon/manifest.json">
+    <link rel="apple-touch-icon" sizes="57x57" href="<%- page_url("favicon/apple-icon-57x57.png") %>">
+    <link rel="apple-touch-icon" sizes="60x60" href="<%- page_url("favicon/apple-icon-60x60.png") %>">
+    <link rel="apple-touch-icon" sizes="72x72" href="<%- page_url("favicon/apple-icon-72x72.png") %>">
+    <link rel="apple-touch-icon" sizes="76x76" href="<%- page_url("favicon/apple-icon-76x76.png") %>">
+    <link rel="apple-touch-icon" sizes="114x114" href="<%- page_url("favicon/apple-icon-114x114.png") %>">
+    <link rel="apple-touch-icon" sizes="120x120" href="<%- page_url("favicon/apple-icon-120x120.png") %>">
+    <link rel="apple-touch-icon" sizes="144x144" href="<%- page_url("favicon/apple-icon-144x144.png") %>">
+    <link rel="apple-touch-icon" sizes="152x152" href="<%- page_url("favicon/apple-icon-152x152.png") %>">
+    <link rel="apple-touch-icon" sizes="180x180" href="<%- page_url("favicon/apple-icon-180x180.png") %>">
+    <link rel="icon" type="image/png" sizes="192x192"  href="<%- page_url("favicon/android-icon-192x192.png") %>">
+    <link rel="icon" type="image/png" sizes="32x32" href="<%- page_url("favicon/favicon-32x32.png") %>">
+    <link rel="icon" type="image/png" sizes="96x96" href="<%- page_url("favicon/favicon-96x96.png") %>">
+    <link rel="icon" type="image/png" sizes="16x16" href="<%- page_url("favicon/favicon-16x16.png") %>">
+    <link rel="manifest" href="<%- page_url("favicon/manifest.json") %>">
     <meta name="msapplication-TileColor" content="#ffffff">
-    <meta name="msapplication-TileImage" content="favicon/ms-icon-144x144.png">
+    <meta name="msapplication-TileImage" content="<%- page_url("favicon/ms-icon-144x144.png") %>">
     <meta name="theme-color" content="#ffffff">
 </head>
 
@@ -83,13 +83,13 @@
                         <a href="<%- page_url("/") %>">Welcome</a>
                     </li>
                     <li class="<% if(path.indexOf('tutorial')!==-1){ %> active <% } %>">
-                        <a href="<%- page_url("tutorials") %>">Tutorials</a>
+                        <a href="<%- page_url("tutorials/") %>">Tutorials</a>
                     </li>
                     <li class="<% if(path.indexOf('example')!==-1){ %> active <% } %>">
-                        <a href="<%- page_url("examples") %>">Examples</a>
+                        <a href="<%- page_url("examples/") %>">Examples</a>
                     </li>
                     <li>
-                        <a href="<%- page_url("apidocs") %>">API Docs</a>
+                        <a href="<%- page_url("apidocs/") %>">API Docs</a>
                     </li>
                     <li>
                         <a href="https://github.com/OpenGeoscience/geojs">GitHub</a>


### PR DESCRIPTION
Clicking on Tutorials, Examples, or API Docs would leave https.  The tutorials and examples were not showing the favicon.