### PR TITLE
docs: Guard tutorial urls

### DIFF
--- a/tutorials/common/tutorials.js
+++ b/tutorials/common/tutorials.js
@@ -280,6 +280,7 @@ function start_keeper(alwaysKeep) {
       if (query.keep && alwaysKeep !== true) {
         newQuery.keep = query.keep;
       }
+      var guard = false;
       $('.codeblock').each(function () {
         var block = $(this),
             defaultSrc = $('textarea', block).attr('defaultvalue'),
@@ -295,8 +296,12 @@ function start_keeper(alwaysKeep) {
            * average length of the url by 6 percent. */
           comp = comp.replace(/\//g, '.').replace(/\+/g, '-').replace(/=/g, '_');
           newQuery[key] = comp;
+          guard = !(/[A-Za-z0-9]/.test(comp.slice(-1)));
         }
       });
+      if (guard) {
+        newQuery['_'] = '_';
+      }
       if (!inPop) {
         utils.setQuery(newQuery, true);
       }


### PR DESCRIPTION
When using a tutorial where we update the url to include the source, the url can end in characters that some services misinterpret (e.g., if the url ends in `.`, slack assumes that the `.` is not part of the url).  If the last `src` chunk added does not end in an alphanumeric value, add a `_=_` property to guard the end of the url.