### PR TITLE
docs: Improve docs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,15 +39,19 @@ Documentation
 =============
 You can find more information on GeoJS installation and usage in our [Documentation](https://geojs.readthedocs.org/en/latest/index.html).
 
+There are some additional resources:
+
+- [Quick-Start Guide](docs/quickstart.rst)
+- [Provisioning for Development](docs/provisioning.rst)
+- [Developer's Guide](docs/developers.rst)
+- [User's Guide](docs/users.rst)
+- [Examples](https://opengeoscience.github.io/geojs/examples)
+- [Tutorials](https://opengeoscience.github.io/geojs/tutorials)
+- [API Documentation](https://opengeoscience.github.io/geojs/apidocs)
 
 Support
 =======
-We would love to get your feedback and bug reports. Please send us an email at
-[geojs-developers](https://public.kitware.com/mailman/listinfo/geojs-developers)
-for questions related to feature requests, roadmap or in-depth
-technical discussions. Use [geojs-users](https://public.kitware.com/mailman/listinfo/geojs-users)
-if you have general questions or bug reports on GeoJS.
-
+We would love to get your feedback and bug reports.  Please use GitHub issues.
 
 Get Involved
 ============

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -65,7 +65,7 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-project = u'geojs'
+project = u'GeoJS'
 copyright = u'Kitware, Inc.'
 
 # The version info for the project you're documenting, acts as replacement for

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,6 +1,6 @@
-================================
-Welcome to GeoJS's documentation
-================================
+=====
+GeoJS
+=====
 
 GeoJS is a flexible library for all kinds of geospatial and 2-D visualizations
 from traditional point markers to 3D climatological simulations.  It is
@@ -13,9 +13,7 @@ WebGL features and even through active layers.
 
 See the growing list of `examples <https://opengeoscience.github.io/geojs/examples/index.html>`_
 for a live demonstration of GeoJS's features or go to our Github
-`repository <https://github.com/OpenGeoscience/geojs>`_ to start hacking.
-If you have any questions or comments, feel free to join us on our
-`mailing list <https://public.kitware.com/mailman/listinfo/geojs-users>`_.
+`repository <https://github.com/OpenGeoscience/geojs>`_ to start experimenting.
 
 .. toctree::
     :maxdepth: 2
@@ -25,9 +23,3 @@ If you have any questions or comments, feel free to join us on our
     developers
     provisioning
     API Reference <https://opengeoscience.github.io/geojs/apidocs/geo.html>
-
-Indices and tables
-==================
-
-* :ref:`genindex`
-* :ref:`search`

--- a/src/camera.js
+++ b/src/camera.js
@@ -862,7 +862,7 @@ var camera = function (spec) {
 
 /**
  * Supported projection types.
- * @enum
+ * @enum {boolean}
  */
 camera.projection = {
   perspective: true,
@@ -872,7 +872,7 @@ camera.projection = {
 /**
  * Default camera clipping bounds.  Some features and renderers may rely on the
  * far clip value being more positive than the near clip value.
- * @enum
+ * @enum {number}
  */
 camera.clipbounds = {
   perspective: {

--- a/src/markerFeature.js
+++ b/src/markerFeature.js
@@ -442,7 +442,7 @@ markerFeature.primitiveShapes = pointFeature.primitiveShapes;
 
 /**
  * Marker symbols
- * @enum
+ * @enum {number}
  */
 markerFeature.symbols = {
   // for circle (alias ellipse), the symbolValue is the ratio of the minor to
@@ -499,7 +499,7 @@ markerFeature.symbols = {
 
 /**
  * Marker scale modes
- * @enum
+ * @enum {number}
  */
 markerFeature.scaleMode = {
   none: 0,

--- a/src/pointFeature.js
+++ b/src/pointFeature.js
@@ -554,7 +554,7 @@ pointFeature.capabilities = {
 
 /**
  * Support primitive shapes
- * @enum
+ * @enum {string}
  */
 pointFeature.primitiveShapes = {
   auto: 'auto',

--- a/src/typedef.js
+++ b/src/typedef.js
@@ -234,3 +234,5 @@
  *
  * @typedef {geo.polygonFlat|geo.polygonObject} geo.polygon
  */
+
+module.exports = {};

--- a/src/webgl/webglRenderer.js
+++ b/src/webgl/webglRenderer.js
@@ -319,6 +319,7 @@ webglRenderer.supported = function () {
     var canvas, ctx, exts; // eslint-disable-line no-unused-vars
     try {
       canvas = document.createElement('canvas');
+      /** @type {WebGLRenderingContext} */
       ctx = (canvas.getContext('webgl') ||
              canvas.getContext('experimental-webgl'));
       /* getSupportExtensions will throw an exception if the context isn't


### PR DESCRIPTION
Note: Quite a while ago, we built some of the rst files into webpages using sphinx-build (via `sphinx-build -c ./docs/ -b html ./docs/ dist/docs`).  This hasn't been done since before we switched to semantic release, and would need tweaking to do.  Since all of these docs are available on GitHub and apply mostly to developers, I don't think resuming sphinx-build is needed, but we might want to migrate some of the user guide to the deployed website.