### PR TITLE
Support affine transforms in the proj4 string

### DIFF
--- a/src/featureLayer.js
+++ b/src/featureLayer.js
@@ -137,6 +137,38 @@ var featureLayer = function (arg) {
   };
 
   /**
+   * Get or set the gcs for all features.  For features, the default is usually
+   * the map's ingcs.
+   *
+   * @param {string?} [val] If `undefined`, return the current gcs.  If
+   *    `null`, use the map's interface gcs.  Otherwise, set a new value for
+   *    the gcs.  When getting the current gcs, if not all features have the
+   *    same gcs, `undefined` will be returned.
+   * @returns {string|this} A string used by {@link geo.transform}.  If the
+   *    map interface gcs is in use, that value will be returned.  If the gcs
+   *    is set, return the current class instance.
+   */
+  this.gcsFeatures = function (val) {
+    if (val === undefined) {
+      var gcs, mixed;
+      this.features().forEach((feature) => {
+        if (gcs === undefined) {
+          gcs = feature.gcs();
+        } else if (feature.gcs() !== gcs) {
+          mixed = true;
+        }
+      });
+      return mixed ? undefined : gcs;
+    }
+    m_this.features().forEach((feature) => {
+      if (feature.gcs() !== val) {
+        feature.gcs(val);
+      }
+    });
+    return m_this;
+  };
+
+  /**
    * Initialize.
    *
    * @returns {this}

--- a/src/tileLayer.js
+++ b/src/tileLayer.js
@@ -684,6 +684,32 @@ var tileLayer = function (arg) {
   };
 
   /**
+   * Get or set the layer gcs.  This defaults to the map's gcs.
+   *
+   * @param {string} [arg] If `undefined`, return the current gcs.  Otherwise,
+   *    a new value for the gcs.  If `null`, use the map's gcs.
+   * @returns {string|this} A string used by {@link geo.transform}.
+   */
+  this.gcs = function (arg) {
+    if (arg === undefined) {
+      return m_this._options.gcs || m_this.map().gcs();
+    }
+    var previous = m_this.gcs();
+    if (arg === null) {
+      delete m_this._options.gcs;
+    } else {
+      m_this._options.gcs = arg;
+    }
+    if (m_this.gcs() !== previous) {
+      m_this.clear();
+      m_this.gcsFeatures(m_this.gcs());
+      m_this.modified();
+      m_this._update();
+    }
+    return m_this;
+  };
+
+  /**
    * Prefetches tiles up to a given zoom level around a given bounding box.
    *
    * @param {number} level The zoom level.

--- a/tests/cases/featureLayer.js
+++ b/tests/cases/featureLayer.js
@@ -118,6 +118,15 @@ describe('geo.featureLayer', function () {
       expect(layer.features().length).toBe(2);
       expect(layer.features()).toEqual([feat2, feat1]);
     });
+    it('gcsFeatures', function () {
+      expect(layer.gcsFeatures()).toBe(layer.map().ingcs());
+      layer.features()[0].gcs('+proj=longlat');
+      expect(layer.gcsFeatures()).toBe(undefined);
+      expect(layer.gcsFeatures('+proj=longlat')).toBe(layer);
+      expect(layer.gcsFeatures()).toBe('+proj=longlat');
+      expect(layer.gcsFeatures(null)).toBe(layer);
+      expect(layer.gcsFeatures()).toBe(layer.map().ingcs());
+    });
     it('visible', function () {
       expect(layer.visible()).toBe(true);
       expect(feat1.visible()).toBe(true);

--- a/tests/cases/tileLayer.js
+++ b/tests/cases/tileLayer.js
@@ -58,6 +58,7 @@ describe('geo.tileLayer', function () {
       size: get_set('size'),
       scale: get_set('scale'),
       zoom: get_set('zoom'),
+      rotation: get_set('rotation'),
       center: get_set('center'),
       origin: get_set('origin'),
       unitsPerPixel: function (zoom) {
@@ -713,6 +714,16 @@ describe('geo.tileLayer', function () {
           {level: 2, x: 1, y: 1}, 'EPSG:4269'), {
           left: 90, top: -66.51, right: 180, bottom: -85.05})).toBe(true);
       });
+    });
+    it('gcs', function () {
+      var l = geo.tileLayer({map: map(), url: function () { return '/testdata/white.jpg'; }, canvas: $('<div/>')});
+      // replace _getTiles so we don't have to actually compute things.
+      l._getTiles = function () {};
+      expect(l.gcs()).toBe(l.map().gcs());
+      expect(l.gcs('+proj=longlat')).toBe(l);
+      expect(l.gcs()).toBe('+proj=longlat');
+      expect(l.gcs(null)).toBe(l);
+      expect(l.gcs()).toBe(l.map().gcs());
     });
     describe('tileCropFromBounds and tilesMaxBounds', function () {
       var w = 5602, h = 4148,

--- a/tests/cases/transform.js
+++ b/tests/cases/transform.js
@@ -429,4 +429,23 @@ describe('geo.transform', function () {
       )).toBeCloseTo(298340.559);
     });
   });
+
+  describe('proj4 with affine parameters', function () {
+    var source = '+proj=longlat +axis=enu',
+        target = '+proj=longlat +axis=enu +s11=1.046 +s12=0.0915 +s21=-0.0915 +s22=1.046 +xoff=-1054.2034 +yoff=-1160.01449';
+    it('transform', function () {
+      expect(closeToEqual(geo.transform.transformCoordinates(source, target, {x: 1, y: 2}), {x: -1052.974, y: -1158.014})).toBe(true);
+      expect(closeToEqual(geo.transform.transformCoordinates(target, source, {x: -1052.974, y: -1158.014}), {x: 1, y: 2})).toBe(true);
+    });
+    it('transform object forward', function () {
+      var proj = geo.transform({source: source, target: target});
+      expect(closeToEqual(proj.forward({x: 1, y: 2}), {x: -1052.974, y: -1158.014, z: 0})).toBe(true);
+      expect(closeToEqual(proj.inverse({x: -1052.974, y: -1158.014}), {x: 1, y: 2, z: 0})).toBe(true);
+    });
+    it('transform object inverse', function () {
+      var proj = geo.transform({source: target, target: source});
+      expect(closeToEqual(proj.inverse({x: 1, y: 2}), {x: -1052.974, y: -1158.014, z: 0})).toBe(true);
+      expect(closeToEqual(proj.forward({x: -1052.974, y: -1158.014}), {x: 1, y: 2, z: 0})).toBe(true);
+    });
+  });
 });


### PR DESCRIPTION
The latest version of proj4 supports [affine transforms](https://proj4.org/operations/transformations/affine.html) via parameters such as +s11 and +xoff.  Proj4js doesn't yet support this, but since it is useful, implement these transforms.

Strictly, in Proj4 6.0.0, you can specify an affine transform like so: `echo 1 2 | cs2cs +proj=affine +to +proj=affine +s11=1.046 +s12=0.0915 +s21=-0.0915 +s22=1.046 +xoff=-1054 +yoff=-1160`, where instead of a projection the `affine` transformation is specified.  However, proj4js expects `+proj=` to be one of its known projections.  Therefore, for know, a layer in image space coordinates could be transformed via something like `+proj=longlat +axis=enu +s11=1.046 +s12=-0.0915 +s21=0.0915 +s22=1.046 +xoff=-1054 +yoff=-1160`.

Add the ability to easily set the tile layer's gcs.  Along with the addition of proj4 affine transforms, this allows multiple tile layers to have different (and adjustable) transforms.

This is a better implementation of the old branch to add a matrix transform the proj4 string (https://github.com/OpenGeoscience/geojs/commit/ec462b57cb93c3a0b65d0dff31f272763028e85a).  This should eventually be able to transition to official support in proj4js.