### PR TITLE
fix: Change modifier keys for wheel actions

### DIFF
--- a/src/mapInteractor.js
+++ b/src/mapInteractor.js
@@ -229,7 +229,7 @@ var mapInteractor = function (args) {
       }, {
         action: geo_action.zoom,
         input: 'wheel',
-        modifiers: {shift: false, ctrl: false},
+        modifiers: {shift: false},
         owner: 'geo.mapInteractor',
         name: 'wheel zoom'
       }, {
@@ -241,7 +241,7 @@ var mapInteractor = function (args) {
       }, {
         action: geo_action.rotate,
         input: 'wheel',
-        modifiers: {shift: false, ctrl: true},
+        modifiers: {shift: true, ctrl: false},
         owner: 'geo.mapInteractor',
         name: 'wheel rotate'
       }, {


### PR DESCRIPTION
Since 2021-09 it has become the unofficial standard to send pinch events on touchpads as wheel events with the ctrl key held down.  This should correspond to zoom.  GeoJS actions predate this and had used ctrl+wheel as rotate (and wheel by itself as zoom).  This changes it so shift+wheel is rotate, and wheel+(no shift) regardless of ctrl state is zoom.