### PR TITLE
fixed typo 'toctree' -> 'doctree'

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -61,7 +61,7 @@ source_suffix = '.rst'
 # The encoding of source files.
 #source_encoding = 'utf-8-sig'
 
-# The master toctree document.
+# The master doctree document.
 master_doc = 'index'
 
 # General information about the project.


### PR DESCRIPTION
Hello there👋

I have made a pull request to fix a small typo in the documentation. The word 'toctree' was misspelled, and I have corrected it to 'doctree'.