### PR TITLE
Speed up webgl point updates.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Improvements
 - Points with small radii or thin strokes are rendered better (#1021)
+- When only updating point styles, don't recompute geometry transforms (#1022)
 
 ### Changes
 - Switched the default tile server to Stamen Design's toner-lite. (#1020)

--- a/src/webgl/pointFeaturePoly.frag
+++ b/src/webgl/pointFeaturePoly.frag
@@ -8,21 +8,19 @@ varying vec4 fillColorVar;
 varying vec4 strokeColorVar;
 varying float radiusVar;
 varying float strokeWidthVar;
-varying float fillVar;
-varying float strokeVar;
 varying vec3 unitVar;  // distinct for square/triangle
 
 void main () {
   vec4 strokeColor, fillColor;
   float endStep;
   // No stroke or fill implies nothing to draw
-  if (fillVar == 0.0 && strokeVar == 0.0)
+  if (fillColorVar.a == 0.0 && strokeColorVar.a == 0.0)
     discard;
   float rad = length(unitVar.xy); // distinct for square/triangle
   if (rad > 1.0)
     discard;
   // If there is no stroke, the fill region should transition to nothing
-  if (strokeVar == 0.0) {
+  if (strokeColorVar.a == 0.0) {
     strokeColor = vec4(fillColorVar.rgb, 0.0);
     endStep = 1.0;
   } else {
@@ -30,7 +28,7 @@ void main () {
     endStep = radiusVar / (radiusVar + strokeWidthVar);
   }
   // Likewise, if there is no fill, the stroke should transition to nothing
-  if (fillVar == 0.0)
+  if (fillColorVar.a == 0.0)
     fillColor = vec4(strokeColor.rgb, 0.0);
   else
     fillColor = fillColorVar;

--- a/src/webgl/pointFeaturePoly.vert
+++ b/src/webgl/pointFeaturePoly.vert
@@ -20,35 +20,29 @@ varying vec4 fillColorVar;
 varying vec4 strokeColorVar;
 varying float radiusVar;
 varying float strokeWidthVar;
-varying float fillVar;
-varying float strokeVar;
 attribute vec2 unit; // for non-sprite
 varying vec3 unitVar; // for non-sprite
 
 void main(void)
 {
   strokeWidthVar = strokeWidth;
+  fillColorVar = vec4(fillColor, fillOpacity);
+  strokeColorVar = vec4(strokeColor, strokeOpacity);
   // No stroke or fill implies nothing to draw
   if (stroke < 1.0 || strokeWidth <= 0.0 || strokeOpacity <= 0.0) {
-    strokeVar = 0.0;
+    strokeColorVar.a = 0.0;
     strokeWidthVar = 0.0;
   }
-  else
-    strokeVar = 1.0;
   if (fill < 1.0 || radius <= 0.0 || fillOpacity <= 0.0)
-    fillVar = 0.0;
-  else
-    fillVar = 1.0;
+    fillColorVar.a = 0.0;
   /* If the point has no visible pixels, skip doing computations on it. */
-  if (fillVar == 0.0 && strokeVar == 0.0) {
+  if (fillColorVar.a == 0.0 && strokeColorVar.a == 0.0) {
     gl_Position = vec4(2, 2, 0, 1);
     return;
   }
-  fillColorVar = vec4 (fillColor, fillOpacity);
-  strokeColorVar = vec4 (strokeColor, strokeOpacity);
   radiusVar = radius;
   // for non-sprite
-  unitVar = vec3 (unit, 1.0);
+  unitVar = vec3(unit, 1.0);
   vec4 p = (projectionMatrix * modelViewMatrix * vec4(pos, 1.0)).xyzw;
   if (p.w != 0.0) {
     p = p / p.w;

--- a/src/webgl/pointFeatureSprite.frag
+++ b/src/webgl/pointFeatureSprite.frag
@@ -8,21 +8,19 @@ varying vec4 fillColorVar;
 varying vec4 strokeColorVar;
 varying float radiusVar;
 varying float strokeWidthVar;
-varying float fillVar;
-varying float strokeVar;
 // the square/triangle shade defines unitVar
 
 void main () {
   vec4 strokeColor, fillColor;
   float endStep;
   // No stroke or fill implies nothing to draw
-  if (fillVar == 0.0 && strokeVar == 0.0)
+  if (fillColorVar.a == 0.0 && strokeColorVar.a == 0.0)
     discard;
   float rad = 2.0 * length(gl_PointCoord - vec2(0.5));  // distinct for sprite
   if (rad > 1.0)
     discard;
   // If there is no stroke, the fill region should transition to nothing
-  if (strokeVar == 0.0) {
+  if (strokeColorVar.a == 0.0) {
     strokeColor = vec4(fillColorVar.rgb, 0.0);
     endStep = 1.0;
   } else {
@@ -30,7 +28,7 @@ void main () {
     endStep = radiusVar / (radiusVar + strokeWidthVar);
   }
   // Likewise, if there is no fill, the stroke should transition to nothing
-  if (fillVar == 0.0)
+  if (fillColorVar.a == 0.0)
     fillColor = vec4(strokeColor.rgb, 0.0);
   else
     fillColor = fillColorVar;

--- a/src/webgl/pointFeatureSprite.vert
+++ b/src/webgl/pointFeatureSprite.vert
@@ -20,31 +20,25 @@ varying vec4 fillColorVar;
 varying vec4 strokeColorVar;
 varying float radiusVar;
 varying float strokeWidthVar;
-varying float fillVar;
-varying float strokeVar;
 // non-sprite has ither definitions.
 
 void main(void)
 {
   strokeWidthVar = strokeWidth;
+  fillColorVar = vec4(fillColor, fillOpacity);
+  strokeColorVar = vec4(strokeColor, strokeOpacity);
   // No stroke or fill implies nothing to draw
   if (stroke < 1.0 || strokeWidth <= 0.0 || strokeOpacity <= 0.0) {
-    strokeVar = 0.0;
+    strokeColorVar.a = 0.0;
     strokeWidthVar = 0.0;
   }
-  else
-    strokeVar = 1.0;
   if (fill < 1.0 || radius <= 0.0 || fillOpacity <= 0.0)
-    fillVar = 0.0;
-  else
-    fillVar = 1.0;
+    fillColorVar.a = 0.0;
   /* If the point has no visible pixels, skip doing computations on it. */
-  if (fillVar == 0.0 && strokeVar == 0.0) {
+  if (fillColorVar.a == 0.0 && strokeColorVar.a == 0.0) {
     gl_Position = vec4(2, 2, 0, 1);
     return;
   }
-  fillColorVar = vec4 (fillColor, fillOpacity);
-  strokeColorVar = vec4 (strokeColor, strokeOpacity);
   radiusVar = radius;
   // for sprite
   gl_Position = (projectionMatrix * modelViewMatrix * vec4(pos, 1.0)).xyzw;

--- a/tests/cases/pointFeature.js
+++ b/tests/cases/pointFeature.js
@@ -372,6 +372,14 @@ describe('geo.pointFeature', function () {
       point.updateStyleFromArray('radius', array1, true);
       expect(count).toBe(2);
     });
+    it('modify and refresh', function () {
+      glCounts = $.extend({}, vgl.mockCounts());
+      point2.modified().draw();
+      expect(count).toBe(2);
+    });
+    waitForIt('next render gl E', function () {
+      return vgl.mockCounts().bufferSubData >= (glCounts.bufferSubData || 0) + 8;
+    });
     it('_exit', function () {
       expect(point.actors().length).toBe(1);
       layer.deleteFeature(point);


### PR DESCRIPTION
When only the point style has changed, just update the GL buffers instead of the entire geometry.  For the shaders, use a few less varying variables.