### PR TITLE
perf: Add addMultipleAnnotations method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,47 @@
 # GeoJS Change Log
 
+## Version 1.12.9
+
+### Performance Improvements
+
+- Add addMultipleAnnotations method ([#1351](../../pull/1351))
+
+## Version 1.12.8
+
+### Performance Improvements
+
+- Switch to more native functions ([#1345](../../pull/1345))
+
+## Version 1.12.7
+
+### Performance Improvements
+
+- Make adding and removing annotations somewhat more efficient ([#1343](../../pull/1343))
+
+## Version 1.12.6
+
+### Performance Improvements
+
+- Stop using jquery extend ([#1342](../../pull/1342))
+
+## Version 1.12.5
+
+### Bug Fixes
+
+- Change how webpack builds some libraries ([#1341](../../pull/1341))
+
+## Version 1.12.4
+
+### Performance Improvements
+
+- Speed up adding annotations ([#1340](../../pull/1340))
+
+## Version 1.12.3
+
+### Bug Fixes
+
+- Improve encoding html for screenshots ([#1334](../../pull/1334))
+
 ## Version 1.12.2
 
 ### Improvements

--- a/src/event.js
+++ b/src/event.js
@@ -656,20 +656,23 @@ geo_event.camera.viewport = 'geo_camera_viewport';
 geo_event.annotation = {};
 
 /**
- * Triggered when an annotation has been added.
+ * Triggered when or more multiple annotations have been added.
  *
  * @event geo.event.annotation.add
  * @type {geo.event.base}
- * @property {geo.annotation} annotation The annotation that was added.
+ * @property {geo.annotation} [annotation] The annotation that was added.
+ * @property {geo.annotation} [annotations] The annotations that were added.
  */
 geo_event.annotation.add = 'geo_annotation_add';
 
 /**
- * Triggered when an annotation is about to be added.
+ * Triggered when one or multiple annotations are about to be added.
  *
  * @event geo.event.annotation.add_before
  * @type {geo.event.base}
- * @property {geo.annotation} annotation The annotation that will be added.
+ * @property {geo.annotation} [annotation] The annotation that will be added.
+ * @property {geo.annotation[]} [annotations] The annotations that will be
+ *   added.
  */
 geo_event.annotation.add_before = 'geo_annotation_add_before';
 

--- a/tests/cases/annotationLayer.js
+++ b/tests/cases/annotationLayer.js
@@ -110,6 +110,18 @@ describe('geo.annotationLayer', function () {
       layer.removeAllAnnotations();
       expect(layer.annotations().length).toBe(0);
     });
+    it('multipleAnnotations', function () {
+      var poly = geo.annotation.polygonAnnotation({
+            state: geo.annotation.state.create, layer: layer}),
+          rect = geo.annotation.rectangleAnnotation({
+            layer: layer,
+            corners: [{x: 0, y: 0}, {x: 1, y: 0}, {x: 1, y: 1}, {x: 0, y: 1}]});
+      expect(layer.annotations().length).toBe(0);
+      layer.addMultipleAnnotations([poly, rect]);
+      expect(layer.annotations().length).toBe(2);
+      expect(layer.annotations()[0]).toBe(poly);
+      expect(layer.annotations()[1]).toBe(rect);
+    });
   });
   describe('Public utility functions', function () {
     var map, layer,


### PR DESCRIPTION
This is primarily faster because of the less events being triggered. The addAnnotation method can also ask to not trigger events.