### PR TITLE
build: Update hexo library.

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -8,14 +8,14 @@
   "dependencies": {
     "hexo": "^5.4.0",
     "hexo-fs": "^3.1.0",
-    "hexo-renderer-ejs": "^1.0.0",
-    "hexo-renderer-marked": "^4.0.0",
+    "hexo-renderer-ejs": "^2.0.0",
+    "hexo-renderer-marked": "^4.1.0",
     "hexo-renderer-scss": "^1.2.0",
     "hexo-renderer-stylus": "^2.0.1",
     "hexo-server": "^2.0.0"
   },
   "devDependencies": {
     "ejs-lint": "^1.2.1",
-    "hexo-cli": "^4.2.0"
+    "hexo-cli": "^4.3.0"
   }
 }


### PR DESCRIPTION
Note: hexo 6.0.0 was just released but doesn't work directly.  This should be revisited in a few weeks and adjusted to work with hexo 6.

This is part of #1132.