### PR TITLE
build: Update jstransformer-markdown-it

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5933,42 +5933,11 @@
       }
     },
     "jstransformer-markdown-it": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/jstransformer-markdown-it/-/jstransformer-markdown-it-2.1.0.tgz",
-      "integrity": "sha1-aewwzkUYvtWZezjwJ2SOjChekvc=",
+      "version": "github:jstransformers/jstransformer-markdown-it#075f3ae04f461a75ec07bc842e640e0fd9b3bb65",
+      "from": "github:jstransformers/jstransformer-markdown-it#snyk-fix-9cae6682d6a0ba4f72fd9fec4e488acd",
       "dev": true,
       "requires": {
-        "markdown-it": "^8.0.0"
-      },
-      "dependencies": {
-        "entities": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
-          "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==",
-          "dev": true
-        },
-        "linkify-it": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-2.2.0.tgz",
-          "integrity": "sha512-GnAl/knGn+i1U/wjBz3akz2stz+HrHLsxMwHQGofCDfPvlf+gDKN58UtfmUquTY4/MXeE2x7k19KQmeoZi94Iw==",
-          "dev": true,
-          "requires": {
-            "uc.micro": "^1.0.1"
-          }
-        },
-        "markdown-it": {
-          "version": "8.4.2",
-          "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-8.4.2.tgz",
-          "integrity": "sha512-GcRz3AWTqSUphY3vsUqQSFMbgR38a4Lh3GWlHRh/7MRwz8mcu9n2IO7HOh+bXHrR9kOPDl5RNCaEsrneb+xhHQ==",
-          "dev": true,
-          "requires": {
-            "argparse": "^1.0.7",
-            "entities": "~1.1.1",
-            "linkify-it": "^2.0.0",
-            "mdurl": "^1.0.1",
-            "uc.micro": "^1.0.5"
-          }
-        }
+        "markdown-it": "^12.3.2"
       }
     },
     "jszip": {

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "jsdoc": "^3.6.10",
     "jsdoc-autoprivate": "0.0.1",
     "jsonlint-mod": "^1.7.6",
-    "jstransformer-markdown-it": "^2.0.0",
+    "jstransformer-markdown-it": "jstransformers/jstransformer-markdown-it#snyk-fix-9cae6682d6a0ba4f72fd9fec4e488acd",
     "karma": "^6.3.15",
     "karma-chrome-launcher": "^3.1.0",
     "karma-coverage": "^2.1.1",


### PR DESCRIPTION
Switch to a branch on jstransformer-markdown-it to avoid a security issue.  This can be switched back when jstransformer-markdown-it published as new version.