### PR TITLE
fix: Remove wikimedia map source.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # GeoJS Change Log
 
-## Version 1.4.1
+## Version 1.4.3
+
+### Changes
+
+- Removed wikimedia from the map source list (#1109)
+
+## Version 1.4.2
 
 ### Improvements
 

--- a/src/osmLayer.js
+++ b/src/osmLayer.js
@@ -231,13 +231,6 @@ osmLayer.tileSources = {
     name:'Carto Voyager Without Layers',
     minLevel: 0,
     maxLevel: 18
-  },
-  'wikimedia': {
-    url: 'https://maps.wikimedia.org/osm-intl/{z}/{x}/{y}.png',
-    attribution: '<a href="https://wikimediafoundation.org/wiki/Maps_Terms_of_Use">Wikimedia maps</a> | Map data &copy; <a href="http://openstreetmap.org/copyright">OpenStreetMap contributors</a>',
-    name:'Wikimedia',
-    minLevel: 0,
-    maxLevel: 19
   }
 };
 


### PR DESCRIPTION
As of April 5, 2021, Wikimedia map terns of service no longer allows third party use (see
https://foundation.wikimedia.org/w/index.php?title=Maps_Terms_of_Use&action=history)