### PR TITLE
Ignore z coordinates on gl point and polygon features.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features
 - Feature selection API is now enabled automatically if any event handlers are bounds to the feature (#921)
-- Added a VTK.js renderer which supports a point feature (#893)
+- Added a VTK.js renderer which supports a point feature (#893, #953)
 
 ### Improvements
 - Coordinate transforms on flat arrays are now faster (#939)
@@ -12,13 +12,22 @@
 - All features have a `featureType` property (#931)
 - When changing geometry sizes, buffers are reallocated less (#941)
 - Initial rendering webGL features is somewhat faster (#943)
+- WebGL point and polygon features no longer clip by z coordinates (#963)
 
 ### Changes
 - Removed the dependency on the vgl module for the `object` and `timestamp` classes (#918)
 - CSS color names are obtained from an npm package rather than being defined in the util module (#936)
+- Updated several npm modules (#944)
+- Report the unmasked renderer used with webgl (#947)
+- Width and height are now in the base renderer class (#962)
 
 ### Bug Fixes
 - Fixed some minor issues with layers (#949)
+
+### Documentation
+- Improve documentation (#922, #928, #929, #930, #932, #948, #950, #951, #956, #960, #961)
+- Added a point cluster example (#957)
+- Editor tutorials keep history in browser (#926)
 
 ## Version 0.18.1
 

--- a/src/gl/pointFeature.js
+++ b/src/gl/pointFeature.js
@@ -282,7 +282,7 @@ var gl_pointFeature = function (arg) {
         vpf = m_this.verticesPerFeature(),
         data = m_this.data(),
         item, ivpf, ivpf3, iunit, i3,
-        geom = m_mapper.geometryData(), nonzeroZ;
+        geom = m_mapper.geometryData();
 
     posFunc = m_this.position();
     radFunc = m_this.style.get('radius');
@@ -300,19 +300,11 @@ var gl_pointFeature = function (arg) {
       posVal = posFunc(data[i], i);
       position[i3] = posVal.x;
       position[i3 + 1] = posVal.y;
-      position[i3 + 2] = posVal.z || 0;
-      nonzeroZ = nonzeroZ || position[i3 + 2];
+      // ignore the z values until we support them
+      position[i3 + 2] = 0;  // posVal.z || 0;
     }
     position = transform.transformCoordinates(
       m_this.gcs(), m_this.layer().map().gcs(), position, 3);
-    /* Some transforms modify the z-coordinate.  If we started with all zero z
-     * coordinates, don't modify them.  This could be changed if the
-     * z-coordinate space of the gl cube is scaled appropriately. */
-    if (!nonzeroZ && m_this.gcs() !== m_this.layer().map().gcs()) {
-      for (i = i3 = 0; i < numPts; i += 1, i3 += 3) {
-        position[i3 + 2] = 0;
-      }
-    }
 
     posBuf = util.getGeomBuffer(geom, 'pos', vpf * numPts * 3);
 

--- a/src/gl/polygonFeature.js
+++ b/src/gl/polygonFeature.js
@@ -141,7 +141,8 @@ var gl_polygonFeature = function (arg) {
           c = posFunc(outer[i], i, item, itemIndex);
           geometry[d3] = c.x;
           geometry[d3 + 1] = c.y;
-          geometry[d3 + 2] = c.z || 0;
+          // ignore the z values until we support them
+          geometry[d3 + 2] = 0;  // c.z || 0;
         }
         geometry = {vertices: geometry, dimensions: 3, holes: []};
         original = outer;
@@ -157,7 +158,8 @@ var gl_polygonFeature = function (arg) {
               c = posFunc(hole[i], i, item, itemIndex);
               geometry.vertices[d3] = c.x;
               geometry.vertices[d3 + 1] = c.y;
-              geometry.vertices[d3 + 2] = c.z || 0;
+              // ignore the z values until we support them
+              geometry.vertices[d3 + 2] = 0;  // c.z || 0;
             }
           });
         }


### PR DESCRIPTION
We currently ignore the z coordinate on line features.  We don't support z coordinates yet, so disable them until we do.