### PR TITLE
Add auto primitiveShape to the webgl point feature.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Points with small radii or thin strokes are rendered better (#1021)
 - When only updating point styles, don't recompute geometry transforms (#1022)
 - Optimized a transform code path for pixel coordinates (#1023)
+- WebGL point features automatically use the most memory-efficient primitive shape for the point sizes used based on the system's graphics capabilities (#1031)
 
 ### Changes
 - Switched the default tile server to Stamen Design's toner-lite. (#1020)

--- a/examples/animation/main.js
+++ b/examples/animation/main.js
@@ -435,7 +435,7 @@ $(function () {
   map.createLayer('osm');
   layer = map.createLayer('feature', layerOptions);
   pointFeature = layer.createFeature('point', {
-    primitiveShape: query.primitive ? query.primitive : 'sprite'
+    primitiveShape: query.primitive ? query.primitive : geo.pointFeature.primitiveShapes.auto
   })
   .position(function (d) {
     return {x: d[2], y: d[1]};

--- a/src/pointFeature.js
+++ b/src/pointFeature.js
@@ -11,13 +11,19 @@ var feature = require('./feature');
  *   style options.
  * @property {boolean|geo.pointFeature.clusteringSpec} [clustering=false]
  *   Enable point clustering.
- * @property {string} [primitiveShape='sprite'] For the webgl renderer, select
- *   the primitive shape.  This is one of `'triangle'`, `'square'`, or
- *   `'sprite'`.  `sprite` uses the least memory, `triangle` is fastest if the
- *   vertex shader is the bottleneck, and `square` is fastest if the fragment
- *   shader is the bottleneck.  `sprite` may not work for very large points.
+ * @property {string} [primitiveShape='auto'] For the webgl renderer, select
+ *   the primitive shape.  This is one of `pointFeature.primitiveShapes`:
+ *   `'auto'`, `'sprite'`, `'triangle'`, or `'square'`.  `sprite` uses the
+ *   least memory but has a maximum size dependent on the GPU, `triangle` is
+ *   fastest if the vertex shader is the bottleneck, and `square` is fastest if
+ *   the fragment shader is the bottleneck.  `auto` will use `sprite` unless
+ *   the largest point exceeds the size that can be rendered via GL points, and
+ *   then it will switch to `triangle`.  The computation for `auto` uses some
+ *   time, so using a specific primitive could be faster.
  * @property {boolean} [dynamicDraw=false] For the webgl renderer, if this is
  *   truthy, webgl source buffers can be modified and updated directly.
+ *   truthy, webgl source buffers can be modified and updated directly.  This
+ *   is not strictly necessary, as it is just a recommendation for the GPU.
  */
 
 /**
@@ -539,6 +545,17 @@ pointFeature.capabilities = {
   feature: 'point',
   /* support for stroke properties */
   stroke: 'point.stroke'
+};
+
+/**
+ * Support primitive shapes
+ * @enum
+ */
+pointFeature.primitiveShapes = {
+  auto: 'auto',
+  sprite: 'sprite',
+  triangle: 'triangle',
+  square: 'square'
 };
 
 inherit(pointFeature, feature);

--- a/src/util/mockVGL.js
+++ b/src/util/mockVGL.js
@@ -88,8 +88,10 @@ module.exports.mockWebglRenderer = function mockWebglRenderer(supported) {
     getExtension: incID('getExtension'),
     getParameter: function (key) {
       count('getParameter');
-      if (key === vgl.GL.DEPTH_BITS) {
-        return 16;
+      switch (key) {
+        case vgl.GL.ALIASED_POINT_SIZE_RANGE: return [1, 64];
+        case vgl.GL.DEPTH_BITS: return 16;
+        case vgl.GL.MAX_TEXTURE_SIZE: return 4096;
       }
     },
     getProgramParameter: function (id, key) {
@@ -174,6 +176,8 @@ module.exports.mockWebglRenderer = function mockWebglRenderer(supported) {
   webglRenderer.supported = function () {
     return !!supported;
   };
+  webglRenderer._maxTextureSize = 4096;
+  webglRenderer._maxPointSize = 64;
 
   vgl._mocked = true;
   vgl.mockCounts = function () {

--- a/src/webgl/pointFeature.js
+++ b/src/webgl/pointFeature.js
@@ -220,7 +220,9 @@ var webgl_pointFeature = function (arg) {
       fillVal = fillFunc(item, i) ? 1.0 : 0.0;
       fillOpacityVal = fillOpacityFunc(item, i);
       fillColorVal = fillColorFunc(item, i);
-      if (m_primitiveShapeAuto && ((fillVal && fillOpacityVal) || (strokeVal && strokeOpacityVal)) && radiusVal + (strokeVal && strokeOpacityVal ? strokeWidthVal : 0) > maxr) {
+      if (m_primitiveShapeAuto &&
+          ((fillVal && fillOpacityVal) || (strokeVal && strokeOpacityVal)) &&
+          radiusVal + (strokeVal && strokeOpacityVal ? strokeWidthVal : 0) > maxr) {
         maxr = radiusVal + (strokeVal && strokeOpacityVal ? strokeWidthVal : 0);
       }
       for (j = 0; j < vpf; j += 1, ivpf += 1, ivpf3 += 3) {

--- a/src/webgl/webglRenderer.js
+++ b/src/webgl/webglRenderer.js
@@ -330,6 +330,9 @@ webglRenderer.supported = function () {
         webglRenderer._unmaskedRenderer = ctx.getParameter(ctx.getExtension(
           'WEBGL_debug_renderer_info').UNMASKED_RENDERER_WEBGL);
       }
+      // store some parameters for convenience
+      webglRenderer._maxTextureSize = ctx.getParameter(ctx.MAX_TEXTURE_SIZE);
+      webglRenderer._maxPointSize = ctx.getParameter(ctx.ALIASED_POINT_SIZE_RANGE)[1];
       checkedWebGL = true;
     } catch (e) {
       console.warn('No webGL support');

--- a/tests/cases/pointFeature.js
+++ b/tests/cases/pointFeature.js
@@ -330,13 +330,16 @@ describe('geo.pointFeature', function () {
       return vgl.mockCounts().createProgram >= (glCounts.createProgram || 0) + 1;
     });
     it('other primitive shapes', function () {
+      expect(point.primitiveShape()).toBe(geo.pointFeature.primitiveShapes.auto);
+      expect(point.primitiveShape(undefined, true)).toBe(geo.pointFeature.primitiveShapes.sprite);
       point2 = layer.createFeature('point', {
-        primitiveShape: 'triangle'
+        primitiveShape: geo.pointFeature.primitiveShapes.triangle
       }).data(testPoints);
+      expect(point2.primitiveShape()).toBe(geo.pointFeature.primitiveShapes.triangle);
       expect(point2.verticesPerFeature()).toBe(3);
       layer.deleteFeature(point2);
       point2 = layer.createFeature('point', {
-        primitiveShape: 'square'
+        primitiveShape: geo.pointFeature.primitiveShapes.square
       }).data(testPoints);
       expect(point2.verticesPerFeature()).toBe(6);
       glCounts = $.extend({}, vgl.mockCounts());
@@ -344,6 +347,24 @@ describe('geo.pointFeature', function () {
     });
     waitForIt('next render gl B', function () {
       return vgl.mockCounts().drawArrays >= (glCounts.drawArrays || 0) + 1;
+    });
+    it('change primitive shapes', function () {
+      expect(point2.primitiveShape(geo.pointFeature.primitiveShapes.auto)).toBe(point2);
+      point2.draw();
+      expect(point2.primitiveShape()).toBe(geo.pointFeature.primitiveShapes.auto);
+      expect(point2.primitiveShape(undefined, true)).toBe(geo.pointFeature.primitiveShapes.sprite);
+      point2.style('radius', 20000);
+      point2.draw();
+      expect(point2.primitiveShape()).toBe(geo.pointFeature.primitiveShapes.auto);
+      expect(point2.primitiveShape(undefined, true)).toBe(geo.pointFeature.primitiveShapes.triangle);
+      point2.style('radius', 20);
+      point2.draw();
+      expect(point2.primitiveShape()).toBe(geo.pointFeature.primitiveShapes.auto);
+      expect(point2.primitiveShape(undefined, true)).toBe(geo.pointFeature.primitiveShapes.sprite);
+      expect(point2.primitiveShape(geo.pointFeature.primitiveShapes.triangle)).toBe(point2);
+      point2.draw();
+      expect(point2.primitiveShape()).toBe(geo.pointFeature.primitiveShapes.triangle);
+      expect(point2.primitiveShape(undefined, true)).toBe(geo.pointFeature.primitiveShapes.triangle);
     });
     it('updateStyleFromArray single', function () {
       point.draw = function () {


### PR DESCRIPTION
The new default primitiveShape, `auto`, uses a sprite (a webgl point) if points are smaller than the GPU's maximum point size and a triangle if any are larger.  Specific primitive shapes can still be specified, as there are performance reasons for each of them and auto detection has some time cost.