### PR TITLE
Improve jsdocs typedefs.

### DIFF
--- a/src/choroplethFeature.js
+++ b/src/choroplethFeature.js
@@ -5,6 +5,7 @@ var feature = require('./feature');
  * Choropleth feature specification.
  *
  * @typedef {geo.feature.spec} geo.choroplethFeature.spec
+ * @extends geo.feature.spec
  * @property {geo.colorObject[]} [colorRange] Color lookup table.  Default is
  *   9-step color table.
  * @property {function} [scale] A scale converts a input domain into the

--- a/src/feature.js
+++ b/src/feature.js
@@ -49,6 +49,7 @@ var geo_event = require('./event');
 
 /**
  * @typedef {geo.feature.spec} geo.feature.createSpec
+ * @extends geo.feature.spec
  * @property {string} type A supported feature type.
  * @property {object[]} [data=[]] An array of arbitrary objects used to
  *   construct the feature.  These objects (and their associated indices in the

--- a/src/graphFeature.js
+++ b/src/graphFeature.js
@@ -5,6 +5,7 @@ var feature = require('./feature');
  * Object specification for a graph feature.
  *
  * @typedef {geo.feature.spec} geo.graphFeature.spec
+ * @extends geo.feature.spec
  * @property {geo.graphFeature.styleSpec} [style] Style object with default
  *   style options.
  */

--- a/src/heatmapFeature.js
+++ b/src/heatmapFeature.js
@@ -7,6 +7,7 @@ var transform = require('./transform');
  * Heatmap feature specification.
  *
  * @typedef {geo.feature.spec} geo.heatmapFeature.spec
+ * @extends geo.feature.spec
  * @property {geo.geoPosition|function} [position] Position of the data.
  *   Default is (data).
  * @property {function} [intensity] Scalar value of each data point.  The

--- a/src/isolineFeature.js
+++ b/src/isolineFeature.js
@@ -7,6 +7,7 @@ var util = require('./util');
  * Isoline feature specification.
  *
  * @typedef {geo.feature.spec} geo.isolineFeature.spec
+ * @extend geo.feature.spec
  * @property {object[]} [data=[]] An array of arbitrary objects used to
  *    construct the feature.
  * @property {geo.isolineFeature.styleSpec} [style] An object that contains
@@ -54,6 +55,7 @@ var util = require('./util');
  * passed the {@link geo.meshFeature.meshInfo} object.
  *
  * @typedef {geo.meshFeature.meshSpec} geo.isolineFeature.isolineSpec
+ * @extends geo.meshFeature.meshSpec
  * @property {number} [min] Minimum isoline value.  If unspecified, taken from
  *    the computed minimum of the `value` style.
  * @property {number} [max] Maximum isoline value.  If unspecified, taken from

--- a/src/lineFeature.js
+++ b/src/lineFeature.js
@@ -8,6 +8,7 @@ var util = require('./util');
  * Line feature specification.
  *
  * @typedef {geo.feature.spec} geo.lineFeature.spec
+ * @extends geo.feature.spec
  * @property {geo.geoPosition|function} [position] Position of the data.
  *   Default is (data).
  * @property {object|function} [line] Lines from the data.  Default is (data).

--- a/src/map.js
+++ b/src/map.js
@@ -65,6 +65,7 @@ var sceneObject = require('./sceneObject');
  * Specification used with `map.create`.
  *
  * @typedef {geo.map.spec} geo.map.createSpec
+ * @extends geo.map.spec
  * @property {object[]} [data=[]] The default data array to apply to each
  *      feature if none exists.
  * @property {geo.layer.spec[]} [layers=[]] Layers to create.

--- a/src/markerFeature.js
+++ b/src/markerFeature.js
@@ -6,6 +6,7 @@ var pointFeature = require('./pointFeature');
  * Object specification for a marker feature.
  *
  * @typedef {geo.feature.spec} geo.markerFeature.spec
+ * @extends geo.feature.spec
  * @property {geo.geoPosition|function} [position] Position of the data.
  *   Default is (data).
  * @property {geo.markerFeature.styleSpec} [style] Style object with default

--- a/src/pixelmapFeature.js
+++ b/src/pixelmapFeature.js
@@ -8,6 +8,7 @@ var util = require('./util');
  * Pixelmap feature specification.
  *
  * @typedef {geo.feature.spec} geo.pixelmapFeature.spec
+ * @extends geo.feature.spec
  * @property {string|function|HTMLImageElement} [url] URL of a pixel map or an
  *   HTML Image element.  The rgb data is interpretted as an index of the form
  *   0xbbggrr.  The alpha channel is ignored.

--- a/src/pointFeature.js
+++ b/src/pointFeature.js
@@ -5,6 +5,7 @@ var feature = require('./feature');
  * Object specification for a point feature.
  *
  * @typedef {geo.feature.spec} geo.pointFeature.spec
+ * @extends geo.feature.spec
  * @property {geo.geoPosition|function} [position] Position of the data.
  *   Default is (data).
  * @property {geo.pointFeature.styleSpec} [style] Style object with default

--- a/src/polygonFeature.js
+++ b/src/polygonFeature.js
@@ -7,6 +7,7 @@ var transform = require('./transform');
  * Polygon feature specification.
  *
  * @typedef {geo.feature.spec} geo.polygonFeature.spec
+ * @extends geo.feature.spec
  * @property {geo.geoPosition|function} [position] Position of the data.
  *   Default is (data).
  * @property {geo.polygon|function} [polygon] Polygons from the data.  Default

--- a/src/quadFeature.js
+++ b/src/quadFeature.js
@@ -6,6 +6,7 @@ var feature = require('./feature');
  * Quad feature specification.
  *
  * @typedef {geo.feature.spec} geo.quadFeature.spec
+ * @extends geo.feature.spec
  * @property {object|function} [position] Position of the quad.  Default is
  *   (data).  The position is an object which specifies the corners of the
  *   quad: ll, lr, ur, ul.  At least two opposite corners must be specified.

--- a/src/textFeature.js
+++ b/src/textFeature.js
@@ -5,6 +5,7 @@ var feature = require('./feature');
  * Object specification for a text feature.
  *
  * @typedef {geo.feature.spec} geo.textFeature.spec
+ * @extends geo.feature.spec
  * @property {geo.geoPosition[]|function} [position] The position of each data
  *   element.  Defaults to the `x`, `y`, and `z` properties of the data
  *   element.

--- a/src/trackFeature.js
+++ b/src/trackFeature.js
@@ -7,6 +7,7 @@ var util = require('./util');
  * Track feature specification.
  *
  * @typedef {geo.feature.spec} geo.trackFeature.spec
+ * @extends geo.feature.spec
  * @property {geo.geoPosition|function} [position] Position of the data.
  *   Default is (data).
  * @property {float|function} [time] Time of the data.  Default is `(data).t`.

--- a/src/vectorFeature.js
+++ b/src/vectorFeature.js
@@ -5,6 +5,7 @@ var feature = require('./feature');
  * Object specification for a graph feature.
  *
  * @typedef {geo.feature.spec} geo.vectorFeature.spec
+ * @extends geo.feature.spec
  * @property {geo.vectorFeature.styleSpec} [style] Style object with default
  *   style options.
  * @property {function|object} [origin={x: 0, y: 0, z: 0}] Origin accessor.


### PR DESCRIPTION
Some typedefs that extend other types are displayed better if `@extends` is added.