### PR TITLE
Fix the name of some example controls.

### DIFF
--- a/examples/annotations/index.pug
+++ b/examples/annotations/index.pug
@@ -61,10 +61,10 @@ block append mainContent
                 input#edit-radius(option='radius', format='positive')
               .form-group(annotation-types='point', title='Set to "false" to disable, "true" to use the specified radius at the current zoom, or a zoom level to use the specified radius at that zoom level.')
                 label(for='edit-scaled') Scale with Zoom
-                input#edit-radius(option='scaled', format='booleanOrNumber')
+                input#edit-scaled(option='scaled', format='booleanOrNumber')
               .form-group(annotation-types='point polygon rectangle')
                 label(for='edit-fill') Fill
-                select#edit-stroke(option='fill', format='boolean')
+                select#edit-fill(option='fill', format='boolean')
                   option(value='true') Yes
                   option(value='false') No
               .form-group(annotation-types='point polygon rectangle')
@@ -141,7 +141,7 @@ block append mainContent
                   option(value='right') Right
               .form-group(annotation-types='all', title='Vertical alignment')
                 label(for='edit-textBaseline') Vertical Align.
-                select#edit-textAlign(option='textBaseline', format='text', optiontype='label')
+                select#edit-textBaseline(option='textBaseline', format='text', optiontype='label')
                   option(value='middle') Middle
                   option(value='top') Top
                   option(value='hanging') Hanging

--- a/examples/measure/index.pug
+++ b/examples/measure/index.pug
@@ -88,10 +88,10 @@ block append mainContent
                 input#edit-radius(option='radius', format='positive')
               .form-group(annotation-types='point', title='Set to "false" to disable, "true" to use the specified radius at the current zoom, or a zoom level to use the specified radius at that zoom level.')
                 label(for='edit-scaled') Scale with Zoom
-                input#edit-radius(option='scaled', format='booleanOrNumber')
+                input#edit-scaled(option='scaled', format='booleanOrNumber')
               .form-group(annotation-types='point polygon rectangle')
                 label(for='edit-fill') Fill
-                select#edit-stroke(option='fill', format='boolean')
+                select#edit-fill(option='fill', format='boolean')
                   option(value='true') Yes
                   option(value='false') No
               .form-group(annotation-types='point polygon rectangle')
@@ -168,7 +168,7 @@ block append mainContent
                   option(value='right') Right
               .form-group(annotation-types='all', title='Vertical alignment')
                 label(for='edit-textBaseline') Vertical Align.
-                select#edit-textAlign(option='textBaseline', format='text', optiontype='label')
+                select#edit-textBaseline(option='textBaseline', format='text', optiontype='label')
                   option(value='middle') Middle
                   option(value='top') Top
                   option(value='hanging') Hanging


### PR DESCRIPTION
In the annotations and the measure examples, some controls were misnamed preventing changing some parameters (for instance, base scale).