### PR TITLE
Disable the sld example and its tests.

### DIFF
--- a/examples/sld/example.json
+++ b/examples/sld/example.json
@@ -5,7 +5,8 @@
   "about": {
     "text": "Rendering tiles from a WMS server by customizing the style."
   },
-  "tests": [{
+  "disabled": true,
+  "disable_tests": [{
     "description": "data is loaded from the WMS source",
     "idle": ["$('#map.geojs-map').data('data-geojs-map').onIdle"],
     "tests": [


### PR DESCRIPTION
The geoserver we were using has gone offline.  Until it comes back online or we choose a different geoserver, this example will not work and will cause tests to fail.