### PR TITLE
feat: Add scaleWithZoom option to heatmaps.

### DIFF
--- a/examples/heatmap/index.pug
+++ b/examples/heatmap/index.pug
@@ -46,6 +46,9 @@ block append mainContent
     .form-group(title="Use either a Gaussian distribution or a solid circle with a blurred edge for each point.  If a Gaussian is used, the total radius is the sume of the radius and blur radius values.")
       label(for="gaussian") Gaussian Points
       input#gaussian(type="checkbox", placeholder="true", checked="checked")
+    .form-group(title="If true, scale the point size with zoom.  In this case, the radius is specified in pixels a zoom-level 0.")
+      label(for="scaleWithZoom") Scale With Zoom
+      input#scaleWithZoom(type="checkbox", placeholder="false")
     .form-group(title="Color Gradient.  Entries with intensities of 0 and 1 are needed to form a valid color gradient.")
       label Color Gradient
       table.gradient

--- a/examples/heatmap/main.js
+++ b/examples/heatmap/main.js
@@ -52,6 +52,7 @@ $(function () {
         ctlvalue = value ? value : 'adderall';
         break;
       case 'gaussian':
+      case 'scaleWithZoom':
         ctlvalue = value === 'true';
         heatmapOptions.style[key] = value;
         break;
@@ -100,7 +101,6 @@ $(function () {
           heatmapOptions[key] = ctlvalue = parseInt(value, 10);
         }
         break;
-      // add gaussian and binning when they are added as features
     }
     if (ctlvalue !== undefined) {
       $('#' + ctlkey).val(ctlvalue);
@@ -229,6 +229,7 @@ $(function () {
         fetch_data();
         break;
       case 'gaussian':
+      case 'scaleWithZoom':
         heatmapOptions.style[param] = processedValue;
         heatmap.style(param, processedValue);
         heatmap.draw();

--- a/src/heatmapFeature.js
+++ b/src/heatmapFeature.js
@@ -40,6 +40,11 @@ var transform = require('./transform');
  *   approximation.  The total weight of the gaussian area is approximately the
  *   `9/16 r^2`.  The sum of `radius + blurRadius` is used as the radius for
  *   the gaussian distribution.
+ * @property {boolean} [scaleWithZoom=false] If truthy, the value for radius
+ *   and blurRadius scale with zoom.  In this case, the values for radius and
+ *   blurRadius are the values at zoom-level zero.  If the scaled radius is
+ *   less than 0.5 or more than 8192 screen pixels, the heatmap will not
+ *   render.
  */
 
 /**
@@ -238,7 +243,8 @@ var heatmapFeature = function (arg) {
           0.25: {r: 0, g: 0, b: 1, a: 0.5},
           0.5:  {r: 0, g: 1, b: 1, a: 0.6},
           0.75: {r: 1, g: 1, b: 0, a: 0.7},
-          1:    {r: 1, g: 0, b: 0, a: 0.8}}
+          1:    {r: 1, g: 0, b: 0, a: 0.8}},
+        scaleWithZoom: false
       },
       arg.style === undefined ? {} : arg.style
     );

--- a/tests/cases/heatmap.js
+++ b/tests/cases/heatmap.js
@@ -164,6 +164,20 @@ describe('canvas heatmap', function () {
       stepAnimationFrame(Date.now());
       expect(feature1._binned).toBe(r / 8);
     });
+
+    it('scaleWithZoom', function () {
+      // animation frames are already mocked
+      var r = 0.80;
+      feature1.style({radius: r, blurRadius: 0, scaleWithZoom: true});
+      map.draw();
+      stepAnimationFrame(Date.now());
+      expect(feature1._binned).toBe(102);
+      feature1.style('scaleWithZoom', false);
+      map.draw();
+      stepAnimationFrame(Date.now());
+      expect(feature1._binned).toBe(1.5);
+    });
+
     it('Remove a feature from a layer', function () {
       layer.deleteFeature(feature1).draw();
       expect(layer.children().length).toBe(0);


### PR DESCRIPTION
If `scaleWithZoom` is truthy, the radius is the radius at zoom level zero, and the heatmap scales with zoom, which makes it looks fairly invariant.  Note that if the functional radius < 0.5 or > 8192, the heatmap won't render.