### PR TITLE
Expose the original event data in the action wheel event.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Bug Fixes
 - Mouse wheel events didn't recompute gcs coordinates, so a wheel event without a previous move event coult list the wrong location (#1027)
+- Original event data was not included with actionwheel events (#1030)
 
 ## Version 0.19.6
 

--- a/src/mapInteractor.js
+++ b/src/mapInteractor.js
@@ -1767,7 +1767,7 @@ var mapInteractor = function (args) {
             break;
         }
         m_this.map().geoTrigger(geo_event.actionwheel, {
-          state: m_this.state(), mouse: m_this.mouse(), event: evt});
+          state: m_this.state(), mouse: m_this.mouse(), eventData: evt});
       }
 
       // reset the queue


### PR DESCRIPTION
This was intended, but since the `event` key was used, and that is populated with the event name, it wasn't actually exposed.

Resolves #1024.