### PR TITLE
build: Update jasmine version.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7011,9 +7011,9 @@
       }
     },
     "jasmine-core": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-3.10.1.tgz",
-      "integrity": "sha512-ooZWSDVAdh79Rrj4/nnfklL3NQVra0BcuhcuWoAwwi+znLDoUeH87AFfeX8s+YeYi6xlv5nveRyaA1v7CintfA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-4.0.0.tgz",
+      "integrity": "sha512-tq24OCqHElgU9KDpb/8O21r1IfotgjIzalfW9eCmRR40LZpvwXT68iariIyayMwi0m98RDt16aljdbwK0sBMmQ==",
       "dev": true
     },
     "java-properties": {

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "istanbul-combine": "^0.3.0",
     "istanbul-instrumenter-loader": "^3.0.1",
     "jaguarjs-jsdoc": "^1.0.2",
-    "jasmine-core": "3.10.1",
+    "jasmine-core": "^4.0.0",
     "js-yaml": "^4.1.0",
     "jsdoc": "^3.6.7",
     "jsdoc-autoprivate": "0.0.1",

--- a/tests/cases/map.js
+++ b/tests/cases/map.js
@@ -779,7 +779,7 @@ describe('geo.core.map', function () {
 
       m.draw();
       // make sure that drawing has occurred
-      window.requestAnimationFrame(done);
+      window.requestAnimationFrame(() => done());
     });
     // all screen shots are in separate it blocks to make them more consistent
     it('basic', function (done) {

--- a/tests/cases/osmLayer.js
+++ b/tests/cases/osmLayer.js
@@ -43,7 +43,7 @@ describe('geo.core.osmLayer', function () {
         map.transition({
           center: {x: -0.1275, y: 51.5072},
           duration: 500,
-          done: done
+          done: () => done()
         });
       });
       it('next animation', function (done) {
@@ -53,7 +53,7 @@ describe('geo.core.osmLayer', function () {
           ease: function (t) {
             return Math.pow(2.0, -10.0 * t) * Math.sin((t - 0.075) * (2.0 * Math.PI) / 0.3) + 1.0;
           },
-          done: done
+          done: () => done()
         });
       });
       it('next animation', function (done) {
@@ -77,7 +77,7 @@ describe('geo.core.osmLayer', function () {
             t -= 2.625 / r;
             return s * t * t + 0.984375;
           },
-          done: done
+          done: () => done()
         });
       });
       it('next animation', function (done) {
@@ -87,7 +87,7 @@ describe('geo.core.osmLayer', function () {
           ease: function (t) {
             return Math.pow(2.0, -10.0 * t) * Math.sin((t - 0.075) * (2.0 * Math.PI) / 0.3) + 1.0;
           },
-          done: done
+          done: () => done()
         });
       });
       it('next animation', function (done) {
@@ -95,7 +95,7 @@ describe('geo.core.osmLayer', function () {
           center: {x: 19.0514, y: 47.4925},
           rotation: Math.PI * 2,
           duration: 500,
-          done: done
+          done: () => done()
         });
       });
       it('check findings', function () {

--- a/tests/gl-cases/webglLinesSpeed.js
+++ b/tests/gl-cases/webglLinesSpeed.js
@@ -81,7 +81,7 @@ describe('webglLinesSpeed', function () {
       $('#map').append($('<div style="display: none" id="framerateResults">')
         .attr('results', fps));
 
-      myMap.onIdle(done);
+      myMap.onIdle(() => done());
     }
 
     function loadTest() {

--- a/tests/gl-cases/webglPointsSpeed.js
+++ b/tests/gl-cases/webglPointsSpeed.js
@@ -81,7 +81,7 @@ describe('webglPointsSpeed', function () {
       $('#map').append($('<div style="display: none" id="framerateResults">')
         .attr('results', fps));
 
-      myMap.onIdle(done);
+      myMap.onIdle(() => done());
     }
 
     function loadTest() {

--- a/tests/headed-cases/examples.js
+++ b/tests/headed-cases/examples.js
@@ -136,7 +136,7 @@ describe('examples', function () {
               });
               subtestDeferreds.push(subtestDefer);
             });
-            ex$.when.apply(ex$, subtestDeferreds).then(done);
+            ex$.when.apply(ex$, subtestDeferreds).then(() => done());
           }, function () {
             fail(desc + ' -> idle functions were rejected');
           });


### PR DESCRIPTION
Jasmine made a substantial version change.  The only real difference to our code is that it throws an error if you call the done function with an argument, so we can't pass the done function directly to certain other functions (like `requestAnimationFrame`) since those call it a value.  Nicely, since we can use arrow functions, this just means changing a callback argument of `done` to `() => done()`.

This could be considered as part of #1132, though Jasmine's update occurred after that issue was completed.