### PR TITLE
Fix redirects on the website.

### DIFF
--- a/website/themes/agency/layout/examples.ejs
+++ b/website/themes/agency/layout/examples.ejs
@@ -10,7 +10,7 @@
                 <div class="col-md-6 example-container">
                     <div class="row">
                         <div class="col-xs-5 thumbnail-container">
-                            <a href="<%- example.name %>">
+                            <a href="<%- example.name %>/">
                                 <div class="thumbnail-hover">
                                 </div>
                                 <img src="<%

--- a/website/themes/agency/layout/tutorials.ejs
+++ b/website/themes/agency/layout/tutorials.ejs
@@ -9,7 +9,7 @@
             <div class="row">
             <% for(let tutorial of site.data.tutorials) { %>
                 <div class="col-md-3 col-sm-4 portfolio-item">
-                    <a class="portfolio-link" href="<%- tutorial.name %>">
+                    <a class="portfolio-link" href="<%- tutorial.name %>/">
                         <div class="portfolio-hover">
                         </div>
                         <img class="img-responsive" src="<%


### PR DESCRIPTION
The website redirects bare paths to http, but paths ending with / to the same protocol, so build example and tutorial lists with / after the example or tutorial name.