### PR TITLE
Fix a small bug in canvas quads with fixed scale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Changes
 - The point clustering radius value is now in display pixels (#983)
 
+### Bug Fixes
+- Fixed drawing partial fixed-scale canvas quads (#985)
+
 ## Version 0.19.2
 
 ### Improvements

--- a/src/canvas/quadFeature.js
+++ b/src/canvas/quadFeature.js
@@ -174,8 +174,8 @@ var canvas_quadFeature = function (arg) {
         if (!quad.crop) {
           context2d.drawImage(src, 0, 0);
         } else {
-          var cropx = Math.min(src.w, quad.crop.x),
-              cropy = Math.min(src.h, quad.crop.y);
+          var cropx = Math.min(w, quad.crop.x),
+              cropy = Math.min(h, quad.crop.y);
           if (cropx > 0 && cropy > 0) {
             context2d.drawImage(src, 0, 0, cropx, cropy, 0, 0, cropx, cropy);
           }


### PR DESCRIPTION
This can be seen, for instance, in the deep zoom example where the lower partial tiles were not being rendered.
