### PR TITLE
Disable Deepzoom Example

### DIFF
--- a/examples/deepzoom/example.json
+++ b/examples/deepzoom/example.json
@@ -4,11 +4,12 @@
   "about": {
     "text": "Rendering a tiled image using the Deep Zoom protocol."
   },
-  "tests": [{
+  "disable-tests": [{
     "description": "data is loaded from the Deep Zoom server",
     "idle": ["$('#map.geojs-map').data('data-geojs-map').onIdle"],
     "tests": [
       "Object.keys($('#map.geojs-map').data('data-geojs-map').layers()[0]._activeTiles).length === 11"
     ]
-  }]
+  }],
+  "disabled": true
 }


### PR DESCRIPTION
NASA's deepzoom server no longer allows cross-site usage.

Disable the example for now; otherwise, CI is broken.

Reference #1036.