### PR TITLE
fix: Tile layers with keepLower: false purged tiles on high zoom

### DIFF
--- a/src/tileLayer.js
+++ b/src/tileLayer.js
@@ -676,7 +676,10 @@ var tileLayer = function (arg) {
   this._getTiles = function (maxLevel, bounds, sorted, onlyIfChanged) {
     var i, j, tiles = [], index, nTilesLevel,
         start, end, indexRange, source, center, changed = false, old, level,
-        minLevel = (m_this._options.keepLower ? m_this._options.minLevel : Math.max(maxLevel, m_this._options.minLevel));
+        minLevel = (
+          m_this._options.keepLower ?
+            m_this._options.minLevel :
+            Math.min(Math.max(maxLevel, m_this._options.minLevel), m_this._options.maxLevel));
     if (maxLevel < minLevel) {
       maxLevel = minLevel;
     }
@@ -1533,7 +1536,9 @@ var tileLayer = function (arg) {
        * semi-transparent layers. */
       if ((doneLoading || m_this._isCovered(tile)) &&
           zoom !== tile.index.level &&
-          (zoom >= m_this._options.minLevel || tile.index.level !== m_this._options.minLevel)) {
+          (zoom >= m_this._options.minLevel || tile.index.level !== m_this._options.minLevel) &&
+          (zoom < m_this._options.maxLevel || tile.index.level !== m_this._options.maxLevel)
+      ) {
         return true;
       }
     }

--- a/tests/cases/tileLayer.js
+++ b/tests/cases/tileLayer.js
@@ -1257,6 +1257,13 @@ describe('geo.tileLayer', function () {
         expect(l._canPurge({index: {level: 2}}, {}, 1, true)).toBe(true);
         expect(l._canPurge({index: {level: 2}}, {}, 1, false)).toBe(false);
       });
+      it('past max zoom', function () {
+        var l = geo.tileLayer({map: map({max: 3}), keepLower: true});
+        l._outOfBounds = function () { return false; };
+        expect(l._canPurge({index: {level: 2}}, {}, 3)).toBe(false);
+        expect(l._canPurge({index: {level: 2}}, {}, 2)).toBe(false);
+        expect(l._canPurge({index: {level: 2}}, {}, 1)).toBe(true);
+      });
     });
 
     describe('_outOfBounds', function () {


### PR DESCRIPTION
If a map allows zooming further than a tile set has layers and keepLower is set to false, the tiles would be purged.