### PR TITLE
perf: Fixed size annotations.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,16 @@
 # GeoJS Change Log
 
+## Version 1.8.6
+
+### Improvements
+
+- Allow constraining rectangle and ellipse annotations to a list of fixed sizes ([#1205](../../pull/1205))
+
 ## Version 1.8.5
 
 ### Improvements
 
--Optimize reordering fetch queue ([#1203](../../pull/1203))
+- Optimize reordering fetch queue ([#1203](../../pull/1203))
 
 ## Version 1.8.4
 

--- a/src/typedef.js
+++ b/src/typedef.js
@@ -75,6 +75,15 @@
  */
 
 /**
+ * Represention of a size in gcs coordinates.
+ *
+ * @typedef geo.geoSize
+ * @type {object}
+ * @property {number} width Width in gcs coordinates.
+ * @property {number} height Height in gcs coordinates.
+ */
+
+/**
  * Represention of a size in pixels.
  *
  * @typedef geo.screenSize

--- a/tests/cases/annotation.js
+++ b/tests/cases/annotation.js
@@ -1583,6 +1583,71 @@ describe('geo.annotation', function () {
     });
   });
 
+  describe('contrainAspectRatio', function () {
+    it('ratio', function () {
+      const func = geo.annotation.constrainAspectRatio([2, 0.5]);
+
+      let result;
+      result = func(
+        {x: 40, y: 5},
+        {x: 0, y: 0});
+      expect(result.pos).toEqual({x: 20, y: 10});
+      result = func(
+        {x: 40, y: 5},
+        {x: 0, y: 0},
+        [{x: 0, y: 0}, {x: 10, y: 0}, {x: 10, y: 10}, {x: 0, y: 10}]);
+      expect(result.pos).toEqual({x: 20, y: 10});
+      result = func(
+        {x: 5, y: 40},
+        {x: 0, y: 0},
+        [{x: 0, y: 0}, {x: 10, y: 0}, {x: 10, y: 10}, {x: 0, y: 10}]);
+      expect(result.pos).toEqual({x: 10, y: 20});
+      result = func(
+        {x: 0, y: 0},
+        {x: 0, y: 0},
+        [{x: -10, y: 5}, {x: 30, y: 5}, {x: 30, y: 10}, {x: -10, y: 10}],
+        'edge', [0, -Math.PI / 2, Math.PI, Math.PI / 2], 0);
+      expect(result.corners).toEqual([{x: 20, y: 20}, {x: 0, y: 20}, {x: 0, y: 10}, {x: 20, y: 10}]);
+      result = func(
+        {x: 0, y: 0},
+        {x: 0, y: 0},
+        [{x: -10, y: 5}, {x: 30, y: 5}, {x: 30, y: 10}, {x: -10, y: 10}],
+        'vertex', [0, -Math.PI / 2, Math.PI, Math.PI / 2], 0);
+      expect(result.corners).toEqual([{x: 10, y: 20}, {x: 30, y: 20}, {x: 30, y: 10}, {x: 10, y: 10}]);
+    });
+    it('fixed size', function () {
+      const func = geo.annotation.constrainAspectRatio({width: 20, height: 10});
+
+      let result;
+      result = func(
+        {x: 40, y: 5},
+        {x: 0, y: 0});
+      expect(result.pos).toEqual({x: 20, y: 10});
+      result = func(
+        {x: 40, y: 5},
+        {x: 0, y: 0},
+        [{x: 0, y: 0}, {x: 10, y: 0}, {x: 10, y: 10}, {x: 0, y: 10}]);
+      expect(result.pos).toEqual({x: 20, y: 10});
+      result = func(
+        {x: 5, y: 40},
+        {x: 0, y: 0},
+        [{x: 0, y: 0}, {x: 10, y: 0}, {x: 10, y: 10}, {x: 0, y: 10}]);
+      expect(result.pos).toEqual({x: 20, y: 10});
+      result = func(
+        {x: 0, y: 0},
+        {x: 0, y: 0},
+        [{x: -10, y: 5}, {x: 30, y: 5}, {x: 30, y: 10}, {x: -10, y: 10}],
+        'edge', [0, -Math.PI / 2, Math.PI, Math.PI / 2], 0);
+      expect(result.corners).toEqual([{x: 20, y: 20}, {x: 0, y: 20}, {x: 0, y: 10}, {x: 20, y: 10}]);
+      result = func(
+        {x: 0, y: 0},
+        {x: 0, y: 0},
+        [{x: -10, y: 5}, {x: 30, y: 5}, {x: 30, y: 10}, {x: -10, y: 10}],
+        'vertex', [0, -Math.PI / 2, Math.PI, Math.PI / 2], 0);
+      expect(result.corners).toEqual([{x: 10, y: 20}, {x: 30, y: 20}, {x: 30, y: 10}, {x: 10, y: 10}]);
+    });
+  });
+
   describe('annotation registry', function () {
     var newshapeCount = 0;
     it('listAnnotations', function () {


### PR DESCRIPTION
Add options to the default annotation constraint function to allow for fixed size annotations.

You can try this out with the annotation example.  Select the rectangle or ellipse annotation, and from the console type: `annotationDebug.layer.annotations()[0]._selectionConstraint = geo.annotation.constrainAspectRatio([{width: 15000, height: 12000}]);`, and only that size annotation can be created.
