### PR TITLE
adds basemaps from Carto

### DIFF
--- a/src/osmLayer.js
+++ b/src/osmLayer.js
@@ -131,6 +131,9 @@ let StamenAttribution = 'Map tiles by <a href="http://stamen.com">Stamen ' +
   'CC BY 3.0</a>. Data by <a href="http://openstreetmap.org">OpenStreetMap' +
   '</a>, under <a href="http://www.openstreetmap.org/copyright">ODbL</a>.';
 
+/* Per Carto's website regarding basemap attribution: https://carto.com/help/working-with-data/attribution/#basemaps */
+let CartoAttribution = '<a href="https://carto.com"> Carto</a> ' + 'Contributors <a href="https://www.openstreetmap.org/"> OpenStreetMap</a>'
+
 /**
  * This is a list of known tile sources.  It can be added to via
  * `geo.osmLayer.tilesource[<key>] = <object>`, where the object has `url`,
@@ -139,6 +142,18 @@ let StamenAttribution = 'Map tiles by <a href="http://stamen.com">Stamen ' +
  * @type {object}
  */
 osmLayer.tileSources = {
+  'darkMatter-with-labels': {
+    url: ' https://{s}.basemaps.cartocdn.com/rastertiles/dark_all/{z}/{x}/{y}.png',
+    attribution: CartoAttribution,
+    minLevel: 0,
+    maxLevel: 18
+  },
+  'darkMatter-without-labels': {
+    url: 'https://{s}.basemaps.cartocdn.com/rastertiles/dark_nolabels/{z}/{x}/{y}.png',
+    attribution: CartoAttribution,
+    minLevel: 0,
+    maxLevel: 18
+  },
   'nationalmap-satellite': {
     url: 'https://basemap.nationalmap.gov/arcgis/rest/services/USGSImageryOnly/MapServer/tile/{z}/{y}/{x}',
     attribution: 'Tile data from <a href="https://basemap.nationalmap.gov/">USGS</a>',
@@ -152,6 +167,18 @@ osmLayer.tileSources = {
     subdomains: 'abc',
     minLevel: 0,
     maxLevel: 19
+  },
+  'positron-with-labels': {
+    url: 'https://{s}.basemaps.cartocdn.com/rastertiles/light_all/{z}/{x}/{y}.png',
+    attribution: CartoAttribution,
+    minLevel: 0,
+    maxLevel: 18
+  },
+  'positron-without-labels': {
+    url: 'https://{s}.basemaps.cartocdn.com/rastertiles/light_nolabels/{z}/{x}/{y}.png',
+    attribution: CartoAttribution,
+    minLevel: 0,
+    maxLevel: 18
   },
   'stamen-terrain': {
     url: 'https://stamen-tiles-{s}.a.ssl.fastly.net/terrain/{z}/{x}/{y}.png',
@@ -180,6 +207,18 @@ osmLayer.tileSources = {
     subdomains: 'abcd',
     minLevel: 0,
     maxLevel: 20
+  },
+  'voyager-with-labels': {
+    url: 'https://{s}.basemaps.cartocdn.com/rastertiles/voyager_labels_under/{z}/{x}/{y}.png',
+    attribution: CartoAttribution,
+    minLevel: 0,
+    maxLevel: 18
+  },
+  'voyager-without-layers': {
+    url: 'https://{s}.basemaps.cartocdn.com/rastertiles/voyager_nolabels/{z}/{x}/{y}.png',
+    attribution: CartoAttribution,
+    minLevel: 0,
+    maxLevel: 18
   },
   'wikimedia': {
     url: 'https://maps.wikimedia.org/osm-intl/{z}/{x}/{y}.png',


### PR DESCRIPTION
 Adds base maps from:
   
   https://carto.com/help/building-maps/basemap-list/#carto-vector-basemaps

Attribution modeled after documentation at:

https://carto.com/help/working-with-data/attribution/#basemaps