### PR TITLE
perf: Add more information to annotation mode change events

### DIFF
--- a/src/annotationLayer.js
+++ b/src/annotationLayer.js
@@ -678,10 +678,12 @@ var annotationLayer = function (arg) {
    *    edited or used.
    * @param {object} [options] Additional options to pass when creating an
    *    annotation.
+   * @param {string} [reason] An optional reason to pass to the
+   *    `geo.event.annotation.mode` event.
    * @returns {string|null|this} The current mode or the layer.
    * @fires geo.event.annotation.mode
    */
-  this.mode = function (arg, editAnnotation, options) {
+  this.mode = function (arg, editAnnotation, options, reason) {
     if (arg === undefined) {
       return m_mode;
     }
@@ -701,11 +703,13 @@ var annotationLayer = function (arg) {
         m_keyHandler = Mousetrap(mapNode[0]);
       }
       if (m_mode) {
-        m_keyHandler.bind('esc', function () { m_this.mode(null); });
+        m_keyHandler.bind('esc', function () { m_this.mode(null, undefined, undefined, 'escape'); });
       } else {
         m_keyHandler.unbind('esc');
       }
+      let oldState;
       if (m_this.currentAnnotation) {
+        oldState = m_this.currentAnnotation.state();
         switch (m_this.currentAnnotation.state()) {
           case geo_annotation.state.create:
             m_this.removeAnnotation(m_this.currentAnnotation);
@@ -754,7 +758,7 @@ var annotationLayer = function (arg) {
         });
       }
       m_this.geoTrigger(geo_event.annotation.mode, {
-        mode: m_mode, oldMode: oldMode});
+        mode: m_mode, oldMode: oldMode, oldState: oldState, reason: reason});
       if (oldMode === m_this.modes.edit || oldMode === m_this.modes.cursor) {
         m_this.modified();
       }

--- a/src/event.js
+++ b/src/event.js
@@ -746,9 +746,15 @@ geo_event.annotation.state = 'geo_annotation_state';
  * @event geo.event.annotation.mode
  * @type {geo.event.base}
  * @property {string?} mode The new annotation mode.  This is one of the values
- *      from {@link geo.annotation.state}.
+ *      from {@link geo.annotationLayer.mode} or an annotation name.
  * @property {string?} oldMode The annotation mode before this change.  This is
+ *      one of the values from {@link geo.annotationLayer.mode} or an
+ *      annotation name.
+ * @property {string?} oldState If there was an active annotation before the
+ *      mode change, this is the annotation state before the change.  This is
  *      one of the values from {@link geo.annotation.state}.
+ * @property {string?} reason An optional string that was passed to the mode
+ *      change method.
  */
 geo_event.annotation.mode = 'geo_annotation_mode';
 


### PR DESCRIPTION
Include the last state of an active annotation and a reason