### PR TITLE
Allow continuous drawing of polygon annotations.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Features
+- Polygon annotations can be drawn in the same continuous smooth manner as line annotations.
+
 ### Changes
 - Rename the d3 renderer to svg.  d3 still works as an alias (#965)
 - Rename the vgl renderer to webgl.  vgl still works as an alias (#965)

--- a/tests/cases/annotationLayer.js
+++ b/tests/cases/annotationLayer.js
@@ -68,7 +68,7 @@ describe('geo.annotationLayer', function () {
       expect(layer.mode()).toBe('polygon');
       expect(layer.annotations().length).toBe(1);
       expect(layer.annotations()[0].id()).not.toBe(id);
-      expect(map.interactor().hasAction(undefined, undefined, geo.annotation.actionOwner)).toBeNull();
+      expect(map.interactor().hasAction(undefined, undefined, geo.annotation.actionOwner)).not.toBeNull();
       expect(layer.mode('rectangle')).toBe(layer);
       expect(layer.mode()).toBe('rectangle');
       expect(map.interactor().hasAction(undefined, undefined, geo.annotation.actionOwner)).not.toBeNull();


### PR DESCRIPTION
Before, only clicking for discrete vertices was supported.  This adds the same capabilities as for lines, using the same layer settings to control if it is allowed and the smoothness.