### PR TITLE
Pin colorbrewer to 1.3.0.

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "bootswatch": "^3.4.1",
     "bowser": "^1.9.4",
     "codemirror": "^5.54.0",
-    "colorbrewer": "^1.3.0",
+    "colorbrewer": "1.3.0",
     "css-loader": "^0.28.11",
     "docco": "^0.7.0",
     "eslint": "^5.16.0",


### PR DESCRIPTION
Version 1.5.1 has changed how it is bundled, which no longer works with out current examples.  Until that is refactored, pin to the last known working version.