### PR TITLE
fix: Fix determining annotation correspondence.

### DIFF
--- a/src/action.js
+++ b/src/action.js
@@ -16,10 +16,7 @@ var geo_action = {
   zoomrotate: 'geo_action_zoom_rotate',
   zoomselect: 'geo_action_zoomselect',
 
-  // annotation actions
-  annotation_line: 'geo_annotation_line',
-  annotation_polygon: 'geo_annotation_polygon',
-  annotation_rectangle: 'geo_annotation_rectangle',
+  // annotation actions -- some are also added by the registry
   annotation_edit_handle: 'geo_annotation_edit_handle'
 };
 

--- a/src/annotation/annotation.js
+++ b/src/annotation/annotation.js
@@ -152,6 +152,14 @@ var annotation = function (type, args) {
   };
 
   /**
+   * Assign a new id to this annotation.
+   */
+  this.newId = function () {
+    annotationId += 1;
+    m_id = annotationId;
+  };
+
+  /**
    * Get or set the name of this annotation.
    *
    * @param {string|undefined} [arg] If `undefined`, return the name, otherwise

--- a/src/registry.js
+++ b/src/registry.js
@@ -1,4 +1,6 @@
 var $ = require('jquery');
+var geo_action = require('./action');
+
 var widgets = {
   dom: {}
 };
@@ -398,6 +400,7 @@ util.registerAnnotation = function (name, func, features) {
     console.warn('The ' + name + ' annotation is already registered');
   }
   annotations[name] = {func: func, features: features || {}};
+  geo_action['annotation_' + name] = 'geo_annotation_' + name;
   return old;
 };
 

--- a/src/util/polyops.js
+++ b/src/util/polyops.js
@@ -327,16 +327,19 @@ function generateCorrespondence(poly1, poly2, newpoly, results) {
     results[ekey] = Array(poly.length);
     poly.forEach((p, idx) => {
       const found = {};
+      let missed = 0;
       p.forEach((h) => h.forEach((pt) => {
         const key = '_' + pt[0] + '_' + pt[1];
         if (pts[key]) {
           pts[key].forEach((val) => {
             found[val] = (found[val] || 0) + 1;
           });
+        } else {
+          missed += 1;
         }
       }));
       Object.keys(found).forEach((nidx) => {
-        if (found[nidx] === counts[+nidx]) {
+        if (found[nidx] === counts[+nidx] && !missed && p.length === newpoly[+nidx].length) {
           if (!results[ekey][idx]) {
             results[ekey][idx] = [];
           }


### PR DESCRIPTION
In some instances, annotations with different holes could be considered identical.

Also, don't reuse annotation ids.