### PR TITLE
Explicitly set a z-index on the example map.

### DIFF
--- a/examples/common/examples.css
+++ b/examples/common/examples.css
@@ -21,6 +21,7 @@ html, body {
   width: 100%;
   height: calc(100% - 60px);
   overflow: hidden;
+  z-index: 0;
 }
 
 .gj-screenshot-link {


### PR DESCRIPTION
This creates a stacking context, ensuring that in examples that have a control panel, the control panel always is on top of the map.