### PR TITLE
Fix "npm run examples".

### DIFF
--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
     "test-headed": "GEOJS_TEST_CASE=tests/test-headed.js xvfb-run -s '-ac -screen 0 1280x1024x24' karma start karma-cov.conf.js --single-run --browsers ChromeFull",
     "codecov": "codecov",
     "combine-coverage": "istanbul-combine -d dist/cobertura -r cobertura 'dist/coverage/json/**/coverage-final.json'",
-    "examples": "webpack-dev-server --config webpack-examples.config.js --host ${HOST-127.0.0.1} --port ${PORT-8082} --content-base dist/",
+    "examples": "node examples/build.js && webpack --config webpack-examples.config.js && node tutorials/build.js && webpack --config webpack-tutorials.config.js && node ./tests/runners/server.js --host \"${HOST-}\" --port ${PORT-8082} --dist",
     "start-test": "node examples/build.js; forever start ./tests/runners/server.js",
     "stop-test": "forever stop ./tests/runners/server.js",
     "docs": "jsdoc --pedantic -d dist/apidocs -r src package.json -c jsdoc.conf.json",

--- a/tests/runners/server.js
+++ b/tests/runners/server.js
@@ -9,6 +9,7 @@ var express = require('express'),
     app = express(),
     help = false,
     skip = 2,
+    host = '',
     port = 30100,
     build = false,
     dist = false,
@@ -23,6 +24,11 @@ process.argv.forEach(function (val, idx) {
     build = true;
   } else if (val === '--dist' || val === '-d') {
     dist = true;
+  } else if ((val === '--host' || val === '-h') && idx + 1 < process.argv.length) {
+    host = process.argv[idx + 1];
+    skip = 1;
+  } else if (val.substr(0, 7) === '--host=') {
+    host = val.substr(7);
   } else if ((val === '--port' || val === '-p') && idx + 1 < process.argv.length) {
     port = parseInt(process.argv[idx + 1], 10);
     skip = 1;
@@ -39,6 +45,7 @@ if (help) {
   console.error('Serve the dist, website, and _build directories.  Options:\n' +
     '--build : serve _build directory as build/\n' +
     '--dist : serve distribution directory (default)\n' +
+    '--host (host) : default 0.0.0.0\n' +
     '--port (port) : default 30100\n' +
     '--website : serve website directory (if this and dist are specified,\n' +
     '   dist is located as dist/)\n');
@@ -63,8 +70,8 @@ if (build) {
   }
 }
 
-app.listen(port, function () {
-  console.log('Server listening on ' + port);
+app.listen(port, host, function () {
+  console.log('Server listening on ' + host + ':' + port);
 });
 
 module.exports = app;


### PR DESCRIPTION
In the quickstart documentation we cite this as a way to serve the examples, but that has been broken for quite a while.  This uses the server.js script to serve the examples tutorials.