### PR TITLE
Set overflow: hidden on the main div

### DIFF
--- a/src/main.styl
+++ b/src/main.styl
@@ -3,6 +3,7 @@
 .geojs-map
   position relative
   user-select none
+  overflow hidden
 
   .geo-attribution
     position absolute


### PR DESCRIPTION
This is a better default, as it prevents some features (like heatmaps) from showing outside of the div.