### PR TITLE
If a point has no stroke or fill, don't return it from pointSearch.

### DIFF
--- a/src/pointFeature.js
+++ b/src/pointFeature.js
@@ -231,7 +231,7 @@ var pointFeature = function (arg) {
    * data changes.
    */
   this._updateRangeTree = function () {
-    if (m_rangeTreeTime.timestamp() >= m_this.dataTime().timestamp()) {
+    if (m_rangeTreeTime.timestamp() >= m_this.dataTime().timestamp() && m_rangeTreeTime.timestamp() >= m_this.timestamp()) {
       return;
     }
     var pts, position,
@@ -274,6 +274,7 @@ var pointFeature = function (arg) {
     var min, max, data, idx = [], found = [], ifound = [], map, pt,
         fgcs = m_this.gcs(), // this feature's gcs
         corners,
+        fill = m_this.style.get('fill'),
         stroke = m_this.style.get('stroke'),
         strokeWidth = m_this.style.get('strokeWidth'),
         radius = m_this.style.get('radius');
@@ -314,11 +315,14 @@ var pointFeature = function (arg) {
     // Filter by circular region
     idx.forEach(function (i) {
       var d = data[i],
-          p = m_this.position()(d, i),
+          hasstroke = stroke(data[i], i);
+      if (!hasstroke && !fill(data[i], i)) {
+        return;
+      }
+      var p = m_this.position()(d, i),
           dx, dy, rad, rad2;
-
       rad = radius(data[i], i);
-      rad += stroke(data[i], i) ? strokeWidth(data[i], i) : 0;
+      rad += hasstroke ? strokeWidth(data[i], i) : 0;
       if (rad) {
         rad2 = rad * rad;
         p = map.gcsToDisplay(p, fgcs);

--- a/tests/cases/pointFeature.js
+++ b/tests/cases/pointFeature.js
@@ -129,9 +129,16 @@ describe('geo.pointFeature', function () {
       expect(pt.found.length).toBe(1);
       pt = point.pointSearch(map.displayToGcs({x: p.x, y: p.y + 4.05}));
       expect(pt.found.length).toBe(0);
-      /* We should match two coincident pointss */
+      /* We should match two coincident points */
       pt = point.pointSearch({x: 50, y: 10});
       expect(pt.found.length).toBe(2);
+      /* If a point has no fill or stroke, it won't be found. */
+      point.style({
+        fill: function (d, i) { return i !== 16; },
+        stroke: function (d, i) { return i !== 16; }
+      });
+      pt = point.pointSearch({x: 50, y: 10});
+      expect(pt.found.length).toBe(1);
       /* If we have zero-length data, we get no matches */
       point.data([]);
       pt = point.pointSearch({x: 22, y: 10});


### PR DESCRIPTION
Before, regardless of fill, the point could be returned (unless it had no stroke and a radius of 0).