### PR TITLE
perf: Allow using the rdp functions on non-feature polygons.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## Version 1.10.5
 
+### Improvements
+
+- Allow using the rdp functions on non-feature polygons ([#1234](../../pull/1234))
+- Allow annotations to be created regardless of metakeys ([#1235](../../pull/1235))
+
+## Version 1.10.5
+
+### Bug Fixes
+
+- Guard texture update calls ([#1233](../../pull/1233))
+
+## Version 1.10.5
+
 ### Bug Fixes
 
 - Guard converting an empty polygon ([#1232](../../pull/1232))

--- a/src/polygonFeature.js
+++ b/src/polygonFeature.js
@@ -573,9 +573,11 @@ var polygonFeature = function (arg) {
    *    get the position of each vertex.
    * @param {function} [polyFunc=this.style.get('polygon')] The function to
    *    get each polygon.
-   * @returns {this}
+   * @param {boolean} [returnData=false] If truthy, return the new data array
+   *    rather than modifying the feature.
+   * @returns {this|array}
    */
-  this.rdpSimplifyData = function (data, tolerance, posFunc, polyFunc) {
+  this.rdpSimplifyData = function (data, tolerance, posFunc, polyFunc, returnData) {
     var map = m_this.layer().map(),
         mapgcs = map.gcs(),
         featuregcs = m_this.gcs(),
@@ -633,6 +635,9 @@ var polygonFeature = function (arg) {
       }
       return elem;
     });
+    if (returnData) {
+      return data;
+    }
 
     /* Set the reduced polgons as the data and use simple accessors. */
     m_this.style('position', util.identityFunction);


### PR DESCRIPTION
Specifically, the polygon feature can use rdp without collapsing through holes, and this is a useful property even when the data is not part of the polygon feature itself.