### PR TITLE
Add a little more information to travis artifacts.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,7 +65,7 @@ script:
 
 after_failure:
   # Upload test results.  First make them smaller with optipng.
-  - pip install --user --upgrade girder-client requests[security] pyOpenSSL
+  - pip install --user --upgrade girder-client requests[security] pyOpenSSL six
   - find _build/images -name '*-test.png' -exec optipng {} \+ || true
   - find _build/images -name '*-test.png' -exec python scripts/upload_travis_results.py {} \+ || true
   # Upload build artifacts
@@ -74,7 +74,7 @@ after_failure:
 after_success:
   - npm run codecov
   # Upload build artifacts
-  - pip install --user --upgrade girder-client requests[security] pyOpenSSL
+  - pip install --user --upgrade girder-client requests[security] pyOpenSSL six
   - find dist/built -type f -exec python scripts/upload_travis_results.py {} \+
 
 deploy:


### PR DESCRIPTION
When the travis job finishes, we upload artifacts to data.kitware.com.  This adds the branch name and commit comment to the folder where the artifacts are stored.