### PR TITLE
Minimize the code bundles for examples and tutorials.

### DIFF
--- a/webpack.base.config.js
+++ b/webpack.base.config.js
@@ -48,7 +48,7 @@ module.exports = {
   plugins: [
     /* webpack 3 */
     new UglifyJsPlugin({
-      include: /\.min\.js$/,
+      include: /(bundle|\.min)\.js$/,
       parallel: true,
       uglifyOptions: {
         compress: true,


### PR DESCRIPTION
This speeds up loading examples and tutorials.