### PR TITLE
fix: Ensure compatibility with older systems

### DIFF
--- a/webpack.base.config.js
+++ b/webpack.base.config.js
@@ -54,12 +54,11 @@ module.exports = {
   module: {
     rules: [{
       test: /\.js$/,
-      include: [
-        path.resolve('src'),
-        path.resolve('examples'),
-        path.resolve('tutorials')
+      // include: [ path.resolve('src'), ],
+      exclude: [
+        /node_modules\/(?!kdbush\/).*/,
+        path.resolve('tests')
       ],
-      exclude: /node_modules\/(?!kdbush\/).*/,
       use: [{
         loader: 'babel-loader',
         options: {
@@ -72,7 +71,9 @@ module.exports = {
     }, {
       test: /\.js$/,
       include: [
-        path.resolve('tests')
+        path.resolve('tests'),
+        path.resolve('examples'),
+        path.resolve('tutorials')
       ],
       use: [{
         loader: 'babel-loader',


### PR DESCRIPTION
We need to keep the old grider tests running.

This should have both has the correct coverage and the older compatibility support.