### PR TITLE
docs: Revert hexo, version 6 doesn't quite work the same.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
       with:
         node-version: '14'
     - uses: browser-actions/setup-firefox@latest
-    - run: sudo apt-get install --yes --no-install-recommends cpio optipng
+    - run: sudo apt-get install --yes --no-install-recommends optipng
     - run: sudo apt-get remove --yes fonts-lato
     - run: fc-list
     - run: firefox --version

--- a/docs/provisioning.rst
+++ b/docs/provisioning.rst
@@ -19,7 +19,6 @@ Add nodejs to the sources so it can be installed ::
 Install required packages ::
 
     sudo apt-get install --yes \
-        cpio \
         firefox-esr \
         fonts-dejavu \
         git \

--- a/package.json
+++ b/package.json
@@ -156,7 +156,7 @@
     "website": "cd website && npx hexo server",
     "setup-website": "cd website && npm install",
     "build-website": "npm run ci-build && npm run ci-build-website",
-    "ci-build-website": "cp -a dist/built/. website/source/built && bash -c '(npm run build-website-examples & npm run build-website-tutorials & wait -n && wait -n)' && cd dist && find data \\( -name tiles -o -name base-images -o -name '*-hash-stamp' -o -name '*.tgz' \\) -prune -o \\( -print0 \\) | cpio -pmdL0 ../website/source && cp -ar apidocs/. ../website/source/apidocs && cd ../website && npm install && rm -f db.json && npx hexo generate",
+    "ci-build-website": "cp -a dist/built/. website/source/built && bash -c '(npm run build-website-examples & npm run build-website-tutorials & wait -n && wait -n)' && cd dist && cp -ar apidocs/. ../website/source/apidocs && cd ../website && npm install && rm -f db.json && npx hexo generate",
     "prepublishOnly": "webpack --config webpack.config.js && webpack --config webpack-lean.config.js && cp dist/built/*.js .",
     "semantic-release": "semantic-release"
   },

--- a/website/package.json
+++ b/website/package.json
@@ -6,7 +6,7 @@
     "version": "5.4.0"
   },
   "dependencies": {
-    "hexo": "^6.0.0",
+    "hexo": "^5.4.0",
     "hexo-fs": "^3.1.0",
     "hexo-renderer-ejs": "^2.0.0",
     "hexo-renderer-marked": "^4.1.0",


### PR DESCRIPTION
Remove necessity of cpio.

Add .nvmrc file to indicate node version that was used in testing.