### PR TITLE
perf: Specify dynamic draw for polygon strokes in webgl

### DIFF
--- a/src/polygonFeature.js
+++ b/src/polygonFeature.js
@@ -469,7 +469,8 @@ var polygonFeature = function (arg) {
       m_lineFeature = m_this.layer().createFeature('line', {
         selectionAPI: false,
         gcs: m_this.gcs(),
-        visible: m_this.visible(undefined, true)
+        visible: m_this.visible(undefined, true),
+        dynamicDraw: true
       });
       m_this.dependentFeatures([m_lineFeature]);
     }


### PR DESCRIPTION
In a real use case this change reduced the bufferData time by 11%.