### PR TITLE
build: Use a published version of jstransformer-markdown-it

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52,7 +52,7 @@
         "jsdoc": "^3.6.10",
         "jsdoc-autoprivate": "0.0.1",
         "jsonlint-mod": "^1.7.6",
-        "jstransformer-markdown-it": "git+https://github.com/jstransformers/jstransformer-markdown-it#snyk-fix-9cae6682d6a0ba4f72fd9fec4e488acd",
+        "jstransformer-markdown-it": "^3.0.0",
         "karma": "^6.3.15",
         "karma-chrome-launcher": "^3.1.0",
         "karma-coverage": "^2.1.1",
@@ -7339,15 +7339,52 @@
       }
     },
     "node_modules/jstransformer-markdown-it": {
-      "version": "2.1.0",
-      "resolved": "git+ssh://git@github.com/jstransformers/jstransformer-markdown-it.git#075f3ae04f461a75ec07bc842e640e0fd9b3bb65",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/jstransformer-markdown-it/-/jstransformer-markdown-it-3.0.0.tgz",
+      "integrity": "sha512-/2fNT0ir/D0NYI5roBTVRwDV2YBjMfU3f/wSeraKLfOMNxcrIJatjJQy4zPmwQBxqKxUojXBN8hmfQBMTLZ3KA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "markdown-it": "^12.3.2"
+        "markdown-it": "^13.0.1"
       },
       "engines": {
         "node": ">=7"
+      }
+    },
+    "node_modules/jstransformer-markdown-it/node_modules/entities": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-3.0.1.tgz",
+      "integrity": "sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/jstransformer-markdown-it/node_modules/linkify-it": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-4.0.1.tgz",
+      "integrity": "sha512-C7bfi1UZmoj8+PQx22XyeXCuBlokoyWQL5pWSP+EI6nzRylyThouddufc2c1NDIcP9k5agmN9fLpA7VNJfIiqw==",
+      "dev": true,
+      "dependencies": {
+        "uc.micro": "^1.0.1"
+      }
+    },
+    "node_modules/jstransformer-markdown-it/node_modules/markdown-it": {
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-13.0.1.tgz",
+      "integrity": "sha512-lTlxriVoy2criHP0JKRhO2VDG9c2ypWCsT237eDiLqi09rmbKoUetyGHq2uOIRoRS//kfoJckS0eUzzkDR+k2Q==",
+      "dev": true,
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "entities": "~3.0.1",
+        "linkify-it": "^4.0.1",
+        "mdurl": "^1.0.1",
+        "uc.micro": "^1.0.5"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.js"
       }
     },
     "node_modules/JSV": {
@@ -20174,11 +20211,42 @@
       }
     },
     "jstransformer-markdown-it": {
-      "version": "git+ssh://git@github.com/jstransformers/jstransformer-markdown-it.git#075f3ae04f461a75ec07bc842e640e0fd9b3bb65",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/jstransformer-markdown-it/-/jstransformer-markdown-it-3.0.0.tgz",
+      "integrity": "sha512-/2fNT0ir/D0NYI5roBTVRwDV2YBjMfU3f/wSeraKLfOMNxcrIJatjJQy4zPmwQBxqKxUojXBN8hmfQBMTLZ3KA==",
       "dev": true,
-      "from": "jstransformer-markdown-it@git+https://github.com/jstransformers/jstransformer-markdown-it#snyk-fix-9cae6682d6a0ba4f72fd9fec4e488acd",
       "requires": {
-        "markdown-it": "^12.3.2"
+        "markdown-it": "^13.0.1"
+      },
+      "dependencies": {
+        "entities": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-3.0.1.tgz",
+          "integrity": "sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q==",
+          "dev": true
+        },
+        "linkify-it": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-4.0.1.tgz",
+          "integrity": "sha512-C7bfi1UZmoj8+PQx22XyeXCuBlokoyWQL5pWSP+EI6nzRylyThouddufc2c1NDIcP9k5agmN9fLpA7VNJfIiqw==",
+          "dev": true,
+          "requires": {
+            "uc.micro": "^1.0.1"
+          }
+        },
+        "markdown-it": {
+          "version": "13.0.1",
+          "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-13.0.1.tgz",
+          "integrity": "sha512-lTlxriVoy2criHP0JKRhO2VDG9c2ypWCsT237eDiLqi09rmbKoUetyGHq2uOIRoRS//kfoJckS0eUzzkDR+k2Q==",
+          "dev": true,
+          "requires": {
+            "argparse": "^2.0.1",
+            "entities": "~3.0.1",
+            "linkify-it": "^4.0.1",
+            "mdurl": "^1.0.1",
+            "uc.micro": "^1.0.5"
+          }
+        }
       }
     },
     "JSV": {

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "jsdoc": "^3.6.10",
     "jsdoc-autoprivate": "0.0.1",
     "jsonlint-mod": "^1.7.6",
-    "jstransformer-markdown-it": "git+https://github.com/jstransformers/jstransformer-markdown-it#snyk-fix-9cae6682d6a0ba4f72fd9fec4e488acd",
+    "jstransformer-markdown-it": "^3.0.0",
     "karma": "^6.3.15",
     "karma-chrome-launcher": "^3.1.0",
     "karma-coverage": "^2.1.1",


### PR DESCRIPTION
This package has made a release encompassing the needed changes.