### PR TITLE
fix: When binding an array of events, don't duplicate

### DIFF
--- a/src/pixelmapLayer.js
+++ b/src/pixelmapLayer.js
@@ -120,7 +120,9 @@ var pixelmapLayer = function (arg) {
     ['modified', 'geoOn', 'geoOff', 'geoOnce'].forEach((funcName) => {
       const superFunc = m_this[funcName];
       m_this[funcName] = function () {
-        m_pixelmapFeature[funcName].apply(this, arguments);
+        if (!Array.isArray(arguments[0])) {
+          m_pixelmapFeature[funcName].apply(this, arguments);
+        }
         return superFunc.apply(this, arguments);
       };
     });

--- a/tests/gl-cases/pixelmapLayer.js
+++ b/tests/gl-cases/pixelmapLayer.js
@@ -89,6 +89,25 @@ describe('webglPixelmapLayer', function () {
       done();
     });
   });
+  it('geoOn and geoOff from array', function (done) {
+    createPixelmap();
+    var click = 0;
+    layer.geoOn([geo.event.feature.mouseclick], () => {
+      click += 1;
+    });
+    // wait for the tiles to be available
+    map.onIdle(() => {
+      expect(click).toEqual(0);
+      map.interactor().simulateEvent('mousedown', {map: {x: 390, y: 200}});
+      map.interactor().simulateEvent('mouseup', {map: {x: 390, y: 200}});
+      expect(click).toEqual(1);
+      layer.geoOff([geo.event.feature.mouseclick]);
+      map.interactor().simulateEvent('mousedown', {map: {x: 390, y: 200}});
+      map.interactor().simulateEvent('mouseup', {map: {x: 390, y: 200}});
+      expect(click).toEqual(1);
+      done();
+    });
+  });
   it('geospatial', function (done) {
     map = geo.map({node: '#map'});
     layer = map.createLayer('pixelmap', {


### PR DESCRIPTION
When we bind events from a feature to a parent layer, we were calling the geoOn or geoOff event on both the feature and layer.  For arrays of events, this ended calling the layer with both the array of events and each event.