### PR TITLE
perf: Optimize reordering fetch queue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # GeoJS Change Log
 
+## Version 1.8.5
+
+### Improvements
+
+-Optimize reordering fetch queue ([#1203](../../pull/1203))
+
 ## Version 1.8.4
 
 ### Improvements


### PR DESCRIPTION
When reordering an existing item in a fetch queue, instead of splicing it out of the queue and splicing it back in, shift existing components and add it.  This is faster than splicing.