### PR TITLE
fix: Fix pixelmap parameters for images smaller than tiles

### DIFF
--- a/src/osmLayer.js
+++ b/src/osmLayer.js
@@ -79,7 +79,7 @@ var osmLayer = function (arg) {
       overlap: m_this._options.tileOverlap,
       scale: m_this._options.tileScale,
       url: m_this._options.url.call(
-        m_this, urlParams.x, urlParams.y, urlParams.level || 0,
+        m_this, urlParams.x, urlParams.y, Math.max(urlParams.level || 0, 0),
         m_this._options.subdomains),
       crossDomain: m_this._options.crossDomain
     });

--- a/src/pixelmapLayer.js
+++ b/src/pixelmapLayer.js
@@ -81,7 +81,7 @@ var pixelmapLayer = function (arg) {
       overlap: m_this._options.tileOverlap,
       scale: m_this._options.tileScale,
       url: m_this._options.url.call(
-        m_this, urlParams.x, urlParams.y, urlParams.level || 0,
+        m_this, urlParams.x, urlParams.y, Math.max(urlParams.level || 0, 0),
         m_this._options.subdomains),
       crossDomain: m_this._options.crossDomain
     });

--- a/src/tileLayer.js
+++ b/src/tileLayer.js
@@ -601,7 +601,7 @@ var tileLayer = function (arg) {
       size: {x: m_this._options.tileWidth, y: m_this._options.tileHeight},
       queue: m_this._queue,
       url: m_this._options.url.call(
-        m_this, urlParams.x, urlParams.y, urlParams.level || 0,
+        m_this, urlParams.x, urlParams.y, Math.max(urlParams.level || 0, 0),
         m_this._options.subdomains)
     });
   };

--- a/src/util/common.js
+++ b/src/util/common.js
@@ -569,6 +569,7 @@ var util = {
     };
     var layerParams = {
       maxLevel: maxLevel,
+      minLevel: Math.min(0, maxLevel),
       wrapX: false,
       wrapY: false,
       tileOffset: function () {


### PR DESCRIPTION
Fix an issue when generating pixelmap parameters for images smaller than tiles.  Specifically, if an image was small (say 100 x 100) and claimed to be tiled where the tiles where more than twice the size of the image (say 1024 x 1024), the minimum tile level was not set appropriately for the tile layer, and, if corrected, the url could ask for a negative z level.  If negative z levels are ever desired, this would need to change.