### PR TITLE
Idle handlers no longer defer to scene-graph parents.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 ### Improvements
 - More response zooming via mouse wheel (#993)
 
+### Changes
+- Idle handlers no longer defer to scene-graph parents.  Parents still wait for all children to be idle
+
 ### Bug Fixes
 - Better handling of tiles with overlap (#997)
 

--- a/src/object.js
+++ b/src/object.js
@@ -54,6 +54,20 @@ var object = function () {
   });
 
   /**
+   * Private getter for the number of outstanding promises.
+   *
+   * @property {number} _promises The number of outstanding promises.  If this
+   *    is zero, the object is idle.
+   * @name geo.object#_promises
+   */
+  Object.defineProperty(this, '_promises', {
+    get: function () {
+      return m_promiseCount;
+    },
+    configurable: true
+  });
+
+  /**
    * Add a new promise object preventing idle event handlers from being called
    * until it is resolved.
    *

--- a/src/sceneObject.js
+++ b/src/sceneObject.js
@@ -23,11 +23,10 @@ var sceneObject = function (arg) {
       m_children = [],
       s_exit = this._exit,
       s_trigger = this.geoTrigger,
-      s_addPromise = this.addPromise,
-      s_onIdle = this.onIdle;
+      s_addPromise = this.addPromise;
 
   /**
-   * Override object.addPromise to propagate up the scene tree.
+   * Add the promise here and also propagate up the scene tree.
    *
    * @param {Promise} promise A promise object.
    * @returns {this}
@@ -35,24 +34,8 @@ var sceneObject = function (arg) {
   this.addPromise = function (promise) {
     if (m_parent) {
       m_parent.addPromise(promise);
-    } else {
-      s_addPromise(promise);
     }
-    return m_this;
-  };
-
-  /**
-   * Override object.onIdle to propagate up the scene tree.
-   *
-   * @param {function} handler A function taking no arguments.
-   * @returns {this}
-   */
-  this.onIdle = function (handler) {
-    if (m_parent) {
-      m_parent.onIdle(handler);
-    } else {
-      s_onIdle(handler);
-    }
+    s_addPromise(promise);
     return m_this;
   };
 

--- a/tests/cases/deferred.js
+++ b/tests/cases/deferred.js
@@ -9,6 +9,7 @@ describe('Testing onIdle event handling', function () {
       var obj = geo.object(), called = false;
 
       expect(obj.idle).toBe(true);
+      expect(obj._promises).toBe(0);
       obj.onIdle(function () {
         called = true;
       });
@@ -21,11 +22,13 @@ describe('Testing onIdle event handling', function () {
 
       obj.addPromise(defer);
       expect(obj.idle).toBe(false);
+      expect(obj._promises).toBe(1);
       window.setTimeout(function () {
         var called = false;
         defer.resolve();
 
         expect(obj.idle).toBe(true);
+        expect(obj._promises).toBe(0);
         obj.onIdle(function () {
           called = true;
         });

--- a/tests/cases/sceneObject.js
+++ b/tests/cases/sceneObject.js
@@ -231,18 +231,18 @@ describe('geo.sceneObject', function () {
     root.addChild(child2);
     child2.addChild(child3);
 
-    it('child defers to parent', function () {
+    it('child propagates to parent', function () {
       var defer = $.Deferred(),
           handlerRoot = new CallCounter(null),
           handler1 = new CallCounter(null),
           handler2 = new CallCounter(null),
           handler3 = new CallCounter(null);
 
-      function checkCallCount(count) {
-        expect(handlerRoot.ncalls).toBe(count);
-        expect(handler1.ncalls).toBe(count);
-        expect(handler2.ncalls).toBe(count);
-        expect(handler3.ncalls).toBe(count);
+      function checkCallCount(countr, count1, count2, count3) {
+        expect(handlerRoot.ncalls).toBe(countr);
+        expect(handler1.ncalls).toBe(count1);
+        expect(handler2.ncalls).toBe(count2);
+        expect(handler3.ncalls).toBe(count3);
       }
 
       child3.addPromise(defer);
@@ -251,27 +251,27 @@ describe('geo.sceneObject', function () {
       child2.onIdle(handler2.call);
       child3.onIdle(handler3.call);
 
-      checkCallCount(0);
+      checkCallCount(0, 1, 0, 0);
 
       defer.resolve();
 
-      checkCallCount(1);
+      checkCallCount(1, 1, 1, 1);
 
       defer = $.Deferred();
       child3.addPromise(defer);
 
-      checkCallCount(1);
+      checkCallCount(1, 1, 1, 1);
 
       defer.resolve();
 
-      checkCallCount(1);
+      checkCallCount(1, 1, 1, 1);
 
       root.onIdle(handlerRoot.call);
       child1.onIdle(handler1.call);
       child2.onIdle(handler2.call);
       child3.onIdle(handler3.call);
 
-      checkCallCount(2);
+      checkCallCount(2, 2, 2, 2);
     });
 
     it('aysnchronous events from multiple children', function (done) {


### PR DESCRIPTION
Parents still wait for all children to be idle.

Before, if a map had multiple layers, for instance, `oneLayer.onIdle` would wait for all layers and the map to be idle before triggering.  Now, `oneLayer.onIdle` will only wait for that layer and its children. `mainMap.onIdle` will wait for all of the layers and their children as before.

This is useful, for instance, if you have two tile layers and you wish to trigger a function when one of the tile layers is fully loaded without waiting for the second tile layer.  You can still wait for both by using `map.onIdle`.