### PR TITLE
Quad Texture Support

### DIFF
--- a/package.json
+++ b/package.json
@@ -183,5 +183,5 @@
     "webgl",
     "svg"
   ],
-  "main": "geo.lean.js"
+  "main": "dist/built/geo.lean.js"
 }

--- a/sample.html
+++ b/sample.html
@@ -1,0 +1,104 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>GeoJS QuadFeature with Random Texture</title>
+  <script src="dist/built/geo.js"></script>
+  <style>
+    html, body, #map {
+      height: 100%;
+      margin: 0;
+      overflow: hidden;
+    }
+  </style>
+</head>
+<body>
+  <div id="map"></div>
+  <script>
+    // Define frame size for the texture
+    const frameWidth = 256;
+    const frameHeight = 256;
+
+    // Function to generate a random texture
+    function generateRandomTexture(width, height) {
+      const data = new Uint8Array(width * height * 4); // RGBA
+      for (let i = 0; i < data.length; i += 4) {
+        data[i] = Math.floor(Math.random() * 256);     // R
+        data[i + 1] = Math.floor(Math.random() * 256); // G
+        data[i + 2] = Math.floor(Math.random() * 256); // B
+        data[i + 3] = 255;                             // A
+      }
+      return {
+        data,
+        width,
+        height
+      };
+    }
+
+    function randomTextureToImage(texture) {
+      const { data, width, height } = texture;
+
+      // Create a canvas
+      const canvas = document.createElement('canvas');
+      canvas.width = width;
+      canvas.height = height;
+
+      // Draw the texture data to the canvas
+      const ctx = canvas.getContext('2d');
+      const imageData = ctx.createImageData(width, height);
+      imageData.data.set(data);
+      ctx.putImageData(imageData, 0, 0);
+
+      // Create an image element from the canvas
+      const img = new Image();
+      img.src = canvas.toDataURL(); // Converts canvas to base64 PNG
+
+      return img;
+    }
+
+    const randomTexture = generateRandomTexture(frameWidth, frameHeight);
+
+    //const image = randomTextureToImage(randomTexture)
+    // Create the map
+    const map = geo.map({
+      node: '#map',
+      center: { x: -98, y: 39 }, // Rough center of contiguous U.S.
+      zoom: 3,
+      baselayer: null
+    });
+
+   // map.createLayer('osm');
+    const layer = map.createLayer('feature');
+    const geoCorners = {
+      ul: { x: -125, y: 50 }, // upper-left (NW)
+      ur: { x: -66, y: 50 },  // upper-right (NE)
+      ll: { x: -125, y: 24 }, // lower-left (SW)
+      lr: { x: -66, y: 24 }   // lower-right (SE)
+    };
+
+    // const imageUrl = 'image.jpg';
+    // const imageObj = new Image();
+    // imageObj.src = 'image.jpg'
+    // imageObj.crossOrigin = 'anonymouse'
+
+    // Define geo-coordinates where the image should be projected
+    const corners = {
+      ul: { x: -105, y: 45 }, // Upper-left
+      ur: { x: -95, y: 45 },  // Upper-right
+      ll: { x: -105, y: 35 }, // Lower-left
+      lr: { x: -95, y: 35 }   // Lower-right
+    };
+
+    // Create quad feature using local texture coordinates
+    layer.createFeature('quad')
+      .data([{
+        ul: corners.ul,
+        lr: corners.lr,
+        texture: randomTexture,
+      }])
+      .draw();
+
+    map.draw();
+  </script>
+</body>
+</html>

--- a/src/quadFeature.js
+++ b/src/quadFeature.js
@@ -434,6 +434,20 @@ var quadFeature = function (arg) {
       }
       img = imgFunc.call(m_this, d, i);
       vid = img ? null : vidFunc.call(m_this, d, i);
+
+      // Check for texture data (Uint8Array with width/height) - WebGL only
+      if (d.texture && d.texture.data && d.texture.width && d.texture.height) {
+        // Create a custom image object for vgl.texture
+        var textureImage = {
+          width: d.texture.width,
+          height: d.texture.height,
+          data: d.texture.data
+        };
+        quad.imageTexture = textureImage; // Store as imageTexture for WebGL
+        imgQuads.push(quad);
+        quadinfo.imgquad = quad;
+      }
+
       if (img) {
         quadinfo.imageEntry = img;
         /* Handle image quads */

--- a/src/vgl/texture.js
+++ b/src/vgl/texture.js
@@ -30,6 +30,7 @@ vgl.texture = function () {
   this.m_nearestPixel = false;
 
   this.m_image = null;
+  this.m_texture = null;
 
   var m_setupTimestamp = timestamp(),
       m_that = this;
@@ -64,7 +65,7 @@ vgl.texture = function () {
                                         vgl.GL.TEXTURE_WRAP_S, vgl.GL.CLAMP_TO_EDGE);
     renderState.m_context.texParameteri(vgl.GL.TEXTURE_2D,
                                         vgl.GL.TEXTURE_WRAP_T, vgl.GL.CLAMP_TO_EDGE);
-
+    console.log('Inside the setup vgl function');
     if (this.m_image !== null) {
       renderState.m_context.pixelStorei(vgl.GL.UNPACK_ALIGNMENT, 1);
       renderState.m_context.pixelStorei(vgl.GL.UNPACK_FLIP_Y_WEBGL, true);
@@ -77,8 +78,21 @@ vgl.texture = function () {
       // console.log('m_pixelDataType ' + this.m_pixelDataType);
 
       // FOR now support only 2D textures
+      console.log(this.m_image);
       renderState.m_context.texImage2D(vgl.GL.TEXTURE_2D, 0, this.m_internalFormat,
                                        this.m_pixelFormat, this.m_pixelDataType, this.m_image);
+    } else if (this.m_texture !== null) {
+      // Custom texture data object
+      console.log('Rendering custom Texture with size ' + this.m_texture.width + 'and ' + this.m_texture.height);
+      console.log(this.m_texture.data);
+      renderState.m_context.pixelStorei(vgl.GL.UNPACK_ALIGNMENT, 1);
+      renderState.m_context.pixelStorei(vgl.GL.UNPACK_FLIP_Y_WEBGL, true);
+
+      this.updateDimensions();
+      this.computeInternalFormatUsingImage();
+      renderState.m_context.texImage2D(vgl.GL.TEXTURE_2D, 0, this.m_internalFormat,
+                                       this.m_texture.width, this.m_texture.height, 0,
+                                       this.m_pixelFormat, this.m_pixelDataType, this.m_texture.data);
     } else {
       renderState.m_context.texImage2D(vgl.GL.TEXTURE_2D, 0, this.m_internalFormat,
                                        this.m_width, this.m_height, 0, this.m_pixelFormat, this.m_pixelDataType, null);
@@ -122,6 +136,15 @@ vgl.texture = function () {
   };
 
   /**
+   * Get image used by the texture.
+   *
+   * @returns {vgl.image}
+   */
+  this.texture = function () {
+    return this.m_texture;
+  };
+
+  /**
    * Set image for the texture.
    *
    * @param {vgl.image} image
@@ -138,6 +161,16 @@ vgl.texture = function () {
     return false;
   };
 
+  this.setTexture = function (texture) {
+    if (texture !== null) {
+      this.m_texture = texture;
+      this.updateDimensions();
+      this.modified();
+      return true;
+    }
+
+    return false;
+  };
   /**
    * Get nearest pixel flag for the texture.
    *
@@ -226,6 +259,11 @@ vgl.texture = function () {
     if (this.m_image !== null) {
       this.m_width = this.m_image.width;
       this.m_height = this.m_image.height;
+      this.m_depth = 0; // Only 2D images are supported now
+    }
+    if (this.m_texture !== null) {
+      this.m_width = this.m_texture.width;
+      this.m_height = this.m_texture.height;
       this.m_depth = 0; // Only 2D images are supported now
     }
   };

--- a/src/webgl/quadFeature.js
+++ b/src/webgl/quadFeature.js
@@ -275,25 +275,51 @@ var webgl_quadFeature = function (arg) {
     var texture;
 
     $.each(m_quads.imgQuads, function (idx, quad) {
-      if (!quad.image) {
+      if (!quad.image && !quad.imageTexture) {
         return;
       }
-      if (quad.image._texture) {
-        quad.texture = quad.image._texture;
-      } else {
-        texture = new vgl.texture();
-        texture.setImage(quad.image);
-        let nearestPixel = m_this.nearestPixel();
-        if (nearestPixel !== undefined) {
-          if (nearestPixel !== true && util.isNonNullFinite(nearestPixel)) {
-            const curZoom = m_this.layer().map().zoom();
-            nearestPixel = curZoom >= nearestPixel;
+
+      // Handle custom imageTexture (from texture property)
+      if (quad.imageTexture) {
+        if (quad.imageTexture._texture) {
+          quad.texture = quad.imageTexture._texture;
+          console.log('Texture already has a vgl _texture');
+        } else {
+          console.log('Updating Texture by creating new VGL');
+          texture = new vgl.texture();
+          texture.setTexture(quad.imageTexture);
+          let nearestPixel = m_this.nearestPixel();
+          if (nearestPixel !== undefined) {
+            if (nearestPixel !== true && util.isNonNullFinite(nearestPixel)) {
+              const curZoom = m_this.layer().map().zoom();
+              nearestPixel = curZoom >= nearestPixel;
+            }
           }
+          if (nearestPixel) {
+            texture.setNearestPixel(true);
+          }
+          quad.texture = quad.imageTexture._texture = texture;
         }
-        if (nearestPixel) {
-          texture.setNearestPixel(true);
+      } else if (quad.image) {
+        // Handle regular image
+        if (quad.image._texture) {
+          quad.texture = quad.image._texture;
+        } else {
+          texture = new vgl.texture();
+          console.log('Setting Quad Image');
+          texture.setImage(quad.image);
+          let nearestPixel = m_this.nearestPixel();
+          if (nearestPixel !== undefined) {
+            if (nearestPixel !== true && util.isNonNullFinite(nearestPixel)) {
+              const curZoom = m_this.layer().map().zoom();
+              nearestPixel = curZoom >= nearestPixel;
+            }
+          }
+          if (nearestPixel) {
+            texture.setNearestPixel(true);
+          }
+          quad.texture = quad.image._texture = texture;
         }
-        quad.texture = quad.image._texture = texture;
       }
     });
   };
@@ -382,7 +408,10 @@ var webgl_quadFeature = function (arg) {
         nearestPixel = curZoom >= nearestPixel;
       }
       m_quads.imgQuads.forEach((quad) => {
-        if (quad.image && quad.texture && quad.texture.nearestPixel() !== nearestPixel && quad.texture.textureHandle()) {
+        console.log(nearestPixel);
+        console.log(quad.texture.nearestPixel());
+        console.log(quad.texture.textureHandle());
+        if ((quad.image || quad.imageTexture) && quad.texture && quad.texture.nearestPixel() !== nearestPixel && quad.texture.textureHandle()) {
           /* This could just be
            *   quad.texture.setNearestPixel(nearestPixel);
            * but that needlessly redecodes the image.  Instead, just change the
@@ -404,18 +433,25 @@ var webgl_quadFeature = function (arg) {
     }
     context.bindBuffer(context.ARRAY_BUFFER, m_glBuffers.imgQuadsPosition);
     $.each(m_quads.imgQuads, function (idx, quad) {
-      if (!quad.image) {
+      if (!quad.image && !quad.imageTexture) {
         return;
       }
       quad.texture.bind(renderState);
       // only check if the context is out of memory when using modestly large
       // textures.  The check is slow.
-      if (quad.image.width * quad.image.height > _memoryCheckLargestTested) {
+      if (quad.image && quad.image.width * quad.image.height > _memoryCheckLargestTested) {
         _memoryCheckLargestTested = quad.image.width * quad.image.height;
         if (context.getError() === context.OUT_OF_MEMORY) {
           console.log('Insufficient GPU memory for texture');
         }
       }
+      if (quad.imageTexture && quad.imageTexture.width * quad.imageTexture.height > _memoryCheckLargestTested) {
+        _memoryCheckLargestTested = quad.imageTexture.width * quad.imageTexture.height;
+        if (context.getError() === context.OUT_OF_MEMORY) {
+          console.log('Insufficient GPU memory for texture');
+        }
+      }
+
       if (quad.opacity !== opacity) {
         opacity = quad.opacity;
         context.uniform1fv(renderState.m_material.shaderProgram()
@@ -432,8 +468,14 @@ var webgl_quadFeature = function (arg) {
         context.uniform2fv(renderState.m_material.shaderProgram()
           .uniformLocation('crop'), new Float32Array([crop.x === undefined ? 1 : crop.x, crop.y === undefined ? 1 : crop.y]));
       }
-      w = quad.image.width;
-      h = quad.image.height;
+      if (quad.image) {
+        w = quad.image.width;
+        h = quad.image.height;
+      }
+      if (quad.imageTexture) {
+        w = quad.imageTexture.width;
+        h = quad.imageTexture.height;
+      }
       quadcropsrc = quad.crop || {left: 0, top: 0, right: w, bottom: h};
       if (!cropsrc || quadcropsrc.left !== cropsrc.left || quadcropsrc.top !== cropsrc.top || quadcropsrc.right !== cropsrc.right || quadcropsrc.bottom !== cropsrc.bottom || quadw !== w || quadh !== h) {
         cropsrc = quadcropsrc;
@@ -495,6 +537,9 @@ var webgl_quadFeature = function (arg) {
         if (quad.texture) {
           delete quad.texture;
           delete quad.image._texture;
+        }
+        if (quad.imageTexture) {
+          delete quad.imageTexture._texture;
         }
       });
       m_this._updateTextures();


### PR DESCRIPTION
Exploratory PR for adding in a `data([{texture}]` option to the webGL renderer for a quad.

In this demo, the texture is a RGBA texture similar to the one the image interprets.
```
texture: {
    data: uint8Array,
    width: number,
    height: number,
}

TODO:
- [ ] Determine if I want it to always be an RGBA texture.  Are there reasons to have a luminance texture (note the differences between WebGL and webGL 2.0)
- [ ] I believe there are external references to note that QuadFeatures with webGL support texture and canvas doesn't, this needs to be updated
- [ ] Refactor some logic in the Texture processing, there is some duplication that can be eliminates.  Was dupicated for initial testing purposes
- [ ] Revert the package.json and the sample.html testing files that were used to test the texture loading.
- [ ] Documentation updates are needed for this new feature.


