### PR TITLE
perf: Reduce tile layer updates.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # GeoJS Change Log
 
+## Version 1.8.2
+
+### Improvements
+
+- Reduce tile layer updates ([#1196](../../pull/1196))
+
 ## Version 1.8.1
 
 ### Improvements

--- a/src/webgl/tileLayer.js
+++ b/src/webgl/tileLayer.js
@@ -148,7 +148,10 @@ var webgl_tileLayer = function () {
    *    triggered this.  If `undefined`, clear the quads but don't redraw.
    */
   this._clearQuads = function (evt) {
-    if (evt && (!evt.layer || !(evt.layer instanceof tileLayer))) {
+    if (evt && (!evt.layer || !(evt.layer instanceof tileLayer) || !evt.layer.autoshareRenderer() || (
+      (evt.event === geo_event.layerAdd || evt.event === geo_event.layerRemove) &&
+      m_this.map().layers().every(l => l === evt.layer || evt.layer.zIndex() > l.zIndex())
+    ))) {
       return;
     }
     m_this.clear();


### PR DESCRIPTION
When updating one tile layer's z index, possibly through adding the layer, other tile layers would needlessly rerender.