### PR TITLE
Improve packaging.

### DIFF
--- a/src/polyfills.js
+++ b/src/polyfills.js
@@ -1,1 +1,4 @@
-require('babel-polyfill');
+// prevent errors from double inclusion in downstream libraries
+if (!global._babelPolyfill) {
+  require('babel-polyfill');
+}

--- a/src/vtkjs/vtkjsRenderer.js
+++ b/src/vtkjs/vtkjsRenderer.js
@@ -180,10 +180,10 @@ vtkjsRenderer.supported = function () {
   // webpack expects optional dependencies to be wrapped in a try-catch
   try {
     vtkjsRenderer.vtkjs = require('vtk.js');
-    if (!vtkjsRenderer.vtkjs.Rendering && window.vtk.Rendering) {
-      vtkjsRenderer.vtkjs = window.vtk;
-    }
   } catch (_error) {}
+  if ((!vtkjsRenderer.vtkjs || !vtkjsRenderer.vtkjs.Rendering) && window.vtk && window.vtk.Rendering) {
+    vtkjsRenderer.vtkjs = window.vtk;
+  }
   return vtkjsRenderer.vtkjs !== undefined;
 };
 

--- a/webpack-lean.config.js
+++ b/webpack-lean.config.js
@@ -19,6 +19,6 @@ module.exports = merge(config, {
       // will allow Webpack to create a better error message if a "hammerjs" import fails
       umd: 'hammerjs'
     },
-    'vtk.js': 'vtk'
+    'vtk.js': 'vtk.js'
   }
 });


### PR DESCRIPTION
vtkjs was being required on the lean package, though it should have been optional.

Libraries that someone included geojs twice would fail due to the babel-polyfill.