### PR TITLE
fix: Fix layer parameters for images smaller than tiles

### DIFF
--- a/src/osmLayer.js
+++ b/src/osmLayer.js
@@ -79,7 +79,8 @@ var osmLayer = function (arg) {
       overlap: m_this._options.tileOverlap,
       scale: m_this._options.tileScale,
       url: m_this._options.url.call(
-        m_this, urlParams.x, urlParams.y, Math.max(urlParams.level || 0, 0),
+        m_this, urlParams.x, urlParams.y,
+        Math.max(urlParams.level || 0, Math.min(0, m_this._options.minLevel || 0)),
         m_this._options.subdomains),
       crossDomain: m_this._options.crossDomain
     });

--- a/src/pixelmapLayer.js
+++ b/src/pixelmapLayer.js
@@ -81,7 +81,8 @@ var pixelmapLayer = function (arg) {
       overlap: m_this._options.tileOverlap,
       scale: m_this._options.tileScale,
       url: m_this._options.url.call(
-        m_this, urlParams.x, urlParams.y, Math.max(urlParams.level || 0, 0),
+        m_this, urlParams.x, urlParams.y,
+        Math.max(urlParams.level || 0, Math.min(0, m_this._options.minLevel || 0)),
         m_this._options.subdomains),
       crossDomain: m_this._options.crossDomain
     });

--- a/src/tileLayer.js
+++ b/src/tileLayer.js
@@ -601,7 +601,8 @@ var tileLayer = function (arg) {
       size: {x: m_this._options.tileWidth, y: m_this._options.tileHeight},
       queue: m_this._queue,
       url: m_this._options.url.call(
-        m_this, urlParams.x, urlParams.y, Math.max(urlParams.level || 0, 0),
+        m_this, urlParams.x, urlParams.y,
+        Math.max(urlParams.level || 0, Math.min(0, m_this._options.minLevel || 0)),
         m_this._options.subdomains)
     });
   };


### PR DESCRIPTION
In PR #1359, a problem was fixed when generating pixelmap parameters for images smaller than tiles.  However, when a pixelmap is overlaid on a lower resolution base, this changed the behavior of how that was handled.  This fix specifically allows the lowest tile layer in a tile layer as the minimum rather than zero.