### PR TITLE
If a line is invisible, don't find it in a search.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Changes
+- Line segments with zero width or zero opacity won't be found by pointSearch or polygonSearch (#1041)
+
 ### Bug Fixes
 - Removed extra calls to sceneObject constructors (#1039)
 - Fixed an issue with rendering on hidden tabs in Chrome (#1042)

--- a/src/annotation.js
+++ b/src/annotation.js
@@ -167,10 +167,10 @@ var annotation = function (type, args) {
   /**
    * Get or set the label of this annotation.
    *
-   * @param {string|null|undefined} arg If `undefined`, return the label,
+   * @param {string|null|undefined} [arg] If `undefined`, return the label,
    *    otherwise change it.  `null` to clear the label.
-   * @param {boolean} noFallback If not truthy and the label is `null`, return
-   *    the name, otherwise return the actual value for label.
+   * @param {boolean} [noFallback] If not truthy and the label is `null`,
+   *    return the name, otherwise return the actual value for label.
    * @returns {this|string} The current label or this annotation.
    */
   this.label = function (arg, noFallback) {

--- a/src/webgl/lineFeature.js
+++ b/src/webgl/lineFeature.js
@@ -343,7 +343,11 @@ var webgl_lineFeature = function (arg) {
             strokeColorBuf[dest3] = v1.strokeColor.r;
             strokeColorBuf[dest3 + 1] = v1.strokeColor.g;
             strokeColorBuf[dest3 + 2] = v1.strokeColor.b;
-            strokeOpacityBuf[dest] = v1.strokeOpacity;
+            if ((v1.strokeOpacity <= 0 && v2.strokeOpacity <= 0) || (v1.strokeWidth <= 0 && v2.strokeWidth <= 0)) {
+              strokeOpacityBuf[dest] = -1;
+            } else {
+              strokeOpacityBuf[dest] = v1.strokeOpacity;
+            }
           }
         }
       }


### PR DESCRIPTION
A line segment with either zero opacity or zero width will no longer be returned by a pointSearch or a polygonSearch.  If only one end of the segment has zero opacity or zero width, the segment can still be
returned by the search functions.