### PR TITLE
feat: Improve when tile layers are idle.

### DIFF
--- a/src/sceneObject.js
+++ b/src/sceneObject.js
@@ -23,7 +23,8 @@ var sceneObject = function (arg) {
       m_children = [],
       s_exit = this._exit,
       s_trigger = this.geoTrigger,
-      s_addPromise = this.addPromise;
+      s_addPromise = this.addPromise,
+      s_removePromise = this.removePromise;
 
   /**
    * Add the promise here and also propagate up the scene tree.
@@ -36,6 +37,20 @@ var sceneObject = function (arg) {
       m_parent.addPromise(promise);
     }
     s_addPromise(promise);
+    return m_this;
+  };
+
+  /**
+   * Remove the promise here and also propagate up the scene tree.
+   *
+   * @param {Promise} promise A promise object.
+   * @returns {this}
+   */
+  this.removePromise = function (promise) {
+    if (m_parent) {
+      m_parent.removePromise(promise);
+    }
+    s_removePromise(promise);
     return m_this;
   };
 

--- a/tests/cases/sceneObject.js
+++ b/tests/cases/sceneObject.js
@@ -311,5 +311,32 @@ describe('geo.sceneObject', function () {
       }, 50);
 
     });
+    it('removePromise', function () {
+      var defer = $.Deferred(),
+          handlerRoot = new CallCounter(null),
+          handler1 = new CallCounter(null),
+          handler2 = new CallCounter(null),
+          handler3 = new CallCounter(null);
+
+      function checkCallCount(countr, count1, count2, count3) {
+        expect(handlerRoot.ncalls).toBe(countr);
+        expect(handler1.ncalls).toBe(count1);
+        expect(handler2.ncalls).toBe(count2);
+        expect(handler3.ncalls).toBe(count3);
+      }
+
+      child3.addPromise(defer);
+      root.onIdle(handlerRoot.call);
+      child1.onIdle(handler1.call);
+      child2.onIdle(handler2.call);
+      child3.onIdle(handler3.call);
+
+      checkCallCount(0, 1, 0, 0);
+
+      child3.removePromise(defer);
+      checkCallCount(1, 1, 1, 1);
+
+      defer.resolve();
+    });
   });
 });

--- a/tests/cases/tileLayer.js
+++ b/tests/cases/tileLayer.js
@@ -342,6 +342,7 @@ describe('geo.tileLayer', function () {
       tileHeight: 1024,
       cacheSize: 100,
       keepLower: true,
+      idleAfter: 'view',
       wrapX: false,
       wrapY: true,
       url: function () {},


### PR DESCRIPTION
Add a setting to allow tile layers to be considered idle either when all tiles are finished loading or as soon as all tiles in the view are loaded.  Before this was always equivalent to all tiles.  The new default is just tiles in the view, as this is more relevant to typical use.

feat: Allow removing promises from the idle monitor.

This will facilitate tile layers reporting that they are idle when all tiles in the view are loaded even if tiles out of the view are still loading.