### PR TITLE
feat: Add a geoOnce function.

### DIFF
--- a/src/object.js
+++ b/src/object.js
@@ -122,6 +122,28 @@ var object = function () {
   };
 
   /**
+   * Bind an event handler to this object that will fire once and then
+   * deregister itself.
+   *
+   * @param {string} event An event from {@link geo.event} or a user-defined
+   *   value.
+   * @param {function} handler A function that is called when `event` is
+   *   triggered.  The function is passed a {@link geo.event} object.
+   * @returns {function} The actual bound handler.  This is a wrapper around
+   *   the handler that was passed to the function.
+   */
+  this.geoOnce = function (event, handler) {
+    let wrapper;
+
+    wrapper = function (args) {
+      m_this.geoOff(event, wrapper);
+      handler.call(m_this, args);
+    };
+    m_this.geoOn(event, wrapper);
+    return wrapper;
+  };
+
+  /**
    * Report if an event handler is bound to this object.
    *
    * @param {string|string[]} event An event or list of events to check.

--- a/tests/cases/object.js
+++ b/tests/cases/object.js
@@ -43,6 +43,35 @@ describe('geo.object', function () {
       expect(foo.ncalls).toBe(2);
     });
 
+    it('Make a single object with a once event handler', function () {
+      var obj = new geo.object(),
+          evtData = {},
+          foo = new CallCounter(evtData);
+
+      expect(obj.geoIsOn('testevent')).toBe(false);
+      let handler = obj.geoOnce('testevent', foo.call);
+      expect(obj.geoIsOn('testevent')).toBe(true);
+      expect(obj.geoIsOn('testevent', foo.call)).toBe(false);
+      expect(obj.geoIsOn('testevent', handler)).toBe(true);
+      obj.geoTrigger('anotherevent', evtData);
+      expect(foo.ncalls).toBe(0);
+      expect(obj.geoIsOn('testevent', handler)).toBe(true);
+
+      obj.geoTrigger('testevent', evtData);
+      expect(foo.ncalls).toBe(1);
+      expect(obj.geoIsOn('testevent', handler)).toBe(false);
+
+      obj.geoTrigger('testevent', evtData);
+      expect(foo.ncalls).toBe(1);
+
+      obj.geoTrigger('test', evtData);
+      expect(foo.ncalls).toBe(1);
+
+      expect(obj.geoIsOn('testevent')).toBe(false);
+      obj.geoTrigger('testevent', evtData);
+      expect(foo.ncalls).toBe(1);
+    });
+
     it('Make a single object with several handlers on one event', function () {
       var obj = new geo.object(),
           evtData = {},


### PR DESCRIPTION
This handles an event a single time and then deregisters the callback.  Often, a program calls `geoOn` and in the handler calls `geoOff`.  This allows just calling `geoOnce`.  In order to cancel a `geoOnce`, the return value is the function that would have to be passed to `geoOff`.