### PR TITLE
Move width and height to the base renderer class definition.

### DIFF
--- a/src/canvas/canvasRenderer.js
+++ b/src/canvas/canvasRenderer.js
@@ -89,6 +89,7 @@ var canvasRenderer = function (arg) {
     var canvas = m_this.canvas();
     if (parseInt(canvas.attr('width'), 10) !== w ||
         parseInt(canvas.attr('height'), 10) !== h) {
+      m_this._setWidthHeight(w, h);
       canvas.attr('width', w);
       canvas.attr('height', h);
       m_this._render();

--- a/src/d3/d3Renderer.js
+++ b/src/d3/d3Renderer.js
@@ -43,8 +43,6 @@ var d3Renderer = function (arg) {
       m_sticky = null,
       m_features = {},
       m_corners = null,
-      m_width = null,
-      m_height = null,
       m_diagonal = null,
       m_scale = 1,
       m_transform = {dx: 0, dy: 0, rx: 0, ry: 0, rotation: 0},
@@ -209,11 +207,10 @@ var d3Renderer = function (arg) {
         width = map.size().width,
         height = map.size().height;
 
-    m_width = width;
-    m_height = height;
-    if (!m_width || !m_height) {
+    if (!width || !height) {
       throw new Error('Map layer has size 0');
     }
+    m_this._setWidthHeight(width, height);
     m_diagonal = Math.pow(width * width + height * height, 0.5);
     m_corners = {
       upperLeft: map.displayToGcs({x: 0, y: 0}, null),
@@ -249,8 +246,8 @@ var d3Renderer = function (arg) {
       Math.pow(lowerRight.x - upperLeft.x, 2)) / m_diagonal;
     // calculate the translation
     rotation = map.rotation();
-    rx = -m_width / 2;
-    ry = -m_height / 2;
+    rx = -m_this.width() / 2;
+    ry = -m_this.height() / 2;
     dx = scale * rx + center.x;
     dy = scale * ry + center.y;
 
@@ -454,6 +451,7 @@ var d3Renderer = function (arg) {
     m_svg.attr('width', w);
     m_svg.attr('height', h);
     m_this._setTransform();
+    m_this._setWidthHeight(w, h);
     m_this.layer().geoTrigger(d3Rescale, { scale: m_scale }, true);
     return m_this;
   };

--- a/src/gl/vglRenderer.js
+++ b/src/gl/vglRenderer.js
@@ -33,31 +33,10 @@ var vglRenderer = function (arg) {
   var m_this = this,
       m_contextRenderer = null,
       m_viewer = null,
-      m_width = 0,
-      m_height = 0,
       m_lastZoom,
       m_updateCamera = false,
       s_init = this._init,
       s_exit = this._exit;
-
-  // TODO: Move this API to the base class
-  /**
-   * Return width of the renderer.
-   *
-   * @returns {number} The width of the current canvas.
-   */
-  this.width = function () {
-    return m_width;
-  };
-
-  /**
-   * Return height of the renderer.
-   *
-   * @returns {number} The height of the current canvas.
-   */
-  this.height = function () {
-    return m_height;
-  };
 
   /**
    * Get context specific renderer.
@@ -140,9 +119,8 @@ var vglRenderer = function (arg) {
 
     if (x !== renderWindow.windowPosition[0] ||
         y !== renderWindow.windowPosition[1] ||
-        w !== m_width || h !== m_height) {
-      m_width = w;
-      m_height = h;
+        w !== m_this.width() || h !== m_this.height()) {
+      m_this._setWidthHeight(w, h);
       m_this.canvas().attr('width', w);
       m_this.canvas().attr('height', h);
       renderWindow.positionAndResize(x, y, w, h);

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -23,6 +23,8 @@ var renderer = function (arg) {
 
   arg = arg || {};
   var m_this = this,
+      m_width = 0,
+      m_height = 0,
       m_layer = arg.layer === undefined ? null : arg.layer,
       m_canvas = arg.canvas === undefined ? null : arg.canvas,
       m_initialized = false;
@@ -95,6 +97,37 @@ var renderer = function (arg) {
   };
 
   /**
+   * Get the width of the renderer.
+   *
+   * @returns {number} The width of the renderer.
+   */
+  this.width = function () {
+    return m_width;
+  };
+
+  /**
+   * Get the height of the renderer.
+   *
+   * @returns {number} The height of the renderer.
+   */
+  this.height = function () {
+    return m_height;
+  };
+
+  /**
+   * Set the width and height of the renderer.
+   *
+   * @param {number} width The new width.
+   * @param {number} height The new height.
+   * @returns {this}
+   */
+  this._setWidthHeight = function (width, height) {
+    m_width = width;
+    m_height = height;
+    return m_this;
+  };
+
+  /**
    * Initialize.
    *
    * @returns {this}
@@ -113,6 +146,7 @@ var renderer = function (arg) {
    * @returns {this}
    */
   this._resize = function (x, y, w, h) {
+    m_this._setWidthHeight(w, h);
     return m_this;
   };
 

--- a/src/vtkjs/vtkjsRenderer.js
+++ b/src/vtkjs/vtkjsRenderer.js
@@ -29,8 +29,6 @@ var vtkjsRenderer = function (arg) {
   var vtkGenericRenderWindow = vtkjs.Rendering.Misc.vtkGenericRenderWindow;
 
   var m_this = this,
-      m_width = 0,
-      m_height = 0,
       s_init = this._init;
 
   var vtkRenderer = vtkGenericRenderWindow.newInstance({
@@ -41,24 +39,6 @@ var vtkjsRenderer = function (arg) {
   vtkRenderer.resize();
   var vtkjsren = vtkRenderer.getRenderer();
   var renderWindow = vtkRenderer.getRenderWindow();
-
-  /**
-   * Return width of the renderer.
-   *
-   * @returns {number} The width of the current canvas.
-   */
-  this.width = function () {
-    return m_width;
-  };
-
-  /**
-   * Return height of the renderer.
-   *
-   * @returns {number} The height of the current canvas.
-   */
-  this.height = function () {
-    return m_height;
-  };
 
   /**
    * Get context specific renderer.
@@ -110,6 +90,7 @@ var vtkjsRenderer = function (arg) {
    * @returns {this}
    */
   this._resize = function (x, y, w, h) {
+    m_this._setWidthHeight(w, h);
     vtkRenderer.resize();
     m_this._render();
     return m_this;


### PR DESCRIPTION
This reduces code duplication.  It has been listed as a TODO in the code for a long time.