### PR TITLE
Fix touch event testing on Firefox 67.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,8 @@ node_js:
 addons:
   # version 55.0 - 57.x have an issue with screenshots.
   # version 67.0 has an issue with touch events.
-  # firefox: latest
-  firefox: 66.0.5
+  # firefox: 66.0.5
+  firefox: latest
   # We can change to a specific version of Chrome later.  Versions 68 - 70 have
   # an issue with webgl fallback rendering.
   chrome: stable

--- a/src/mapInteractor.js
+++ b/src/mapInteractor.js
@@ -559,7 +559,8 @@ var mapInteractor = function (args) {
    */
   this.hasTouchSupport = function () {
     return ('ontouchstart' in window) || // touch events
-           (window.Modernizr && window.Modernizr.touch) || // modernizr
+           (window.TouchEvent) ||
+           (window.DocumentTouch && document instanceof window.DocumentTouch) ||
            (navigator.msMaxTouchPoints || navigator.maxTouchPoints) > 1; // pointer events
   };
 

--- a/tests/cases/mapInteractor.js
+++ b/tests/cases/mapInteractor.js
@@ -1695,7 +1695,9 @@ describe('mapInteractor', function () {
         interactor = geo.mapInteractor({map: map}),
         clickTriggered = 0;
 
-    expect(interactor.hasTouchSupport()).toBe(true);
+    if (!interactor.hasTouchSupport()) {
+      interactor.options({alwaysTouch: true});
+    }
 
     // check the pan event was called
     interactor.simulateEvent(
@@ -1859,7 +1861,9 @@ describe('Optional Dependencies', function () {
     var map = geo.map({node: '#mapNode1'}),
         interactor = map.interactor();
 
-    expect(interactor.hasTouchSupport()).toBe(true);
+    if (!interactor.hasTouchSupport()) {
+      interactor.options({alwaysTouch: true});
+    }
     expect(map.center().x).toBeCloseTo(0);
     // We shouldn't process pan touch events
     interactor.simulateEvent(


### PR DESCRIPTION
Firefox 67 changed touch events which caused the headless testing to fail.  This fixes that.  I've confirmed that Firefox 67 mobile responds properly to touch events, so this was purely a testing issue.