### PR TITLE
fix: Publish artifacts with semantic-release releases

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -79,31 +79,7 @@ jobs:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: website/public
         force_orphan: true
-  deploy-releases:
-    if: ${{ startswith(github.ref, 'refs/tags/') }}
-    needs: build
-    runs-on: ubuntu-latest
-    steps:
-    - name: Import artifacts
-      uses: actions/download-artifact@v2
-      with:
-        name: dist
-        path: dist
-    - name: Create Release
-      uses: softprops/action-gh-release@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        # name: "Version ${{ github.ref }}"
-        draft: false
-        prerelease: false
-        files: |
-          dist/built/geo.js
-          dist/built/geo.min.js
-          dist/built/geo.lean.js
-          dist/built/geo.lean.min.js
   deploy-npm:
-    # if: ${{ startswith(github.ref, 'refs/tags/') }}
     needs: build
     runs-on: ubuntu-latest
     steps:

--- a/package.json
+++ b/package.json
@@ -105,6 +105,21 @@
     "webpack-merge": "^4.2.2",
     "webpack-serve": "^1.0.2"
   },
+  "release": {
+    "plugins": [
+      "@semantic-release/commit-analyzer",
+      "@semantic-release/release-notes-generator",
+      "@semantic-release/npm",
+      ["@semantic-release/github", {
+        "assets": [
+          {"path": "dist/built/geo.js", "label": "Full JS distribution"},
+          {"path": "dist/built/geo.min.js", "label": "Minified JS distribution"},
+          {"path": "dist/built/geo.lean.js", "label": "Lean JS distribution"},
+          {"path": "dist/built/geo.lean.min.js", "label": "Lean minified JS distribution"}
+        ]
+      }]
+    ]
+  },
   "scripts": {
     "build": "webpack --config webpack.config.js && webpack --config webpack-lean.config.js",
     "build-examples": "node examples/build.js && webpack --config webpack-examples.config.js",


### PR DESCRIPTION
With semantic release, there is a different technique to publish the build artifacts to the github releases.  This switches to it.