### PR TITLE
fix: Ignore z coordinates on gl line features

### DIFF
--- a/src/webgl/lineFeature.vert
+++ b/src/webgl/lineFeature.vert
@@ -29,6 +29,7 @@ const float PI = 3.14159265358979323846264;
 
 vec4 viewCoord(vec3 c) {
   vec4 result = projectionMatrix * modelViewMatrix * vec4(c.xyz, 1.0);
+  result.z = 0.0;  /* Ignore z coordinates */
   if (result.w != 0.0)  result = result / result.w;
   return result;
 }


### PR DESCRIPTION
Closes #1486.

We don't support z coordinates yet (ever?), so disable them until we do.

See also #963.  There we claimed that we ignored z coordinates on lines, so this is fixing a bug.

One testing concern -- this doesn't seem to reproduce in the xvfb test environment; for instance changing the z value in the lines tutorial makes the lines vanish on both Chrome and Firefox, but not in the xvfb rendered chrome and firefox.  As a result, there is no test added to ensure that this works.