### PR TITLE
Remove some needless calls.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## Unreleased
+
+### Bug Fixes
+- Removed extra calls to sceneObject constructors (#1039)
+
 ## Version 0.19.7
 
 ### Features

--- a/src/canvas/object.js
+++ b/src/canvas/object.js
@@ -1,6 +1,3 @@
-var inherit = require('../inherit');
-var sceneObject = require('../sceneObject');
-
 /**
  * Canvas specific subclass of object which rerenders when the object is drawn.
  * @class
@@ -19,7 +16,6 @@ var canvas_object = function (arg) {
   if (!(this instanceof object)) {
     return new canvas_object(arg);
   }
-  sceneObject.call(this);
 
   var m_this = this,
       s_draw = this.draw,
@@ -81,5 +77,4 @@ var canvas_object = function (arg) {
   return this;
 };
 
-inherit(canvas_object, sceneObject);
 module.exports = canvas_object;

--- a/src/svg/object.js
+++ b/src/svg/object.js
@@ -1,6 +1,3 @@
-var inherit = require('../inherit');
-var sceneObject = require('../sceneObject');
-
 /**
  * SVG specific subclass of object which adds an id property for d3 selections
  * on groups of objects by class id.
@@ -22,7 +19,6 @@ var svg_object = function (arg) {
   if (!(this instanceof object)) {
     return new svg_object(arg);
   }
-  sceneObject.call(this);
 
   var m_id = 'svg-' + uniqueID(),
       s_exit = this._exit,
@@ -66,5 +62,4 @@ var svg_object = function (arg) {
   return this;
 };
 
-inherit(svg_object, sceneObject);
 module.exports = svg_object;


### PR DESCRIPTION
In the svg and canvas object classes, the sceneObject object was needlessly being called.  Since all features are children of scene objects, this isn't necessary to call again.