### PR TITLE
Make zoom via wheel more responsive at the ends of the zoom range.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,10 @@ node_js:
   - 8
 
 addons:
-  firefox: latest  # version 55.0 - 57.x have an issue with screenshots.
-  # firefox: 54.0.1
+  # version 55.0 - 57.x have an issue with screenshots.
+  # version 67.0 has an issue with touch events.
+  # firefox: latest
+  firefox: 66.0.5
   # We can change to a specific version of Chrome later.  Versions 68 - 70 have
   # an issue with webgl fallback rendering.
   chrome: stable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Change Log
 
+## Unreleased
+
+### Features
+- Fetch queues can have an initial size different from their regular size (#1000)
+
+### Improvements
+- More response zooming via mouse wheel (#993)
+
+### Bug Fixes
+- Better handling of tiles with overlap (#997)
+
 ## Version 0.19.4
 
 ### Improvements


### PR DESCRIPTION
Prior to this, zooming via the wheel until the map was fully zoomed in or zoomed out and then reversing the wheel could have a substantial lag before the zoom would reverse.  While some debouncing is fine, this sometimes felt unresponsive.  This ignores wheel events once the end of the range is reached rather than adding more time to the transition.