### PR TITLE
Allow the fetch queue to have an initial size.

### DIFF
--- a/src/fetchQueue.js
+++ b/src/fetchQueue.js
@@ -38,6 +38,7 @@ var fetchQueue = function (options) {
 
   options = options || {};
   this._size = options.size || 6;
+  this._initialSize = options.initialSize || 0;
   this._track = options.track || 600;
   this._needed = options.needed || null;
   this._batch = false;
@@ -54,6 +55,23 @@ var fetchQueue = function (options) {
     get: function () { return m_this._size; },
     set: function (n) {
       m_this._size = n;
+      if (m_this._initialSize > 1 && n < m_this._initialSize) {
+        m_this._initialSize = n;
+      }
+      m_this.next_item();
+    }
+  });
+
+  /**
+   * Get/set the initial maximum concurrent deferred object size.
+   * @property {number} size The initial maximum number of deferred objects.
+   *    `0` to use `size`.
+   * @name geo.fetchQueue#size
+   */
+  Object.defineProperty(this, 'initialSize', {
+    get: function () { return m_this._initialSize; },
+    set: function (n) {
+      m_this._initialSize = n;
       m_this.next_item();
     }
   });
@@ -119,6 +137,7 @@ var fetchQueue = function (options) {
       if (m_this._processing > 0) {
         m_this._processing -= 1;
       }
+      m_this._initialSize = 0;
       m_this.next_item();
     }).promise(defer);
     m_this.next_item();
@@ -217,7 +236,7 @@ var fetchQueue = function (options) {
         }
       }
     }
-    while (m_this._processing < m_this._size && m_this._queue.length) {
+    while (m_this._processing < (m_this._initialSize || m_this._size) && m_this._queue.length) {
       var defer = m_this._queue.shift();
       if (defer.__fetchQueue) {
         m_this._processing += 1;

--- a/tests/cases/fetchQueue.js
+++ b/tests/cases/fetchQueue.js
@@ -129,6 +129,46 @@ describe('geo.core.fetchQueue', function () {
       }, 0);
     });
 
+    it('initial queue size', function (done) {
+      var q = geo.fetchQueue({size: 4, initialSize: 3}), dlist = [];
+
+      expect(q.size).toBe(4);
+      expect(q.initialSize).toBe(3);
+      q.size = 2;
+      expect(q.size).toBe(2);
+      expect(q.initialSize).toBe(2);
+      q.initialSize = 1;
+      expect(q.size).toBe(2);
+      expect(q.initialSize).toBe(1);
+
+      for (var i = 0; i < 5; i += 1) {
+        dlist.push(make_deferred());
+        // add items at end of queue
+        q.add(dlist[i], dlist[i].process, true);
+      }
+      expect(q.length).toBe(4);
+      expect(q.processing).toBe(1);
+
+      // increasing the size shouldn't do anything
+      q.size = 3;
+      expect(q.size).toBe(3);
+      expect(q.length).toBe(4);
+      expect(q.processing).toBe(1);
+
+      dlist[0].defer.resolve();
+      window.setTimeout(function () { // wait for next time slice
+        expect(q.length).toBe(1);
+        expect(q.processing).toBe(3);
+
+        dlist[1].defer.resolve();
+        window.setTimeout(function () { // wait for next time slice
+          expect(q.length).toBe(0);
+          expect(q.processing).toBe(3);
+          done();
+        }, 0);
+      }, 0);
+    });
+
     it('queue removes and skips unneeded items', function (done) {
       var q = geo.fetchQueue({
         size: 2,

--- a/tests/cases/tileLayer.js
+++ b/tests/cases/tileLayer.js
@@ -441,6 +441,21 @@ describe('geo.tileLayer', function () {
       layer._update();
       expect(count).toBe(3);
     });
+    it('queueSize', function () {
+      var m = map(), layer;
+      opts.map = m;
+      layer = geo.tileLayer(opts);
+      expect(layer.queueSize).toBe(6);
+      expect(layer.initialQueueSize).toBe(0);
+      expect(layer._queue.size).toBe(6);
+      expect(layer._queue.initialSize).toBe(0);
+      layer.queueSize = 4;
+      expect(layer.queueSize).toBe(4);
+      expect(layer._queue.size).toBe(4);
+      layer.initialQueueSize = 1;
+      expect(layer.initialQueueSize).toBe(1);
+      expect(layer._queue.initialSize).toBe(1);
+    });
   });
   describe('Public utility methods', function () {
     describe('isValid', function () {


### PR DESCRIPTION
This adds the concept of an initial queue size to the fetch queue.  Once the initial queue size requests have been satisfied, then the regular queue size is used unless the initial queue size is reapplied.

For tile layers, the queue size and initial queue size can now be specified directly, rather than reaching in to the _queue property and modifying the queue there.

The default queue size remains at 6.  This value corresponds to most browsers using a maximum of 6 requests per domain.  If a tile source with subdomains is used, this could be increased to 6 * (number of subdomains).  There doesn't seem to be any measurable improvement doing so with the default osm tile source, though.

The default is not to use an initial queue size.  However, when using tile servers that cache open tile sources and need time to serve the first tile when not in cache, using an initial queue size of 1 can reduce server load, as the tile server will get a single request, serve it, and then get 6 simultaneous requests thereafter.