### PR TITLE
perf: Speed up cluster zoom transition

### DIFF
--- a/src/pointFeature.js
+++ b/src/pointFeature.js
@@ -185,23 +185,26 @@ var pointFeature = function (arg) {
     // store the current zoom level privately
     m_lastZoom = z;
 
-    // get the raw data elements for the points at the current level
-    var data = m_clusterTree.points(z).map(function (d) {
-      return m_allData[d.index];
-    });
+    const points = m_clusterTree.points(z);
+    const clusters = m_clusterTree.clusters(z);
+    const data = new Array(points.length + clusters.length);
+    for (let pidx = 0; pidx < points.length; pidx += 1) {
+      data[pidx] = m_allData[points[pidx].index];
+    }
 
     // append the clusters at the current level
-    m_clusterTree.clusters(z).forEach(function (d) {
+    for (let cidx = 0, didx = points.length; cidx < clusters.length; cidx += 1, didx += 1) {
+      const d = clusters[cidx];
       // mark the datum as a cluster for accessor methods
       d.__cluster = true;
 
       // store all of the data objects for each point in the cluster as __data
-      d.__data = [];
-      d.obj.each(function (e) {
-        d.__data.push(m_allData[e.index]);
-      });
-      data.push(d);
-    });
+      d.__data = new Array(d.obj.length);
+      for (let idx = 0; idx < d.obj.length; idx += 1) {
+        d.__data[idx] = m_allData[d.obj[idx].index];
+      }
+      data[didx] = d;
+    }
 
     // prevent recomputing the clustering and set the new data array
     m_ignoreData = true;

--- a/src/util/distanceGrid.js
+++ b/src/util/distanceGrid.js
@@ -55,7 +55,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  * @copyright 2012, David Leaver
  */
 
-var $ = require('jquery');
 var L = {};
 L.Util = {
     // return unique ID of an object
@@ -181,7 +180,7 @@ DistanceGrid.prototype = {
 
     /* return the point coordinates contained in the structure */
     contents: function () {
-        return $.map(this._objectPoint, function (val) { return val; });
+        return Object.values(this._objectPoint);
     },
 
     _getCoord: function (x) {


### PR DESCRIPTION
In a test of 1.3M points, this saves 500-700 ms per zoom transition in one test.  The clustering took a maximum of 94ms for the zoom transition; the remaining time is in the webGL point transformation and property fetches.  The next improvement would be to cache those values per zoom level.