### PR TITLE
Speed up the pointInPolygon function.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
 - Added a track feature (#1040)
 - Added a geo.gui.scaleWidget.formatUnit utility function (#1048)
 
+### Improvements
+- The pointInPolygon2D function is faster (#1052)
+
 ## Version 0.19.8
 
 ### Changes

--- a/src/util/common.js
+++ b/src/util/common.js
@@ -74,7 +74,7 @@ var util = {
         return false;
       }
     }
-    return util.distanceToPolygon2d(point, inner ? {outer: outer, inner: inner} : outer) > 0;
+    return util.distanceToPolygon2d(point, inner ? {outer: outer, inner: inner} : outer, true) > 0;
   },
 
   /**
@@ -680,10 +680,12 @@ var util = {
    *
    * @param {geo.geoPosition} pt The point.
    * @param {geo.polygonObject} poly The polygon.
+   * @param {boolean} [onlySign] If truthy, only the sign of the answer is
+   *    significant.
    * @returns {number} The signed distance.
    * @memberof geo.util
    */
-  distanceToPolygon2d: function (pt, poly) {
+  distanceToPolygon2d: function (pt, poly, onlySign) {
     let outer = poly.outer || poly;
     let inside = false,
         minDistSq, distSq, dist;
@@ -693,14 +695,14 @@ var util = {
       if (((p0.y > pt.y) !== (p1.y > pt.y)) && (pt.x < (p1.x - p0.x) * (pt.y - p0.y) / (p1.y - p0.y) + p0.x)) {
         inside = !inside;
       }
-      distSq = util.distance2dToLineSquared(pt, p0, p1);
+      distSq = onlySign ? 1 : util.distance2dToLineSquared(pt, p0, p1);
       if (minDistSq === undefined || distSq < minDistSq) {
         minDistSq = distSq;
       }
     }
     if (poly.inner) {
       poly.inner.forEach(inner => {
-        let innerDist = util.distanceToPolygon2d(pt, inner);
+        let innerDist = util.distanceToPolygon2d(pt, inner, onlySign);
         if (innerDist * innerDist < minDistSq) {
           minDistSq = innerDist * innerDist;
         }


### PR DESCRIPTION
This relies on the distanceToPolygon2D function, but we don't actually care about the distance, so skip some calculations.