### PR TITLE
fix: Build for older browsers.

### DIFF
--- a/webpack.base.config.js
+++ b/webpack.base.config.js
@@ -40,6 +40,7 @@ module.exports = {
       mousetrap: 'mousetrap/mousetrap.js'
     }
   },
+  target: ['web', 'es5'],
   plugins: [
     define_plugin
   ],
@@ -56,7 +57,14 @@ module.exports = {
     rules: [{
       test: /\.js$/,
       include: path.resolve('src'),
-      use: ['babel-loader']
+      use: [{
+        loader: 'babel-loader',
+        options: {
+          presets: [['@babel/preset-env', {
+            targets: 'defaults, PhantomJS 2.1'
+          }]]
+        }
+      }]
     }, {
       test: /\.js$/,
       include: [


### PR DESCRIPTION
Otherwise, it is too hard to test in systems that still use PhantomJS.

Specifically, Girder 3 client tests don't work without this update.