### PR TITLE
feat: Never include vtkjs in the bundle

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,5 +5,8 @@ module.exports = merge(config, {
   entry: {
     geo: ['./index.js'],
     'geo.min': ['./index.js']
+  },
+  externals: {
+    'vtk.js': 'vtk.js'
   }
 });


### PR DESCRIPTION
This doesn't affect the lean bundle, only the full bundle.  I don't know that anything is actively using the vtkjs renderer.