### PR TITLE
feat: Crop tiles.

### DIFF
--- a/examples/quads/main.js
+++ b/examples/quads/main.js
@@ -1,4 +1,4 @@
-/* globals $, geo, utils */
+/* globals utils */
 
 var quadDebug = {};
 
@@ -85,6 +85,11 @@ $(function () {
     ur: {x: -138, y: 39},
     opacity: 0.25,
     color: '#0000FF'
+  }, {
+    ll: {x: -88, y: 49},
+    ur: {x: -58, y: 63},
+    image: 'flower1.jpg',
+    crop: {left: 10, right: 240, top: 20, bottom: 260}
   }];
   if (query.canvas === 'true') {
     // You can render a canvas on a quad, but only on the canvas and webgl

--- a/src/canvas/quadFeature.js
+++ b/src/canvas/quadFeature.js
@@ -174,10 +174,17 @@ var canvas_quadFeature = function (arg) {
         if (!quad.crop) {
           context2d.drawImage(src, 0, 0);
         } else {
-          var cropx = Math.min(w, quad.crop.x),
-              cropy = Math.min(h, quad.crop.y);
-          if (cropx > 0 && cropy > 0) {
-            context2d.drawImage(src, 0, 0, cropx, cropy, 0, 0, cropx, cropy);
+          const cropw = Math.min(w, quad.crop.x || w),
+              croph = Math.min(h, quad.crop.y || h),
+              cropx0 = Math.max(0, quad.crop.left || 0),
+              cropy0 = Math.max(0, quad.crop.top || 0),
+              cropx1 = Math.min(w, quad.crop.right || w),
+              cropy1 = Math.min(h, quad.crop.bottom || h);
+          if (w && h && cropw > 0 && croph > 0 && cropx1 > cropx0 && cropy1 > cropy0) {
+            context2d.drawImage(
+              src,
+              cropx0, cropy0, Math.floor((cropx1 - cropx0) * cropw / w), Math.floor((cropy1 - cropy0) * croph / h),
+              0, 0, cropw, croph);
           }
         }
       });

--- a/src/quadFeature.js
+++ b/src/quadFeature.js
@@ -10,6 +10,17 @@ var feature = require('./feature');
  * @property {geo.geoPosition} [ur] Upper right coordinate.
  * @property {geo.geoPosition} [ll] Lower left coordinate.
  * @property {geo.geoPosition} [lr] Lower right coordinate.
+ * @property {object} [crop] Image tile crop size in image pixels.  Areas
+ *   beyond the width ``x`` and height ``y`` are transparent. ``left``,
+ *   ``top``, ``right``, ``bottom`` extract a specific part of the image tile
+ *   as the source and expand it to fill the conceptual space before any crop
+ *   width and height are applied.
+ * @property {number} [crop.x] Width of image after crop.
+ * @property {number} [crop.y] Height of image after crop.
+ * @property {number} [crop.left] Left coordinate of image source.
+ * @property {number} [crop.top] Top coordinate of image source.
+ * @property {number} [crop.right] Right coordinate of image source.
+ * @property {number} [crop.bottom] Bottom coordinate of image source.
  */
 
 /**

--- a/src/webgl/quadFeatureImage.frag
+++ b/src/webgl/quadFeatureImage.frag
@@ -13,4 +13,3 @@ void main(void) {
   color.w *= opacity;
   gl_FragColor = color;
 }
-

--- a/src/webgl/quadFeatureImage.vert
+++ b/src/webgl/quadFeatureImage.vert
@@ -6,10 +6,15 @@ uniform float zOffset;
 uniform mat4 modelViewMatrix;
 uniform mat4 projectionMatrix;
 varying highp vec2 iTextureCoord;
+uniform highp vec4 cropsource;
 
 void main(void) {
   gl_Position = projectionMatrix * modelViewMatrix * vec4(vertexPosition, 1.0);
   gl_Position.z += zOffset;
-  iTextureCoord = textureCoord;
+  if (cropsource.p > cropsource.s && cropsource.q > cropsource.t && (cropsource.p < 1.0 || cropsource.s > 0.0 || cropsource.q < 1.0 || cropsource.t > 0.0)) {
+    iTextureCoord.s = textureCoord.s * (cropsource.p - cropsource.s) + cropsource.s;
+    iTextureCoord.t = textureCoord.t * (cropsource.q - cropsource.t) + cropsource.t;
+  } else {
+    iTextureCoord = textureCoord;
+  }
 }
-


### PR DESCRIPTION
Allow tiles to be cropped from their source in the canvas and webgl renderers.

This can be used to subset a larger image efficiently on multiple tiles (sprites).