### PR TITLE
perf: Add more information to annotation mode change events

### DIFF
--- a/src/annotationLayer.js
+++ b/src/annotationLayer.js
@@ -707,9 +707,10 @@ var annotationLayer = function (arg) {
       } else {
         m_keyHandler.unbind('esc');
       }
-      let oldState;
+      let oldState, oldCoordinates;
       if (m_this.currentAnnotation) {
         oldState = m_this.currentAnnotation.state();
+        oldCoordinates = m_this.currentAnnotation._copyOfCoordinates();
         switch (m_this.currentAnnotation.state()) {
           case geo_annotation.state.create:
             m_this.removeAnnotation(m_this.currentAnnotation);
@@ -757,8 +758,9 @@ var annotationLayer = function (arg) {
           m_this.map().interactor().addAction(action);
         });
       }
+      console.log({mode: m_mode, oldMode, oldState, oldCoordinates, reason});
       m_this.geoTrigger(geo_event.annotation.mode, {
-        mode: m_mode, oldMode: oldMode, oldState: oldState, reason: reason});
+        mode: m_mode, oldMode, oldState, oldCoordinates, reason});
       if (oldMode === m_this.modes.edit || oldMode === m_this.modes.cursor) {
         m_this.modified();
       }

--- a/src/event.js
+++ b/src/event.js
@@ -753,6 +753,10 @@ geo_event.annotation.state = 'geo_annotation_state';
  * @property {string?} oldState If there was an active annotation before the
  *      mode change, this is the annotation state before the change.  This is
  *      one of the values from {@link geo.annotation.state}.
+ * @property {string?} oldCoordinates If there was an active annotation before
+ *      the mode change, these are the annotation's coordinates before the
+ *      change.  This will be an empty list if an annotation in create state
+ *      had not been started and a non-empty list if it is partially created.
  * @property {string?} reason An optional string that was passed to the mode
  *      change method.
  */


### PR DESCRIPTION
Specifically, this add "oldCoordinates" to the event. If there was an active annotation before the mode change, these are the annotation's coordinates before the change.  This will be an empty list if an annotation in create state had not been started and a non-empty list if it is partially created.