### PR TITLE
Return information on which line segment is found.

### DIFF
--- a/src/lineFeature.js
+++ b/src/lineFeature.js
@@ -195,11 +195,13 @@ var lineFeature = function (arg) {
    * the narrow end.
    *
    * @param {geo.geoPosition} p point to search for in map interface gcs.
-   * @returns {object} An object with `index`: a list of line indices, and
-   *    `found`: a list of quads that contain the specified coordinate.
+   * @returns {object} An object with `index`: a list of line indices, `found`:
+   *    a list of quads that contain the specified coordinate, and `extra`: am
+   *    object with keys that are line indices and values that are the first
+   *    segement index for which the line was matched.
    */
   this.pointSearch = function (p) {
-    var data = m_this.data(), indices = [], found = [];
+    var data = m_this.data(), indices = [], found = [], extra = {};
     if (!data || !data.length || !m_this.layer()) {
       return {
         found: found,
@@ -219,13 +221,15 @@ var lineFeature = function (arg) {
         if (util.distance2dToLineSquared(pt, record[j].u, record[j].v) <= record[j].r2 * scale2) {
           found.push(data[i]);
           indices.push(i);
+          extra[i] = j;
           break;
         }
       }
     }
     return {
       found: found,
-      index: indices
+      index: indices,
+      extra: extra
     };
   };
 

--- a/src/quadFeature.js
+++ b/src/quadFeature.js
@@ -155,8 +155,11 @@ var quadFeature = function (arg) {
    *
    * @param {geo.geoPosition} coordinate Coordinate in input gcs to check if it
    *    is located in any quad in map interface gcs.
-   * @returns {object} An object with `index`: a list of quad indices, and
-   *    `found`: a list of quads that contain the specified coordinate.
+   * @returns {object} An object with `index`: a list of quad indices, `found`:
+   *    a list of quads that contain the specified coordinate, and `extra`: an
+   *    object with keys that are quad indices and values that are objects with
+   *    `basis.x` and `basis.y`, values from 0 - 1 relative to interior of the
+   *    quad.
    */
   this.pointSearch = function (coordinate) {
     var found = [], indices = [], extra = {},

--- a/tests/cases/lineFeature.js
+++ b/tests/cases/lineFeature.js
@@ -123,10 +123,12 @@ describe('geo.lineFeature', function () {
        * line, but not on an open line */
       pt = line.pointSearch({x: 31, y: 12.5});
       expect(pt.found.length).toBe(1);
+      expect(pt.extra[1]).toBe(2);
       pt = line.pointSearch({x: 31, y: 22.5});
       expect(pt.found.length).toBe(0);
       pt = line.pointSearch({x: 31, y: 32.5});
       expect(pt.found.length).toBe(1);
+      expect(pt.extra[3]).toBe(2);
       /* On a closed line, we should find a point between the first and last
        * point, but not between the first and a point that isn't the second or
        * last. */


### PR DESCRIPTION
When doing a point search on a line feature, report an index value for the line segment within a line that was matched.