### PR TITLE
Include source event information in some feature events.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features
 - Fetch queues can have an initial size different from their regular size (#1000)
-- Autoshare renderers now has three states, with the default being more likely to not change anythign visually (#1011)
+- Autoshare renderers now has three states, with the default being more likely to not change anything visually (#1011)
 
 ### Improvements
 - More response zooming via mouse wheel (#993)
@@ -12,6 +12,7 @@
 - If a point has no stroke or fill, don't return it from pointSearch (#1003)
 - WebGL point, line, polygon, and contour features use a localized origin for improved precision at high zoom levels.  This reduces panning jitter in zoom levels 19 and up (#1005)
 - When doing a point search on a line feature, report which line segment is found (#1008)
+- Include source event information in some feature events (#1009)
 
 ### Changes
 - Idle handlers no longer defer to scene-graph parents.  Parents still wait for all children to be idle (#1001)

--- a/src/event.js
+++ b/src/event.js
@@ -348,6 +348,7 @@ geo_event.feature = {
    *    features that the mouse moves over simultaneously will have the same
    *    `eventID`.
    * @property {boolean} top True if this is the topmost data element.
+   * @property {geo.event} sourceEvent The underlying event that trigger this.
    */
   mousemove:  'geo_feature_mousemove',
   /**
@@ -365,6 +366,7 @@ geo_event.feature = {
    *    features that the mouse goes over simultaneously will have the same
    *    `eventID`.
    * @property {boolean} top True if this is the topmost data element.
+   * @property {geo.event} sourceEvent The underlying event that trigger this.
    */
   mouseover:  'geo_feature_mouseover',
   /**
@@ -375,10 +377,11 @@ geo_event.feature = {
    * @type {geo.event.base}
    * @property {geo.feature} feature The feature.
    * @property {geo.mouseState} mouse The mouse state.
-   * @proeprty {geo.feature.searchResult} over A list of feature components
+   * @property {geo.feature.searchResult} over A list of feature components
    *    that the mouse is over.
-   * @proeprty {number[]} The indices of the data components that the mouse
+   * @property {number[]} The indices of the data components that the mouse
    *    was over before this event.
+   * @property {geo.event} sourceEvent The underlying event that trigger this.
    */
   mouseover_order: 'geo_feature_mouseover_order',
   /**
@@ -397,6 +400,7 @@ geo_event.feature = {
    *    features that the mouse goes over simultaneously will have the same
    *    `eventID`.
    * @property {boolean} top True if this is the topmost data element.
+   * @property {geo.event} sourceEvent The underlying event that trigger this.
    */
   mouseout:   'geo_feature_mouseout',
   /**
@@ -408,6 +412,7 @@ geo_event.feature = {
    * @property {object} data The feature data the mouse is on.
    * @property {number} index The index of the feature data the mouse is on.
    * @property {geo.mouseState} mouse The mouse state.
+   * @property {geo.event} sourceEvent The underlying event that trigger this.
    */
   mouseon:    'geo_feature_mouseon',
   /**
@@ -419,6 +424,7 @@ geo_event.feature = {
    * @property {object} data The feature data the mouse is off.
    * @property {number} index The index of the feature data the mouse is off.
    * @property {geo.mouseState} mouse The mouse state.
+   * @property {geo.event} sourceEvent The underlying event that trigger this.
    */
   mouseoff:   'geo_feature_mouseoff',
   /**
@@ -435,6 +441,7 @@ geo_event.feature = {
    *    features that the mouse clicks simultaneously will have the same
    *    `eventID`.
    * @property {boolean} top True if this is the topmost data element.
+   * @property {geo.event} sourceEvent The underlying event that trigger this.
    */
   mouseclick: 'geo_feature_mouseclick',
   /**
@@ -445,8 +452,9 @@ geo_event.feature = {
    * @type {geo.event.base}
    * @property {geo.feature} feature The feature that was clicked.
    * @property {geo.mouseState} mouse The mouse state.
-   * @proeprty {geo.feature.searchResult} over A list of feature components
+   * @property {geo.feature.searchResult} over A list of feature components
    *    that the mouse is over.
+   * @property {geo.event} sourceEvent The underlying event that trigger this.
    */
   mouseclick_order: 'geo_feature_mouseclick_order',
   /**

--- a/src/feature.js
+++ b/src/feature.js
@@ -212,6 +212,7 @@ var feature = function (arg) {
    * Private mousemove handler.  This uses `pointSearch` to determine which
    * features the mouse is over, then fires appropriate events.
    *
+   * @param {geo.event} evt The event that triggered this handler.
    * @fires geo.event.feature.mouseover_order
    * @fires geo.event.feature.mouseover
    * @fires geo.event.feature.mouseout
@@ -219,7 +220,7 @@ var feature = function (arg) {
    * @fires geo.event.feature.mouseoff
    * @fires geo.event.feature.mouseon
    */
-  this._handleMousemove = function () {
+  this._handleMousemove = function (evt) {
     var mouse = m_this.layer().map().interactor().mouse(),
         data = m_this.data(),
         over = m_this.pointSearch(mouse.geo),
@@ -241,7 +242,8 @@ var feature = function (arg) {
         feature: m_this,
         mouse: mouse,
         previous: m_selectedFeatures,
-        over: over
+        over: over,
+        sourceEvent: evt
       });
     }
 
@@ -267,7 +269,8 @@ var feature = function (arg) {
         extra: extra[i],
         mouse: mouse,
         eventID: feature.eventID,
-        top: idx === newFeatures.length - 1
+        top: idx === newFeatures.length - 1,
+        sourceEvent: evt
       }, true);
     });
 
@@ -279,7 +282,8 @@ var feature = function (arg) {
         index: i,
         mouse: mouse,
         eventID: feature.eventID,
-        top: idx === oldFeatures.length - 1
+        top: idx === oldFeatures.length - 1,
+        sourceEvent: evt
       }, true);
     });
 
@@ -292,7 +296,8 @@ var feature = function (arg) {
         extra: extra[i],
         mouse: mouse,
         eventID: feature.eventID,
-        top: idx === over.index.length - 1
+        top: idx === over.index.length - 1,
+        sourceEvent: evt
       }, true);
     });
 
@@ -310,7 +315,8 @@ var feature = function (arg) {
         m_this.geoTrigger(geo_event.feature.mouseoff, {
           data: data[lastTop],
           index: lastTop,
-          mouse: mouse
+          mouse: mouse,
+          sourceEvent: evt
         }, true);
       }
 
@@ -319,7 +325,8 @@ var feature = function (arg) {
           data: data[top],
           index: top,
           extra: extra[top],
-          mouse: mouse
+          mouse: mouse,
+          sourceEvent: evt
         }, true);
       }
     }
@@ -357,7 +364,8 @@ var feature = function (arg) {
       m_this.geoTrigger(geo_event.feature.mouseclick_order, {
         feature: m_this,
         mouse: mouse,
-        over: over
+        over: over,
+        sourceEvent: evt
       });
     }
     mouse.buttonsDown = evt.buttonsDown;
@@ -369,7 +377,8 @@ var feature = function (arg) {
         extra: extra[i],
         mouse: mouse,
         eventID: feature.eventID,
-        top: idx === over.index.length - 1
+        top: idx === over.index.length - 1,
+        sourceEvent: evt
       }, true);
     });
   };


### PR DESCRIPTION
This, for instance, allows a event.feature.mouseclick to mark that the underlying event.mouseclick has been processed.