### PR TITLE
fix: Change the event fired when a layer's z-index change.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # GeoJS Change Log
 
+## Version 1.7.2
+
+### Bug Fixes
+
+- Emit layerMove event when changing a lyer's z-index ([#1185](../../pull/1185))
+
 ## Version 1.7.1
 
 ### Improvements

--- a/src/event.js
+++ b/src/event.js
@@ -51,6 +51,16 @@ geo_event.layerAdd = 'geo_layerAdd';
 geo_event.layerRemove = 'geo_layerRemove';
 
 /**
+ * Triggered when a layer z-index is changed.
+ *
+ * @event geo.event.layerMove
+ * @type {geo.event.base}
+ * @property {geo.map} target The current map.
+ * @property {geo.layer} layer The old layer that was removed.
+ */
+geo_event.layerMove = 'geo_layerMove';
+
+/**
  * Triggered when the map's zoom level is changed.
  *
  * @event geo.event.zoom

--- a/src/layer.js
+++ b/src/layer.js
@@ -174,7 +174,7 @@ var layer = function (arg) {
     if (zIndex !== m_zIndex) {
       m_zIndex = zIndex;
       m_node.css('z-index', m_zIndex);
-      m_this.geoTrigger(geo_event.layerRemove, {
+      m_this.geoTrigger(geo_event.layerMove, {
         layer: m_this
       });
     }


### PR DESCRIPTION
The event should be a layer move event, not a layer remove event.