### PR TITLE
fix(security): 2 improvements across 2 files

### DIFF
--- a/scripts/get_tiles.py
+++ b/scripts/get_tiles.py
@@ -39,9 +39,9 @@ for line in list.split('\n'):
     except Exception:
         pass
     print(tile)
-    os.system('curl -s -o ' + path + ' ' + url)
+    subprocess.run(['curl', '-s', '-o', path, url])
     PIL.Image.open(path)
 os.chdir('dist/data/tiles')
 os.unlink('../tiles.tgz')
-os.system('tar -zcvf ../tiles.tgz *')
+subprocess.run(['tar', '-zcvf', '../tiles.tgz'] + os.listdir('.'))
 os.chdir('../../..')

--- a/scripts/preprocess_glsl.py
+++ b/scripts/preprocess_glsl.py
@@ -7,11 +7,15 @@ import sys
 
 
 def readSource(source):
+    base_dir = os.path.abspath(os.path.dirname(source))
     data = open(source).read()
     parts = re.split('(\\$[-.\\w]+)', data)
     for idx, chunk in enumerate(parts):
         if chunk.startswith('$') and len(chunk) > 1:
-            parts[idx] = readSource(os.path.join(os.path.dirname(source), chunk[1:] + '.glsl'))
+            filepath = os.path.abspath(os.path.join(base_dir, chunk[1:] + '.glsl'))
+            if not filepath.startswith(base_dir + os.sep):
+                raise ValueError('Invalid include path: ' + chunk)
+            parts[idx] = readSource(filepath)
     return ''.join(parts)
 
 


### PR DESCRIPTION
## Summary

fix(security): 2 improvements across 2 files

## Problem

**Severity**: `High` | **File**: `scripts/get_tiles.py:L35`

The `scripts/get_tiles.py` script constructs a shell command using string concatenation with `url` and `path` variables, and then executes it using `os.system`. If these variables are influenced by external input or untrusted data, an attacker could inject arbitrary shell commands. The use of `os.system` is inherently unsafe for executing commands with variable arguments.

## Solution

Replace `os.system` with `subprocess.run` and pass the arguments as a list. This prevents shell injection by ensuring arguments are treated strictly as parameters rather than shell syntax. For example: `subprocess.run(['curl', '-s', '-o', path, url])`.

## Changes

- `scripts/get_tiles.py` (modified)
- `scripts/preprocess_glsl.py` (modified)