### PR TITLE
docs: Fix docco output.

### DIFF
--- a/examples/build-website.js
+++ b/examples/build-website.js
@@ -14,30 +14,22 @@ examples.forEach(function (json) {
   if (json.main) {
     const options = {
       args: [json.main],
-      output: path.resolve(json.output, 'docs'),
-      layout: 'classic'
+      opts: () => ({
+        output: path.resolve(json.output, 'docs'),
+        layout: 'classic'
+      })
     };
-    // docco 0.8.1 requires this weirdness
-    options.opts = () => options;
-    docco(options, function () {
-      // simplify the docco output to reduce the output size by
-      // removing the unnecessary public/ directory
-      fs.removeSync(path.resolve(json.output, 'docs', 'public'));
-    });
+    docco(options, buildUtils.fixupDocco(options.args[0], json.output));
   }
   (json.docJs || []).forEach(function (name) {
     const options = {
       args: [path.resolve(json.dir, name)],
-      output: path.resolve(json.output, 'docs'),
-      layout: 'classic'
+      opts: () => ({
+        output: path.resolve(json.output, 'docs'),
+        layout: 'classic'
+      })
     };
-    // docco 0.8.1 requires this weirdness
-    options.opts = () => options;
-    docco(options, function () {
-      // simplify the docco output to reduce the output size by
-      // removing the unnecessary public/ directory
-      fs.removeSync(path.resolve(json.output, 'docs', 'public'));
-    });
+    docco(options, buildUtils.fixupDocco(options.args[0], json.output));
   });
   json.docHTML = 'docs/' + path.basename(json.main).replace(/js$/, 'html');
 

--- a/examples/build.js
+++ b/examples/build.js
@@ -15,30 +15,22 @@ examples.forEach(function (json) {
   if (json.exampleJs.length) {
     const options = {
       args: [json.main],
-      output: path.resolve(json.output, 'docs'),
-      layout: 'classic'
+      opts: () => ({
+        output: path.resolve(json.output, 'docs'),
+        layout: 'classic'
+      })
     };
-    // docco 0.8.1 requires this weirdness
-    options.opts = () => options;
-    docco(options, function () {
-      // simplify the docco output to reduce the output size by
-      // removing the unnecessary public/ directory
-      fs.removeSync(path.resolve(json.output, 'docs', 'public'));
-    });
+    docco(options, buildUtils.fixupDocco(options.args[0], json.output));
   }
   (json.docJs || []).forEach(function (name) {
     const options = {
       args: [path.resolve(json.dir, name)],
-      output: path.resolve(json.output, 'docs'),
-      layout: 'classic'
+      opts: () => ({
+        output: path.resolve(json.output, 'docs'),
+        layout: 'classic'
+      })
     };
-    // docco 0.8.1 requires this weirdness
-    options.opts = () => options;
-    docco(options, function () {
-      // simplify the docco output to reduce the output size by
-      // removing the unnecessary public/ directory
-      fs.removeSync(path.resolve(json.output, 'docs', 'public'));
-    });
+    docco(options, buildUtils.fixupDocco(options.args[0], json.output));
   });
   json.docHTML = 'docs/' + path.basename(json.main).replace(/js$/, 'html');
 

--- a/website/package.json
+++ b/website/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "hexo": {
-    "version": "5.4.0"
+    "version": "5.4.1"
   },
   "dependencies": {
     "hexo": "^5.4.0",


### PR DESCRIPTION
docco 0.8 changed the paths of the output files.  This fixes them.

Resolves #1168.