### PR TITLE
Make fewer style.get calls when computing polygon strokes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,14 @@
 # Change Log
 
+## Unreleased
+
+### Improvements
+- Make fewer function calls when computing polygon strokes (#980)
+
 ## Version 0.19.1
 
 ### Features
-- Polygon annotations can be drawn in the same continuous smooth manner as line annotations.
+- Polygon annotations can be drawn in the same continuous smooth manner as line annotations. (#976)
 
 ### Changes
 - Rename the d3 renderer to svg.  d3 still works as an alias (#965)

--- a/src/polygonFeature.js
+++ b/src/polygonFeature.js
@@ -337,7 +337,17 @@ var polygonFeature = function (arg) {
       });
       m_this.dependentFeatures([m_lineFeature]);
     }
-    var polyStyle = m_this.style();
+    var polyStyle = m_this.style(),
+        strokeOpacity;
+    if (util.isFunction(polyStyle.stroke) || !polyStyle.stroke) {
+      var strokeFunc = m_this.style.get('stroke'),
+          strokeOpacityFunc = m_this.style.get('strokeOpacity');
+      strokeOpacity = function (d) {
+        return strokeFunc(d[2], d[3]) ? strokeOpacityFunc(d[0], d[1], d[2], d[3]) : 0;
+      };
+    } else {
+      strokeOpacity = linePolyStyle(polyStyle.strokeOpacity);
+    }
     m_lineFeature.style({
       antialiasing: linePolyStyle(polyStyle.antialiasing),
       closed: true,
@@ -348,11 +358,7 @@ var polygonFeature = function (arg) {
       strokeStyle: linePolyStyle(polyStyle.strokeStyle),
       strokeColor: linePolyStyle(polyStyle.strokeColor),
       strokeOffset: linePolyStyle(polyStyle.strokeOffset),
-      strokeOpacity: util.isFunction(polyStyle.stroke) || !polyStyle.stroke ?
-        function (d) {
-          return m_this.style.get('stroke')(d[2], d[3]) ? m_this.style.get('strokeOpacity')(d[0], d[1], d[2], d[3]) : 0;
-        } :
-        linePolyStyle(polyStyle.strokeOpacity)
+      strokeOpacity: strokeOpacity
     });
     var data = m_this.data(),
         posVal = m_this.style('position');


### PR DESCRIPTION
If the polygon stroke or strokeOpacity are functions, then style.get was called for every polygon's stroke.  This can be done once, saving needless function calls.